### PR TITLE
Add rate limiting for socket events

### DIFF
--- a/docs/todos/04-socket-patterns.md
+++ b/docs/todos/04-socket-patterns.md
@@ -470,7 +470,7 @@ io.on('connection', (socket) => {
 
 ---
 
-## Task 6: Server - Add Rate Limiting
+## Task 6: Server - Add Rate Limiting ✅
 
 **Problem:** No protection against spam/abuse
 
@@ -649,7 +649,7 @@ socketManager.on('pong', (latency) => {
 2. [ ] Reconnection works and restores game state
 3. [ ] Connection indicator shows correct status
 4. [x] Invalid data is rejected with helpful error messages - Joi validation in validators.js
-5. [ ] Rate limiting prevents spam
+5. [x] Rate limiting prevents spam - rateLimiter.js with per-socket tracking
 6. [x] Errors don't crash server - errorHandler.js wraps all handlers
 7. [ ] Room-based broadcasting works correctly
 8. [ ] Stale connections are cleaned up

--- a/server/socket/rateLimiter.js
+++ b/server/socket/rateLimiter.js
@@ -1,0 +1,154 @@
+/**
+ * Rate limiting for socket events
+ * Prevents spam and abuse by limiting event frequency per socket
+ */
+
+class RateLimiter {
+    constructor() {
+        // Define rate limits per event type
+        // { max: number of requests, windowMs: time window in milliseconds }
+        this.limits = {
+            // Auth - strict limits to prevent brute force
+            signIn: { max: 5, windowMs: 60000 },       // 5 per minute
+            signUp: { max: 3, windowMs: 300000 },      // 3 per 5 minutes
+
+            // Chat - moderate limits
+            chatMessage: { max: 10, windowMs: 10000 }, // 10 per 10 seconds
+
+            // Game actions - reasonable limits for gameplay
+            playCard: { max: 20, windowMs: 60000 },    // 20 per minute
+            playerBid: { max: 10, windowMs: 60000 },   // 10 per minute
+            draw: { max: 10, windowMs: 60000 },        // 10 per minute
+
+            // Queue - prevent queue spam
+            joinQueue: { max: 5, windowMs: 30000 },    // 5 per 30 seconds
+            leaveQueue: { max: 5, windowMs: 30000 }    // 5 per 30 seconds
+        };
+
+        // Track requests: Map<string, number[]> where key is "socketId:event"
+        this.requests = new Map();
+
+        // Cleanup old entries periodically (every 5 minutes)
+        this.cleanupInterval = setInterval(() => this.cleanup(), 300000);
+    }
+
+    /**
+     * Check if a request is allowed
+     * @param {string} socketId - Socket ID making the request
+     * @param {string} event - Event name
+     * @returns {boolean} - true if allowed, false if rate limited
+     */
+    check(socketId, event) {
+        const limit = this.limits[event];
+
+        // No limit defined for this event - allow
+        if (!limit) {
+            return true;
+        }
+
+        const key = `${socketId}:${event}`;
+        const now = Date.now();
+        const windowStart = now - limit.windowMs;
+
+        // Get existing timestamps or create new array
+        let timestamps = this.requests.get(key) || [];
+
+        // Filter out old timestamps outside the window
+        timestamps = timestamps.filter(t => t > windowStart);
+
+        // Check if limit exceeded
+        if (timestamps.length >= limit.max) {
+            console.warn(`Rate limit exceeded: ${socketId} for ${event} (${timestamps.length}/${limit.max})`);
+            return false;
+        }
+
+        // Record this request
+        timestamps.push(now);
+        this.requests.set(key, timestamps);
+
+        return true;
+    }
+
+    /**
+     * Get remaining requests for a socket/event
+     * @param {string} socketId - Socket ID
+     * @param {string} event - Event name
+     * @returns {number} - Remaining requests allowed
+     */
+    getRemaining(socketId, event) {
+        const limit = this.limits[event];
+        if (!limit) return Infinity;
+
+        const key = `${socketId}:${event}`;
+        const now = Date.now();
+        const windowStart = now - limit.windowMs;
+
+        const timestamps = this.requests.get(key) || [];
+        const validTimestamps = timestamps.filter(t => t > windowStart);
+
+        return Math.max(0, limit.max - validTimestamps.length);
+    }
+
+    /**
+     * Clear all rate limit data for a socket (call on disconnect)
+     * @param {string} socketId - Socket ID to clear
+     */
+    clearSocket(socketId) {
+        const prefix = `${socketId}:`;
+        for (const key of this.requests.keys()) {
+            if (key.startsWith(prefix)) {
+                this.requests.delete(key);
+            }
+        }
+    }
+
+    /**
+     * Cleanup old entries to prevent memory leaks
+     */
+    cleanup() {
+        const now = Date.now();
+        let cleaned = 0;
+
+        for (const [key, timestamps] of this.requests.entries()) {
+            // Find the event type from the key
+            const event = key.split(':')[1];
+            const limit = this.limits[event];
+
+            if (!limit) {
+                this.requests.delete(key);
+                cleaned++;
+                continue;
+            }
+
+            // Filter out old timestamps
+            const windowStart = now - limit.windowMs;
+            const validTimestamps = timestamps.filter(t => t > windowStart);
+
+            if (validTimestamps.length === 0) {
+                this.requests.delete(key);
+                cleaned++;
+            } else if (validTimestamps.length !== timestamps.length) {
+                this.requests.set(key, validTimestamps);
+            }
+        }
+
+        if (cleaned > 0) {
+            console.log(`Rate limiter cleanup: removed ${cleaned} stale entries`);
+        }
+    }
+
+    /**
+     * Shutdown the rate limiter (clear interval)
+     */
+    shutdown() {
+        if (this.cleanupInterval) {
+            clearInterval(this.cleanupInterval);
+            this.cleanupInterval = null;
+        }
+    }
+}
+
+// Singleton instance
+const rateLimiter = new RateLimiter();
+
+module.exports = rateLimiter;


### PR DESCRIPTION
## Summary
- Add per-socket rate limiting to prevent spam and abuse
- Configurable limits per event type
- Auto-cleanup on disconnect

## Rate Limits
| Event | Limit | Window |
|-------|-------|--------|
| signIn | 5 | 1 min |
| signUp | 3 | 5 min |
| chatMessage | 10 | 10 sec |
| playCard | 20 | 1 min |
| playerBid | 10 | 1 min |
| draw | 10 | 1 min |
| joinQueue | 5 | 30 sec |

## Files
- **server/socket/rateLimiter.js** - New rate limiter module
- **server/socket/errorHandler.js** - Integrated rate limiting into handlers
- **server/socket/index.js** - Clear rate limits on disconnect

## Test plan
- [ ] Server starts without errors
- [ ] Normal gameplay works (limits are generous)
- [ ] Rapid repeated actions trigger rate limit error

🤖 Generated with [Claude Code](https://claude.com/claude-code)