### PR TITLE
Add reconnection logic for disconnected players

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -11,6 +11,65 @@ document.addEventListener("playerAssigned", (event) => {
         console.log("✅ playerID:", playerId);
     }
 });
+
+// Handle rejoin after reconnection
+document.addEventListener("rejoinSuccess", (event) => {
+    let data = event.detail;
+    console.log("🔄 Rejoining game:", data);
+
+    // Restore position and game state
+    position = data.position;
+    playerId = socket.id;
+
+    // Restore player data
+    playerData = {
+        position: data.players.map(p => p.position),
+        socket: data.players.map(p => p.socketId),
+        username: data.players.map(p => ({ username: p.username })),
+        pics: data.players.map(p => p.pic)
+    };
+
+    // Restore game state
+    playerCards = data.hand;
+    trump = data.trump;
+    dealer = data.dealer;
+    currentTurn = data.currentTurn;
+    bidding = data.bidding ? 1 : 0;
+    score1 = data.score.team1;
+    score2 = data.score.team2;
+
+    // Rebuild UI - trigger a scene restart with the restored state
+    let scene = game.scene.scenes[0];
+    if (scene) {
+        console.log("🔄 Rebuilding game UI after rejoin");
+        // Remove waiting screen if present
+        removeWaitingScreen();
+        removeDraw();
+        createGameFeed();
+        initGameChat();
+        if (!scoreUI) {
+            scoreUI = createScorebug();
+        }
+        // Trigger displayCards with restored hand
+        if (playerCards && playerCards.length > 0) {
+            displayCards.call(scene, playerCards);
+        }
+    }
+});
+
+// Handle rejoin failure
+document.addEventListener("rejoinFailed", (event) => {
+    console.log("❌ Rejoin failed:", event.detail.reason);
+    // Show lobby screen since we can't rejoin
+    showLobbyScreen();
+});
+
+// Handle player reconnection notification
+document.addEventListener("playerReconnected", (event) => {
+    let data = event.detail;
+    console.log(`🔄 Player ${data.username} at position ${data.position} reconnected`);
+    addToGameFeed(`${data.username} reconnected`);
+});
 function visible(){
     if(document.visibilityState === "visible"){
         return true;

--- a/client/socketManager.js
+++ b/client/socketManager.js
@@ -1,22 +1,117 @@
+/**
+ * Socket.IO connection manager with reconnection support
+ */
+
 const socket = io(
     location.hostname === "localhost"
       ? "http://localhost:3000"
       : "https://bab-online-production.up.railway.app",
-       { transports: ["websocket"] }
+    {
+        transports: ["websocket"],
+        reconnection: true,
+        reconnectionAttempts: 5,
+        reconnectionDelay: 1000,
+        reconnectionDelayMax: 5000
+    }
 );
+
+// Track game state for reconnection
+let currentGameId = null;
+
+/**
+ * Store the current game ID (call when game starts)
+ */
+function setGameId(gameId) {
+    currentGameId = gameId;
+    sessionStorage.setItem('gameId', gameId);
+    console.log('Game ID stored:', gameId);
+}
+
+/**
+ * Clear the game ID (call when game ends)
+ */
+function clearGameId() {
+    currentGameId = null;
+    sessionStorage.removeItem('gameId');
+    console.log('Game ID cleared');
+}
+
+/**
+ * Get the stored game ID
+ */
+function getGameId() {
+    if (!currentGameId) {
+        currentGameId = sessionStorage.getItem('gameId');
+    }
+    return currentGameId;
+}
+
+/**
+ * Get the stored username
+ */
+function getUsername() {
+    return sessionStorage.getItem('username');
+}
+
+// Connection event handlers
 socket.on("connect", () => {
-    console.log("Connected to server");
+    console.log("Connected to server:", socket.id);
+
+    // Check if we were in a game and should try to rejoin
+    const gameId = getGameId();
+    const username = getUsername();
+
+    if (gameId && username) {
+        console.log(`Attempting to rejoin game ${gameId} as ${username}`);
+        socket.emit('rejoinGame', { gameId, username });
+    }
+});
+
+socket.on("disconnect", (reason) => {
+    console.log("Disconnected from server:", reason);
+
+    // Dispatch event for UI to show disconnected state
+    document.dispatchEvent(new CustomEvent("connectionLost", { detail: { reason } }));
+});
+
+socket.on("reconnect_attempt", (attemptNumber) => {
+    console.log(`Reconnection attempt ${attemptNumber}/5`);
+    document.dispatchEvent(new CustomEvent("reconnecting", { detail: { attempt: attemptNumber } }));
+});
+
+socket.on("reconnect_failed", () => {
+    console.log("Reconnection failed after all attempts");
+    document.dispatchEvent(new CustomEvent("reconnectFailed"));
+    clearGameId(); // Clear game since we can't reconnect
 });
 
 socket.on("error", (data) => {
     console.error("🚨 Server error:", data);
 });
 
+// Rejoin response handlers
+socket.on("rejoinSuccess", (data) => {
+    console.log("Rejoin successful:", data);
+    document.dispatchEvent(new CustomEvent("rejoinSuccess", { detail: data }));
+});
+
+socket.on("rejoinFailed", (data) => {
+    console.log("Rejoin failed:", data.reason);
+    clearGameId(); // Clear invalid game ID
+    document.dispatchEvent(new CustomEvent("rejoinFailed", { detail: data }));
+});
+
+// Player reconnected notification (for other players)
+socket.on("playerReconnected", (data) => {
+    console.log(`Player at position ${data.position} (${data.username}) reconnected`);
+    document.dispatchEvent(new CustomEvent("playerReconnected", { detail: data }));
+});
+
+// Forward events to game.js
 socket.on("playerAssigned", (data) => {
     console.log("📡 (socketManager) Received playerAssigned:", data);
     console.log(`You are player ${data.position}`);
 
-    // ✅ Forward the event to game.js
     setTimeout(() => {
         document.dispatchEvent(new CustomEvent("playerAssigned", { detail: data }));
     }, 0);
@@ -24,8 +119,25 @@ socket.on("playerAssigned", (data) => {
 
 socket.on("gameStart", (data) => {
     console.log("Game Started", data);
+    // Store gameId when game starts (it's sent in the gameStart data)
+    if (data.gameId) {
+        setGameId(data.gameId);
+    }
 });
 
 socket.on("cardPlayed", (data) => {
     console.log(`Player ${data.playerId} played ${data.card.rank} of ${data.card.suit}`);
 });
+
+socket.on("gameEnd", (data) => {
+    console.log("Game ended:", data);
+    clearGameId(); // Clear game ID when game ends
+});
+
+// Export functions for use by other modules
+window.socketManager = {
+    setGameId,
+    clearGameId,
+    getGameId,
+    getUsername
+};

--- a/server/game/GameManager.js
+++ b/server/game/GameManager.js
@@ -138,6 +138,26 @@ class GameManager {
     }
 
     /**
+     * Update player-game mapping when a player reconnects with new socket
+     * @param {string} oldSocketId - Previous socket ID
+     * @param {string} newSocketId - New socket ID
+     * @param {string} gameId - Game ID
+     */
+    updatePlayerGameMapping(oldSocketId, newSocketId, gameId) {
+        this.playerGames.delete(oldSocketId);
+        this.playerGames.set(newSocketId, gameId);
+    }
+
+    /**
+     * Find game by ID (for reconnection)
+     * @param {string} gameId - Game ID to find
+     * @returns {GameState|null}
+     */
+    getGameById(gameId) {
+        return this.games.get(gameId) || null;
+    }
+
+    /**
      * Handle player disconnect
      */
     handleDisconnect(socketId) {

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -138,6 +138,7 @@ async function startHand(game, io) {
     // Send game start to all players (each gets their own hand)
     for (const socketId of socketIds) {
         game.sendToPlayer(io, socketId, 'gameStart', {
+            gameId: game.gameId,
             players: socketIds,
             hand: game.getHand(socketId),
             trump: game.trump,
@@ -422,6 +423,7 @@ async function cleanupNextHand(game, io, dealer, handSize) {
     // Send new hand to all players (each gets their own hand)
     for (const socketId of socketIds) {
         game.sendToPlayer(io, socketId, 'gameStart', {
+            gameId: game.gameId,
             players: socketIds,
             hand: game.getHand(socketId),
             trump: game.trump,

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -7,6 +7,7 @@ const authHandlers = require('./authHandlers');
 const queueHandlers = require('./queueHandlers');
 const gameHandlers = require('./gameHandlers');
 const chatHandlers = require('./chatHandlers');
+const reconnectHandlers = require('./reconnectHandlers');
 const { asyncHandler, syncHandler, safeHandler, rateLimiter } = require('./errorHandler');
 
 function setupSocketHandlers(io) {
@@ -43,6 +44,11 @@ function setupSocketHandlers(io) {
         // Chat events - with validation
         socket.on('chatMessage', (data) =>
             syncHandler('chatMessage', chatHandlers.chatMessage)(socket, io, data)
+        );
+
+        // Reconnection events
+        socket.on('rejoinGame', (data) =>
+            asyncHandler('rejoinGame', reconnectHandlers.rejoinGame)(socket, io, data)
         );
 
         // Disconnect - cleanup rate limiter and handle game state

--- a/server/socket/reconnectHandlers.js
+++ b/server/socket/reconnectHandlers.js
@@ -1,0 +1,60 @@
+/**
+ * Reconnection socket event handlers
+ */
+
+const gameManager = require('../game/GameManager');
+
+/**
+ * Handle a player attempting to rejoin a game after disconnect
+ */
+async function rejoinGame(socket, io, data) {
+    const { gameId, username } = data;
+
+    console.log(`Rejoin attempt: ${username} trying to rejoin game ${gameId}`);
+
+    // Find the game
+    const game = gameManager.getGameById(gameId);
+    if (!game) {
+        console.log(`Rejoin failed: game ${gameId} not found`);
+        socket.emit('rejoinFailed', { reason: 'Game no longer exists' });
+        return;
+    }
+
+    // Find player by username
+    const existingPlayer = game.getPlayerByUsername(username);
+    if (!existingPlayer) {
+        console.log(`Rejoin failed: ${username} not found in game ${gameId}`);
+        socket.emit('rejoinFailed', { reason: 'Not a player in this game' });
+        return;
+    }
+
+    // Check if this is actually a reconnect (different socket ID)
+    if (existingPlayer.socketId === socket.id) {
+        console.log(`Rejoin: ${username} already connected with same socket`);
+        socket.emit('rejoinFailed', { reason: 'Already connected' });
+        return;
+    }
+
+    // Update socket ID mapping
+    const oldSocketId = game.updatePlayerSocket(existingPlayer.position, socket.id, io);
+    gameManager.updatePlayerGameMapping(oldSocketId, socket.id, gameId);
+
+    // Register user with new socket
+    gameManager.registerUser(socket.id, username);
+
+    console.log(`Rejoin success: ${username} rejoined game ${gameId} at position ${existingPlayer.position}`);
+
+    // Send current game state to rejoining player
+    const gameState = game.getClientState(socket.id);
+    socket.emit('rejoinSuccess', gameState);
+
+    // Notify other players
+    game.broadcast(io, 'playerReconnected', {
+        position: existingPlayer.position,
+        username
+    });
+}
+
+module.exports = {
+    rejoinGame
+};

--- a/server/socket/validators.js
+++ b/server/socket/validators.js
@@ -52,7 +52,13 @@ const schemas = {
 
     // Queue (no data needed, but validate anyway)
     joinQueue: Joi.object({}).unknown(true),
-    leaveQueue: Joi.object({}).unknown(true)
+    leaveQueue: Joi.object({}).unknown(true),
+
+    // Reconnection
+    rejoinGame: Joi.object({
+        gameId: Joi.string().uuid().required(),
+        username: Joi.string().min(1).max(50).required()
+    })
 };
 
 /**


### PR DESCRIPTION
## Summary
- Players can now rejoin a game after disconnecting (browser refresh, network issues)
- Socket.IO auto-reconnection enabled (5 attempts, 1-5 second delays)
- Game ID stored in sessionStorage for reconnection
- Server tracks and restores player state on rejoin

## Changes

**Server:**
- `GameState`: Added `getPlayerByUsername()`, `updatePlayerSocket()`, `getClientState()`
- `GameManager`: Added `updatePlayerGameMapping()`, `getGameById()`
- New `reconnectHandlers.js` with `rejoinGame` handler
- `gameStart` now includes `gameId` for client storage

**Client:**
- `socketManager.js`: Reconnection options, gameId tracking, auto-rejoin on connect
- `game.js`: Handlers for `rejoinSuccess`, `rejoinFailed`, `playerReconnected`

## Test plan
- [ ] Start a game with 4 players
- [ ] Refresh one player's browser mid-game
- [ ] Verify they automatically rejoin with their hand and game state
- [ ] Verify other players see "X reconnected" in game feed
- [ ] Test rejoin fails gracefully if game ended

🤖 Generated with [Claude Code](https://claude.com/claude-code)