### PR TITLE
Fix game end cleanup: remove game log and clear player mappings

### DIFF
--- a/client/ui.js
+++ b/client/ui.js
@@ -1301,6 +1301,13 @@ function hideFinal() {
     if (overlay) {
         overlay.remove();
         console.log(" Final score popup closed.");
+
+        // Remove game feed/log
+        let gameFeed = document.getElementById("gameFeed");
+        if (gameFeed) {
+            gameFeed.remove();
+        }
+
         gameScene.scene.restart();
         socket.off("gameStart");
         playZone = null;

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -424,6 +424,8 @@ async function handleHandComplete(game, io) {
         // Clear active game for all players
         await gameManager.clearActiveGameForAll(game.gameId);
         game.leaveAllFromRoom(io);
+        // Clear playerGames Map entries so players can create new lobbies
+        gameManager.endGame(game.gameId);
         game.resetForNewGame();
     } else {
         gameLogger.debug('Starting next hand', { dealer: nextDealer, handSize: nextHandSize, gameId: game.gameId });


### PR DESCRIPTION
## Summary
- Fix game log persisting after returning to main room by removing `gameFeed` element in `hideFinal()`
- Fix "Already in game" error when creating new lobby by calling `gameManager.endGame()` on game completion to clear `playerGames` Map entries

## Test plan
- [ ] Play through a full game until it ends
- [ ] Click "Return to Lobby"
- [ ] Verify game log is no longer visible in main room
- [ ] Verify you can create a new lobby without "Already in game" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)