### PR TITLE
Fix client stuck on redeal when all players bid zero

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -750,6 +750,13 @@ socket.on("destroyHands", (data) => {
     socket.off("bidReceived");
     socket.off("cardPlayed");
     destroyAllCards();
+    // Reset flag so listeners are re-registered on redeal
+    gameListenersRegistered = false;
+    // Reset bid and trick state for redeal
+    currentTeamBids = "-/-";
+    currentOppBids = "-/-";
+    teamTricks = 0;
+    oppTricks = 0;
 });
 // Track drawn cards display during draw phase
 let drawnCardDisplays = [];


### PR DESCRIPTION
## Summary
- Fix bug where client gets stuck when all players bid zero and a redeal occurs

## Root Cause
When `destroyHands` event fires during redeal, it removes all socket listeners with `socket.off()` but doesn't reset the `gameListenersRegistered` flag. When the server sends `gameStart` for the new hand, `displayCards()` checks this flag and returns early without re-registering listeners.

## Changes
- Reset `gameListenersRegistered = false` in `destroyHands` handler so listeners are re-registered on redeal
- Reset `currentTeamBids`, `currentOppBids`, `teamTricks`, `oppTricks` for clean UI state

## Test plan
- [ ] Start a game and have all 4 players bid zero
- [ ] Verify redeal occurs and game continues normally without requiring browser refresh
- [ ] Verify bid UI appears and players can bid on the redealt hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)