### PR TITLE
Fix game log width consistency across platforms

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -93,7 +93,6 @@ button, input[type="button"], input[type="submit"], .bid-button {
 
     /* Game feed on mobile */
     #gameFeed {
-        width: 40vw !important;
         font-size: 12px !important;
         padding: 6px !important;
     }
@@ -119,11 +118,6 @@ button, input[type="button"], input[type="submit"], .bid-button {
 
 /* Tablet styles */
 @media (min-width: 769px) and (max-width: 1024px) {
-    #gameFeed {
-        width: 15vw !important;
-        font-size: 14px !important;
-    }
-
     .bid-button {
         min-width: 36px !important;
         min-height: 38px !important;
@@ -133,7 +127,6 @@ button, input[type="button"], input[type="submit"], .bid-button {
 /* Large screens */
 @media (min-width: 1920px) {
     #gameFeed {
-        width: 12vw !important;
         font-size: 16px !important;
     }
 }

--- a/client/styles/components.css
+++ b/client/styles/components.css
@@ -430,6 +430,7 @@
     right: 10px;
     bottom: 10px;
     width: 300px;
+    min-width: 220px;
     background: rgba(0, 0, 0, 0.85);
     border-radius: 8px;
     display: flex;


### PR DESCRIPTION
## Summary
Fix game log appearing too narrow on Windows computers due to display scaling differences.

## Problem
The game log used `vw` (viewport width) units which behave inconsistently across different display DPIs and Windows scaling settings, causing the log to appear too narrow on some systems.

## Changes
- Remove `vw`-based width overrides from `styles.css`
- Add `min-width: 220px` to `.chat-container` to prevent log from becoming too narrow
- Game log now uses consistent fixed pixel widths (300px default, scaling down at breakpoints)

## Test plan
- [ ] Test on Mac - verify game log looks correct
- [ ] Test on Windows with different display scaling settings (100%, 125%, 150%)
- [ ] Verify game log is readable and text doesn't wrap awkwardly

🤖 Generated with [Claude Code](https://claude.com/claude-code)