### PR TITLE
Separate game area from game log with distinct backgrounds

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -1,5 +1,5 @@
 html,body {
-    background: radial-gradient(ellipse at center, #228B22 0%, #0d1a0d 100%); /* Green poker table gradient */
+    background: #0a0a0f; /* Dark background for game log area */
     font-family: Arial, sans-serif;
     text-align: center;
     margin: 0;
@@ -18,6 +18,10 @@ canvas {
     position: absolute;
     left: 0;
     top: 0;
+    /* Width set dynamically in game.js to match canvas (viewport - game log width) */
+    width: calc(100vw - 320px);
+    height: 100vh;
+    background: radial-gradient(ellipse at center, #228B22 0%, #0d1a0d 100%); /* Green poker table gradient */
     z-index: 1;
     overflow: hidden; /* Prevent UI elements from overlapping game log */
 }
@@ -76,6 +80,31 @@ h1 {
 }
 
 /* ==================== RESPONSIVE DESIGN ==================== */
+
+/* Game container width must match game log responsive widths */
+@media (max-width: 1400px) {
+    #game-container {
+        width: calc(100vw - 280px); /* 260px game log + 20px padding */
+    }
+}
+
+@media (max-width: 1200px) {
+    #game-container {
+        width: calc(100vw - 240px); /* 220px game log + 20px padding */
+    }
+}
+
+@media (max-width: 1000px) {
+    #game-container {
+        width: calc(100vw - 200px); /* 180px game log + 20px padding */
+    }
+}
+
+@media (max-width: 800px) {
+    #game-container {
+        width: calc(100vw - 170px); /* 150px game log + 20px padding */
+    }
+}
 
 /* Ensure minimum touch target sizes for all interactive elements */
 button, input[type="button"], input[type="submit"], .bid-button {


### PR DESCRIPTION
## Summary
- Game area (green background) now ends where the game log begins
- No more overlap between game content and game log

## Changes
- Moved green gradient from `body` to `#game-container`
- Set `#game-container` width to `calc(100vw - 320px)` 
- Added responsive width rules matching game log's responsive breakpoints
- `body` now has dark background (`#0a0a0f`) for game log area

## Test plan
- [ ] Start a game and verify green area doesn't extend behind game log
- [ ] Resize browser to various widths
- [ ] Verify game log sits on dark background to the right of game area

🤖 Generated with [Claude Code](https://claude.com/claude-code)