### PR TITLE
Fix green background - full width everywhere

### DIFF
--- a/client/styles.css
+++ b/client/styles.css
@@ -1,5 +1,5 @@
 html,body {
-    background: #0a0a0f; /* Dark background for game log area */
+    background: radial-gradient(ellipse at center, #228B22 0%, #0d1a0d 100%); /* Green poker table gradient */
     font-family: Arial, sans-serif;
     text-align: center;
     margin: 0;
@@ -9,7 +9,6 @@ html,body {
 
 canvas {
     display: block;
-    margin: auto;
     position: relative;
     z-index: 1;
 }
@@ -18,12 +17,8 @@ canvas {
     position: absolute;
     left: 0;
     top: 0;
-    /* Width set dynamically in game.js to match canvas (viewport - game log width) */
-    width: calc(100vw - 320px);
-    height: 100vh;
-    background: radial-gradient(ellipse at center, #228B22 0%, #0d1a0d 100%); /* Green poker table gradient */
     z-index: 1;
-    overflow: hidden; /* Prevent UI elements from overlapping game log */
+    overflow: hidden;
 }
 
 h1 {
@@ -80,31 +75,6 @@ h1 {
 }
 
 /* ==================== RESPONSIVE DESIGN ==================== */
-
-/* Game container width must match game log responsive widths */
-@media (max-width: 1400px) {
-    #game-container {
-        width: calc(100vw - 280px); /* 260px game log + 20px padding */
-    }
-}
-
-@media (max-width: 1200px) {
-    #game-container {
-        width: calc(100vw - 240px); /* 220px game log + 20px padding */
-    }
-}
-
-@media (max-width: 1000px) {
-    #game-container {
-        width: calc(100vw - 200px); /* 180px game log + 20px padding */
-    }
-}
-
-@media (max-width: 800px) {
-    #game-container {
-        width: calc(100vw - 170px); /* 150px game log + 20px padding */
-    }
-}
 
 /* Ensure minimum touch target sizes for all interactive elements */
 button, input[type="button"], input[type="submit"], .bid-button {


### PR DESCRIPTION
## Summary
Different approach to fix backgrounds:
- Body has green gradient (full width) - fixes lobby/main room black bar
- game-container no longer width-restricted  
- Game content stays left of game log via existing Phaser canvas width constraint + position clamps from PR #48

## Key difference from previous attempt
The Phaser canvas is already configured with `width: innerWidth - 320px` in game.js, which should constrain game content. Combined with the position clamps we added, game elements should stay left of the game log without needing CSS width restrictions on game-container.

## Test plan
- [ ] Verify lobby/main room has full green background
- [ ] Verify in-game green background is full width
- [ ] Verify game content (cards/avatars) doesn't overlap game log

🤖 Generated with [Claude Code](https://claude.com/claude-code)