### PR TITLE
Apply game container width restriction only during game

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -787,6 +787,9 @@ function createGameFeed() {
 
     // Add initial message to confirm feed is working
     addToGameFeed("Game started!");
+
+    // Apply width restriction to game container to prevent overlap with game log
+    document.getElementById('game-container').classList.add('in-game');
 }
 function addToGameFeed(message, playerPosition = null) {
     let messagesArea = document.getElementById("gameFeedMessages");

--- a/client/styles.css
+++ b/client/styles.css
@@ -21,6 +21,12 @@ canvas {
     overflow: hidden;
 }
 
+/* Applied dynamically when in a game to prevent overlap with game log */
+#game-container.in-game {
+    width: calc(100vw - 320px);
+    height: 100vh;
+}
+
 h1 {
     color: white;
 }
@@ -75,6 +81,31 @@ h1 {
 }
 
 /* ==================== RESPONSIVE DESIGN ==================== */
+
+/* Game container width must match game log responsive widths (only when in-game) */
+@media (max-width: 1400px) {
+    #game-container.in-game {
+        width: calc(100vw - 280px);
+    }
+}
+
+@media (max-width: 1200px) {
+    #game-container.in-game {
+        width: calc(100vw - 240px);
+    }
+}
+
+@media (max-width: 1000px) {
+    #game-container.in-game {
+        width: calc(100vw - 200px);
+    }
+}
+
+@media (max-width: 800px) {
+    #game-container.in-game {
+        width: calc(100vw - 170px);
+    }
+}
 
 /* Ensure minimum touch target sizes for all interactive elements */
 button, input[type="button"], input[type="submit"], .bid-button {

--- a/client/ui.js
+++ b/client/ui.js
@@ -1360,6 +1360,9 @@ function hideFinal() {
             gameFeed.remove();
         }
 
+        // Remove width restriction from game container
+        document.getElementById('game-container').classList.remove('in-game');
+
         gameScene.scene.restart();
         socket.off("gameStart");
         playZone = null;


### PR DESCRIPTION
## Summary
- Game container width restriction now only applies during active gameplay
- Lobby/main room has full green background (no black bar)
- In-game, content stays left of game log (no overlap)

## Changes
- `client/styles.css`: Added `.in-game` class with width restrictions + responsive variants
- `client/game.js`: Add class in `createGameFeed()` when game starts
- `client/ui.js`: Remove class in `hideFinal()` when game ends

## Test plan
- [ ] Lobby/main room has full green background
- [ ] Start a game - verify content doesn't overlap game log
- [ ] End game and return to lobby - verify full green background

🤖 Generated with [Claude Code](https://claude.com/claude-code)