### PR TITLE
Always restrict game-container, green on both body and container

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -787,9 +787,6 @@ function createGameFeed() {
 
     // Add initial message to confirm feed is working
     addToGameFeed("Game started!");
-
-    // Apply width restriction to game container to prevent overlap with game log
-    document.getElementById('game-container').classList.add('in-game');
 }
 function addToGameFeed(message, playerPosition = null) {
     let messagesArea = document.getElementById("gameFeedMessages");

--- a/client/styles.css
+++ b/client/styles.css
@@ -17,14 +17,11 @@ canvas {
     position: absolute;
     left: 0;
     top: 0;
-    z-index: 1;
-    overflow: hidden;
-}
-
-/* Applied dynamically when in a game to prevent overlap with game log */
-#game-container.in-game {
     width: calc(100vw - 320px);
     height: 100vh;
+    background: radial-gradient(ellipse at center, #228B22 0%, #0d1a0d 100%); /* Green poker table gradient */
+    z-index: 1;
+    overflow: hidden;
 }
 
 h1 {
@@ -82,27 +79,27 @@ h1 {
 
 /* ==================== RESPONSIVE DESIGN ==================== */
 
-/* Game container width must match game log responsive widths (only when in-game) */
+/* Game container width must match game log responsive widths */
 @media (max-width: 1400px) {
-    #game-container.in-game {
+    #game-container {
         width: calc(100vw - 280px);
     }
 }
 
 @media (max-width: 1200px) {
-    #game-container.in-game {
+    #game-container {
         width: calc(100vw - 240px);
     }
 }
 
 @media (max-width: 1000px) {
-    #game-container.in-game {
+    #game-container {
         width: calc(100vw - 200px);
     }
 }
 
 @media (max-width: 800px) {
-    #game-container.in-game {
+    #game-container {
         width: calc(100vw - 170px);
     }
 }

--- a/client/ui.js
+++ b/client/ui.js
@@ -1360,9 +1360,6 @@ function hideFinal() {
             gameFeed.remove();
         }
 
-        // Remove width restriction from game container
-        document.getElementById('game-container').classList.remove('in-game');
-
         gameScene.scene.restart();
         socket.off("gameStart");
         playZone = null;


### PR DESCRIPTION
## Summary
Simpler approach that should work:
- game-container ALWAYS has width restriction (like PR #49 that worked)
- Green background on BOTH body AND game-container
- Body green shows in the game log area (no black bar)
- Container green shows for the game area

## Test plan
- [ ] Lobby/main room: Full green background everywhere
- [ ] In-game: Game content left of game log, no overlap, full green everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)