### PR TITLE
Dynamic game container width - full in lobby, restricted in game

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -787,6 +787,11 @@ function createGameFeed() {
 
     // Add initial message to confirm feed is working
     addToGameFeed("Game started!");
+
+    // Restrict game container width to make room for game log
+    document.getElementById('game-container').classList.add('in-game');
+    // Trigger resize so Phaser recalculates canvas size
+    window.dispatchEvent(new Event('resize'));
 }
 function addToGameFeed(message, playerPosition = null) {
     let messagesArea = document.getElementById("gameFeedMessages");

--- a/client/styles.css
+++ b/client/styles.css
@@ -17,11 +17,16 @@ canvas {
     position: absolute;
     left: 0;
     top: 0;
-    width: calc(100vw - 320px);
+    width: 100%;
     height: 100vh;
     background: radial-gradient(ellipse at center, #228B22 0%, #0d1a0d 100%); /* Green poker table gradient */
     z-index: 1;
     overflow: hidden;
+}
+
+/* Applied when in active game to make room for game log */
+#game-container.in-game {
+    width: calc(100vw - 320px);
 }
 
 h1 {
@@ -79,27 +84,27 @@ h1 {
 
 /* ==================== RESPONSIVE DESIGN ==================== */
 
-/* Game container width must match game log responsive widths */
+/* Game container width must match game log responsive widths (only when in-game) */
 @media (max-width: 1400px) {
-    #game-container {
+    #game-container.in-game {
         width: calc(100vw - 280px);
     }
 }
 
 @media (max-width: 1200px) {
-    #game-container {
+    #game-container.in-game {
         width: calc(100vw - 240px);
     }
 }
 
 @media (max-width: 1000px) {
-    #game-container {
+    #game-container.in-game {
         width: calc(100vw - 200px);
     }
 }
 
 @media (max-width: 800px) {
-    #game-container {
+    #game-container.in-game {
         width: calc(100vw - 170px);
     }
 }

--- a/client/ui.js
+++ b/client/ui.js
@@ -1360,6 +1360,9 @@ function hideFinal() {
             gameFeed.remove();
         }
 
+        // Remove width restriction from game container
+        document.getElementById('game-container').classList.remove('in-game');
+
         gameScene.scene.restart();
         socket.off("gameStart");
         playZone = null;


### PR DESCRIPTION
## Summary
- Lobby/main room/draw: Full green background (no cutoff)
- In-game: Container restricted to make room for game log

## Key fix
Added `window.dispatchEvent(new Event('resize'))` after adding the .in-game class to trigger Phaser to recalculate canvas size.

## Test plan
- [ ] Lobby/main room: Full green, no cutoff on right
- [ ] Draw for deal: Full green, no cutoff
- [ ] In-game: Game content left, game log right, no overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)