### PR TITLE
Fix draw animation, card table layout, and opponent turn indicators

### DIFF
--- a/client/styles/components.css
+++ b/client/styles/components.css
@@ -600,6 +600,43 @@
 }
 
 /* ==========================================================================
+   Opponent Avatars (DOM-based)
+   ========================================================================== */
+
+.opponent-avatar-container {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    pointer-events: none;
+    z-index: 50;
+    transform: translate(-50%, -50%);
+}
+
+.opponent-avatar-img {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    border: 3px solid #333;
+    object-fit: cover;
+    background-color: #1a1a1a;
+}
+
+.opponent-avatar-name {
+    color: #ffffff;
+    font-size: 18px;
+    font-weight: bold;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
+}
+
+/* Turn glow for opponent avatars - reuses pulse-glow animation */
+.opponent-avatar-container.turn-glow .opponent-avatar-img {
+    box-shadow: 0 0 30px 15px rgba(255, 215, 0, 0.5);
+    animation: pulse-glow 1s ease-in-out infinite alternate;
+}
+
+/* ==========================================================================
    Hand Info
    ========================================================================== */
 


### PR DESCRIPTION
## Summary
- **Draw for deal**: Card now flips and animates from clicked position with two-phase animation (card back → revealed)
- **Card table layout**: Smaller table (40% width) that fits cards snugly, cards vertically centered, played cards animate into the green play zone
- **Opponent turn indicators**: Convert avatars from Phaser sprites to DOM elements with CSS glow for consistent turn indication

## Test plan
- [ ] Start a new game and click different positions in the deck spread - verify card flips from clicked position
- [ ] Check cards are vertically centered on the smaller table
- [ ] Play a card and verify it lands inside the green play zone
- [ ] Verify opponent turn indicators show golden CSS glow (same as player's own turn)
- [ ] Test window resize to ensure all elements reposition correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)