### PR TITLE
Fix card hover, resize positioning, and self-played card visibility

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -338,6 +338,7 @@ function repositionHandCards(screenWidth, screenHeight, scaleFactorX, scaleFacto
         if (card && card.active) {
             card.x = startX + index * cardSpacing;
             card.y = startY;
+            card.setData('baseY', startY); // Update baseY for hover effects
         }
     });
 }
@@ -1922,6 +1923,7 @@ function displayCards(playerHand) {
         // Store card data on sprite for legality checks
         cardSprite.setData('card', card);
         cardSprite.setData('isLegal', false);
+        cardSprite.setData('baseY', startY); // Store base Y for hover effects
         myCards.push(cardSprite);
         if (visible()){
             this.tweens.add({
@@ -1942,9 +1944,10 @@ function displayCards(playerHand) {
         cardSprite.on("pointerover", () => {
             // Only raise card if it's a legal move
             if (cardSprite.getData('isLegal')) {
+                const baseY = cardSprite.getData('baseY');
                 this.tweens.add({
                     targets: cardSprite,
-                    y: startY - 30,
+                    y: baseY - 30,
                     duration: 150,
                     ease: 'Power2'
                 });
@@ -1952,13 +1955,16 @@ function displayCards(playerHand) {
         });
 
         cardSprite.on("pointerout", () => {
-            // Return card to original position
-            this.tweens.add({
-                targets: cardSprite,
-                y: startY,
-                duration: 150,
-                ease: 'Power2'
-            });
+            // Only return card if it was raised (isLegal)
+            if (cardSprite.getData('isLegal')) {
+                const baseY = cardSprite.getData('baseY');
+                this.tweens.add({
+                    targets: cardSprite,
+                    y: baseY,
+                    duration: 150,
+                    ease: 'Power2'
+                });
+            }
         });
 
         cardSprite.on("pointerdown", () => {
@@ -2267,7 +2273,7 @@ function displayCards(playerHand) {
             }
         }
         else if (data.position === position){
-            currentTrick.push(this.add.image(selfPlay_x, selfPlay_y, 'cards', cardKey).setScale(1.5));
+            currentTrick.push(this.add.image(selfPlay_x, selfPlay_y, 'cards', cardKey).setScale(1.5).setDepth(200));
         }
     })
     socket.on("trickComplete", (data) => {


### PR DESCRIPTION
## Summary
- Store `baseY` on card sprite and use it in hover handlers (instead of stale closure variable)
- Update `baseY` in `repositionHandCards` when resizing
- Only trigger `pointerout` animation when `isLegal` is true
- Add `setDepth(200)` to self-played card

## Test plan
- [ ] During bidding, hovering over cards should NOT move them
- [ ] After resizing window and refreshing, cards should deal to correct position
- [ ] First player's card should appear in center play zone for them

🤖 Generated with [Claude Code](https://claude.com/claude-code)