### PR TITLE
Fix card tinting bug after bidding phase ends

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -2619,7 +2619,8 @@ function displayCards(playerHand, skipAnimation = false) {
             }
         });
         myCards = [];
-        displayCards.call(gameScene, hand, true); // true = skip animation
+        displayCards.call(gameScene, playerCards, true); // true = skip animation
+        forceRenderUpdate();  // Force WebGL to render card tinting
         playerBids = data;
         console.log("bids: ", playerBids);
         rainbows.forEach((rainbow) => {


### PR DESCRIPTION
## Summary
- Fix undefined `hand` variable by changing to `playerCards` in doneBidding handler
- Add `forceRenderUpdate()` call to flush WebGL pipeline after card recreation

## Problem
After bidding ended, the first player's cards were:
- All tinted gray instead of showing legal/illegal moves
- Not responding to hover animations
- But clicking the correct card still worked server-side

## Root Cause
The `doneBidding` handler was passing `hand` (undefined) to `displayCards()` instead of `playerCards` (the global holding the player's cards).

## Test plan
- [ ] Start server with `npm run dev`
- [ ] Create 4-player game through bidding phase
- [ ] Verify lead player sees properly tinted cards after bidding
- [ ] Verify hover animations work on legal cards
- [ ] Verify cards can be clicked to play

🤖 Generated with [Claude Code](https://claude.com/claude-code)