### PR TITLE
Fix bid UI showing to multiple players on subsequent hands

### DIFF
--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -466,8 +466,9 @@ async function cleanupNextHand(game, io, dealer, handSize) {
         }
     }
 
-    // Send new hand to all players (each gets their own hand)
+    // Send new hand to all players (each gets their own hand and position)
     for (const socketId of socketIds) {
+        const playerPosition = game.getPositionBySocketId(socketId);
         game.sendToPlayer(io, socketId, 'gameStart', {
             gameId: game.gameId,
             players: socketIds,
@@ -475,7 +476,8 @@ async function cleanupNextHand(game, io, dealer, handSize) {
             trump: game.trump,
             score1: game.score.team1,
             score2: game.score.team2,
-            dealer: game.dealer
+            dealer: game.dealer,
+            position: playerPosition  // Include player's position to fix bid UI bug
         });
     }
 


### PR DESCRIPTION
## Summary
Add missing `position` field to `gameStart` event in `cleanupNextHand()`

## Problem
After the first hand, subsequent hands were sent without the player's position.
Clients used stale position values, causing multiple players to see the bid UI.

## Root Cause
`startHand()` includes `position: playerPosition` but `cleanupNextHand()` did not.

## Test plan
- [ ] Play through first hand completely
- [ ] Verify only the correct player (left of dealer) sees bid UI on second hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)