### PR TITLE
Clear tricks at start of new hand as safeguard

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -625,6 +625,10 @@ function processPositionUpdate(data) {
 
 function processGameStart(data) {
     console.log("🎮 processGameStart called!");
+
+    // Clear any remaining tricks from previous hand (safeguard for race conditions)
+    clearAllTricks();
+
     console.log("🎮 gameScene:", gameScene);
     console.log("🎮 gameScene.add:", gameScene?.add);
     console.log("🎮 gameScene.textures:", gameScene?.textures);


### PR DESCRIPTION
## Summary
Add `clearAllTricks()` call at start of `processGameStart()` 

## Problem
Old trick sprites weren't being cleaned up between hands.

## Fix
Call `clearAllTricks()` at the beginning of `processGameStart()` as a safeguard.
This ensures old tricks are cleared before new hand setup, even if there's
a race condition with the `handComplete` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)