### PR TITLE
Fix dealer token visibility and opponent avatar glow issues

### DIFF
--- a/client/game.js
+++ b/client/game.js
@@ -553,7 +553,10 @@ function repositionOpponentElements(screenWidth, screenHeight, scaleFactorX, sca
     if (typeof buttonHandle !== 'undefined' && buttonHandle && buttonHandle.active) {
         // Find which position has the dealer and reposition accordingly
         if (typeof dealer !== 'undefined' && typeof position !== 'undefined' && typeof team === 'function' && typeof rotate === 'function') {
-            if (team(position) === dealer) {
+            if (dealer === position) {
+                // Player is the dealer - position near player info box
+                buttonHandle.setPosition(screenWidth - 380 * scaleFactorX + 100 * scaleFactorX, screenHeight - 150 * scaleFactorY - 60 * scaleFactorY);
+            } else if (team(position) === dealer) {
                 buttonHandle.setPosition(positions.partner.avatarX + 75 * scaleFactorX, positions.partner.avatarY);
             } else if (rotate(position) === dealer) {
                 buttonHandle.setPosition(positions.opp1.avatarX - 75 * scaleFactorX, positions.opp1.avatarY);
@@ -2917,16 +2920,6 @@ function displayOpponentHands(numCards, dealer, skipAnimation = false) {
                 playerInfo.playerPositionText.setText("UTG");
             }
         }
-        if(dealer === position){
-            if (buttonHandle && typeof buttonHandle.destroy === 'function') {
-                buttonHandle.destroy();
-            }
-            playerInfo.playerPositionText.setText("BTN");
-            buttonHandle = this.add.image(centerPlayAreaX + 580*scaleFactorX, centerPlayAreaY + 365*scaleFactorY, "dealer")
-            .setScale(0.03) // Adjust size
-            .setDepth(250) // Ensure it's above the cards
-            .setAlpha(1);
-        }
         opponentCardSprites[opponentId] = [];
         for (let i = 0; i < numCards; i++) {
             let offsetX = horizontal ? (i - numCards / 2) * cardSpacing : 0; // ✅ Left/Right: No horizontal movement
@@ -2960,6 +2953,19 @@ function displayOpponentHands(numCards, dealer, skipAnimation = false) {
             }
         }
     });
+
+    // Create dealer button for current player (outside the opponent loop)
+    if(dealer === position){
+        if (buttonHandle && typeof buttonHandle.destroy === 'function') {
+            buttonHandle.destroy();
+        }
+        playerInfo.playerPositionText.setText("BTN");
+        // Position near player info box (bottom right)
+        buttonHandle = this.add.image(screenWidth - 280*scaleFactorX, screenHeight - 210*scaleFactorY, "dealer")
+            .setScale(0.03)
+            .setDepth(250)
+            .setAlpha(1);
+    }
 
     console.log("🎭 Opponent hands displayed correctly.");
 }

--- a/client/styles/components.css
+++ b/client/styles/components.css
@@ -619,6 +619,8 @@
     height: 80px;
     border-radius: 50%;
     object-fit: cover;
+    background-color: #1a1a2e;
+    border: none;
 }
 
 .opponent-avatar-name {
@@ -628,7 +630,12 @@
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
 }
 
-/* Turn glow for opponent avatars - reuses pulse-glow animation */
+/* Turn glow for opponent avatars - only apply glow to img, not container */
+.opponent-avatar-container.turn-glow {
+    box-shadow: none;
+    animation: none;
+}
+
 .opponent-avatar-container.turn-glow .opponent-avatar-img {
     box-shadow: 0 0 30px 15px rgba(255, 215, 0, 0.5);
     animation: pulse-glow 1s ease-in-out infinite alternate;


### PR DESCRIPTION
## Summary
- Fix dealer token not showing when the current player is the dealer
- Fix opponent avatar glow showing ugly rectangular border around container instead of circular glow on image
- Add dark background to opponent avatars to prevent green table showing through transparent areas

## Test plan
- [ ] Start a game and progress to a hand where you are the dealer - verify dealer token appears near your avatar
- [ ] Verify dealer token repositions correctly on window resize when you're the dealer
- [ ] When it's an opponent's turn, verify their avatar has a clean circular glow (no rectangular border)
- [ ] Verify opponent avatars have a dark ring around them instead of green table bleed

🤖 Generated with [Claude Code](https://claude.com/claude-code)