### PR TITLE
Persist game log history on reconnection

### DIFF
--- a/server/socket/chatHandlers.js
+++ b/server/socket/chatHandlers.js
@@ -21,6 +21,13 @@ function chatMessage(socket, io, data) {
         return;
     }
 
+    // Get player info for username
+    const player = game.getPlayerByPosition(position);
+    const username = player ? player.username : 'Unknown';
+
+    // Add to game log for reconnection persistence
+    game.addLogEntry(`${username}: ${data.message}`, position, 'chat');
+
     // Broadcast to players in the same game only
     game.broadcast(io, 'chatMessage', {
         position,


### PR DESCRIPTION
## Summary
- Fixed issue where reconnecting players lost game log history and saw "Game started!" on every reconnect
- Game log now persists on the server and restores full history when players reconnect
- Matches the log history that all other players see

## Changes
- Added `gameLog` array to `GameState` to store log entries server-side
- Added `addLogEntry()` calls for all game events (bids, trick winners, scoring, rainbows, chat)
- Included `gameLog` in `rejoinSuccess` data sent to reconnecting players
- Updated client to restore game log history on reconnection
- Skip duplicate "Game started!" message since it's already in the history

## Test plan
- [x] Start a 4-player game and progress through bidding and tricks
- [x] Refresh one player's browser to disconnect/reconnect
- [x] Verify game log shows full history (bids, trick winners, etc.)
- [x] Verify "Reconnected to game!" appears at the end of the log
- [x] Verify new messages appear for all players after reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)