### PR TITLE
Fix in-game chat not displaying messages

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1748,7 +1748,7 @@ function initializeApp() {
       if (!gameLogInstance) {
         gameLogInstance = showGameLog({
           onChatSubmit: (message) => {
-            const socket = getSocketManager()?.getSocket();
+            const socket = getSocketManager()?.socket;
             if (socket) {
               socket.emit('chatMessage', { message });
             }

--- a/server/socket/chatHandlers.js
+++ b/server/socket/chatHandlers.js
@@ -31,7 +31,8 @@ function chatMessage(socket, io, data) {
     // Broadcast to players in the same game only
     game.broadcast(io, 'chatMessage', {
         position,
-        message: data.message
+        message: data.message,
+        username
     });
 }
 


### PR DESCRIPTION
## Summary
- Server was broadcasting chat messages without `username` field, causing client to fail silently
- Client called `getSocketManager()?.getSocket()` but `SocketManager` has a `.socket` property, not a `getSocket()` method

## Test plan
- [x] Start a game with 4 players
- [x] Send a chat message during gameplay
- [x] Verify message appears in the game log for all players

🤖 Generated with [Claude Code](https://claude.com/claude-code)