### PR TITLE
Refactor UI elements to DOM and fix cleanup

### DIFF
--- a/client/src/phaser/managers/DrawManager.js
+++ b/client/src/phaser/managers/DrawManager.js
@@ -81,7 +81,7 @@ export class DrawManager {
     };
 
     // Add title
-    this.titleText = this.scene.add.text(screenWidth / 2, 80 * scaleY, 'Draw for Deal', {
+    this.titleText = this.scene.add.text(screenWidth / 2, 80 * scaleY, 'Draw for Deal!', {
       fontSize: `${48 * scaleX}px`,
       fontStyle: 'bold',
       color: '#FFFFFF',
@@ -266,24 +266,10 @@ export class DrawManager {
       0.7
     ).setDepth(400);
 
-    // Team announcement title
-    const title = this.scene.add.text(
-      screenWidth / 2,
-      screenHeight / 2 - 120 * scaleY,
-      'Teams',
-      {
-        fontSize: `${56 * scaleX}px`,
-        fontStyle: 'bold',
-        color: '#FFD700',
-        stroke: '#000000',
-        strokeThickness: 4,
-      }
-    ).setOrigin(0.5).setDepth(401);
-
-    // Team 1 display
+    // Team 1 display (centered vertically on screen)
     const team1Label = this.scene.add.text(
       screenWidth / 2,
-      screenHeight / 2 - 30 * scaleY,
+      screenHeight / 2 - 100 * scaleY,
       'Team 1',
       {
         fontSize: `${32 * scaleX}px`,
@@ -294,7 +280,7 @@ export class DrawManager {
 
     const team1Players = this.scene.add.text(
       screenWidth / 2,
-      screenHeight / 2 + 20 * scaleY,
+      screenHeight / 2 - 50 * scaleY,
       `${data.team1[0]} & ${data.team1[1]}`,
       {
         fontSize: `${28 * scaleX}px`,
@@ -305,7 +291,7 @@ export class DrawManager {
     // VS text
     const vsText = this.scene.add.text(
       screenWidth / 2,
-      screenHeight / 2 + 70 * scaleY,
+      screenHeight / 2,
       'vs',
       {
         fontSize: `${24 * scaleX}px`,
@@ -317,7 +303,7 @@ export class DrawManager {
     // Team 2 display
     const team2Label = this.scene.add.text(
       screenWidth / 2,
-      screenHeight / 2 + 120 * scaleY,
+      screenHeight / 2 + 50 * scaleY,
       'Team 2',
       {
         fontSize: `${32 * scaleX}px`,
@@ -328,7 +314,7 @@ export class DrawManager {
 
     const team2Players = this.scene.add.text(
       screenWidth / 2,
-      screenHeight / 2 + 170 * scaleY,
+      screenHeight / 2 + 100 * scaleY,
       `${data.team2[0]} & ${data.team2[1]}`,
       {
         fontSize: `${28 * scaleX}px`,
@@ -337,7 +323,7 @@ export class DrawManager {
     ).setOrigin(0.5).setDepth(401);
 
     // Store for cleanup
-    const teamElements = [overlay, title, team1Label, team1Players, vsText, team2Label, team2Players];
+    const teamElements = [overlay, team1Label, team1Players, vsText, team2Label, team2Players];
     this.drawnCardDisplays.push(...teamElements);
   }
 

--- a/client/src/phaser/scenes/GameScene.js
+++ b/client/src/phaser/scenes/GameScene.js
@@ -123,7 +123,6 @@ export class GameScene extends Phaser.Scene {
 
     // Load other essential assets
     this.load.image('cardBack', 'assets/card_back.png');
-    this.load.image('dealer', 'assets/frog.png');
     this.load.image('background', 'assets/background.png');
     this.load.image('rainbow', 'assets/rainbow1.png');
     this.load.image('ot', 'assets/ot.png');
@@ -644,25 +643,27 @@ export class GameScene extends Phaser.Scene {
   /**
    * Show a chat/bid bubble at a position.
    * Uses ChatBubble.js for consistent styling (white bg, black/red text).
+   * Positions are avatar centers - ChatBubble handles the offset.
    */
   showChatBubble(positionKey, message, color = null, duration = 6000) {
     const { x: scaleX, y: scaleY, screenWidth, screenHeight } = this.getScaleFactors();
     const centerX = screenWidth / 2;
     const centerY = screenHeight / 2;
 
-    // Calculate position based on key
+    // Avatar center positions
+    // 'me' uses window coordinates since player info box is outside game container
     const positions = {
-      opp1: { x: centerX - 480 * scaleX, y: centerY },
-      opp2: { x: centerX + 620 * scaleX, y: centerY },
-      partner: { x: centerX + 20 * scaleX, y: centerY - 380 * scaleY },
-      me: { x: screenWidth - 310 * scaleX, y: screenHeight - 270 * scaleY },
+      opp1: { x: Math.max(130, centerX - 550 * scaleX), y: centerY - 40 },
+      opp2: { x: Math.min(screenWidth - 130, centerX + 550 * scaleX), y: centerY - 40 },
+      partner: { x: centerX, y: centerY - 400 * scaleY },
+      me: { x: window.innerWidth - 405, y: window.innerHeight - 230 },
     };
 
     const pos = positions[positionKey];
     if (!pos) return;
 
-    // Use the imported ChatBubble.js function for consistent styling
-    showChatBubbleUI(this, positionKey, pos.x, pos.y, message, color, duration);
+    // Use the imported ChatBubble.js function (DOM-based)
+    showChatBubbleUI(positionKey, pos.x, pos.y, message, color, duration);
   }
 
   // ============================================

--- a/client/styles/components.css
+++ b/client/styles/components.css
@@ -783,3 +783,90 @@
 .play-again-button:hover {
     background: #357abd;
 }
+
+/* ==========================================================================
+   Chat Bubbles (DOM-based)
+   ========================================================================== */
+
+.chat-bubble {
+    position: absolute;
+    background: #ffffff;
+    color: #000000;
+    padding: 8px 12px;
+    border-radius: 12px;
+    font-size: 14px;
+    font-family: Arial, sans-serif;
+    min-width: 40px;
+    max-width: 200px;
+    word-wrap: break-word;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    z-index: 500;
+    pointer-events: none;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+    text-align: center;
+}
+
+.chat-bubble.fade-out {
+    opacity: 0;
+}
+
+.chat-bubble.bid {
+    color: #FF0000;
+    font-weight: bold;
+}
+
+/* Tail pointing down (centered, points at avatar below) */
+.chat-bubble.tail-down::after {
+    content: '';
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 10px 8px 0 8px;
+    border-style: solid;
+    border-color: #ffffff transparent transparent transparent;
+}
+
+/* Tail pointing left (for opp1 - left side opponent) */
+.chat-bubble.tail-left::after {
+    content: '';
+    position: absolute;
+    left: -10px;
+    top: 50%;
+    transform: translateY(-50%);
+    border-width: 8px 10px 8px 0;
+    border-style: solid;
+    border-color: transparent #ffffff transparent transparent;
+}
+
+/* Tail pointing right (for opp2 - right side opponent) */
+.chat-bubble.tail-right::after {
+    content: '';
+    position: absolute;
+    right: -10px;
+    top: 50%;
+    transform: translateY(-50%);
+    border-width: 8px 0 8px 10px;
+    border-style: solid;
+    border-color: transparent transparent transparent #ffffff;
+}
+
+/* ==========================================================================
+   Dealer Button (DOM-based)
+   ========================================================================== */
+
+.dealer-button {
+    position: absolute;
+    width: 40px;
+    height: 40px;
+    z-index: 150;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+}
+
+.dealer-button img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}


### PR DESCRIPTION
## Summary

- **Chat bubbles**: Converted from Phaser graphics to DOM elements with CSS styling for better text rendering and simpler maintenance
- **Dealer button (frog)**: Moved from Phaser sprite (2048x2048 scaled to 0.02) to DOM element with proper 40px sizing
- **Position label**: Moved BTN/CO/MP/UTG text from Phaser to DOM, now part of player info container
- **UI cleanup**: Fixed issue where game UI elements (avatars, dealer button, chat bubbles, bid UI, game log) remained visible when returning to sign-in screen

## Other fixes

- Player's profile pic now appears at the same time as other players' avatars (was showing early)
- Team declaration centered vertically on screen after removing "Teams" title
- "Draw for Deal" changed to "Draw for Deal!"
- Chat bubble tails now always point at avatar center regardless of message length
- Added minimum width to chat bubbles to prevent gap with tail on short messages

## Test plan

- [ ] Verify chat bubbles appear correctly positioned for all 4 player positions
- [ ] Verify dealer button (frog) appears correctly for all 4 dealer positions
- [ ] Verify UI elements are cleaned up when server disconnects and sign-in screen appears
- [ ] Verify player's avatar appears at same time as opponent avatars
- [ ] Verify team declaration is centered on screen
- [ ] Verify position label (BTN/CO/MP/UTG) displays correctly under player avatar

🤖 Generated with [Claude Code](https://claude.ai/code)