### PR TITLE
Improve trump card display and fix game log trick double-counting

### DIFF
--- a/client/src/handlers/gameHandlers.js
+++ b/client/src/handlers/gameHandlers.js
@@ -231,15 +231,8 @@ export function registerGameHandlers(socketManager, callbacks = {}) {
   socketManager.onGame(SERVER_EVENTS.TRICK_COMPLETE, (data) => {
     console.log('🏆 Trick complete, winner:', data.winner);
 
-    // Update trick counts based on winner's team
-    const myTeam = state.position % 2; // 0 for even, 1 for odd
-    const winnerTeam = data.winner % 2;
-
-    if (myTeam === winnerTeam) {
-      state.teamTricks++;
-    } else {
-      state.oppTricks++;
-    }
+    // Note: trick counts are updated in GameScene.handleTrickComplete
+    // to avoid double-counting
 
     // Clear trick state
     state.clearTrick();

--- a/client/src/phaser/scenes/GameScene.js
+++ b/client/src/phaser/scenes/GameScene.js
@@ -399,7 +399,8 @@ export class GameScene extends Phaser.Scene {
       this.tableCardBackground.setPosition(trumpX, trumpY);
     }
     if (this.tableCardLabel && this.tableCardLabel.active) {
-      this.tableCardLabel.setPosition(trumpX, trumpY - 100);
+      const cardHeight = this.tableCardSprite ? this.tableCardSprite.displayHeight + 10 : 100;
+      this.tableCardLabel.setPosition(trumpX, trumpY - (cardHeight / 2) - 12);
     }
   }
 
@@ -587,21 +588,24 @@ export class GameScene extends Phaser.Scene {
       this.tableCardLabel.destroy();
     }
 
-    // Background
-    this.tableCardBackground = this.add.rectangle(trumpX, trumpY, 120, 180, 0x000000, 0.5);
-    this.tableCardBackground.setDepth(99);
-
     // Card
     const cardKey = getCardImageKey(trumpCard);
     this.tableCardSprite = this.add.image(trumpX, trumpY, 'cards', cardKey);
-    this.tableCardSprite.setScale(1.2);
+    this.tableCardSprite.setScale(1.0);
     this.tableCardSprite.setDepth(100);
 
-    // Label
-    this.tableCardLabel = this.add.text(trumpX, trumpY - 100, 'TRUMP', {
-      fontSize: `${24 * scaleX}px`,
-      fontStyle: 'bold',
-      color: '#FFD700',
+    // Background - subtle box around card
+    const cardWidth = this.tableCardSprite.displayWidth + 10;
+    const cardHeight = this.tableCardSprite.displayHeight + 10;
+    this.tableCardBackground = this.add.rectangle(trumpX, trumpY, cardWidth, cardHeight, 0x000000, 0.3);
+    this.tableCardBackground.setStrokeStyle(1, 0x666666, 0.5);
+    this.tableCardBackground.setDepth(99);
+
+    // Label - smaller and closer to card
+    this.tableCardLabel = this.add.text(trumpX, trumpY - (cardHeight / 2) - 12, 'TRUMP', {
+      fontSize: `${12 * scaleX}px`,
+      fontFamily: 'Arial, sans-serif',
+      color: '#aaaaaa',
     });
     this.tableCardLabel.setOrigin(0.5);
     this.tableCardLabel.setDepth(100);


### PR DESCRIPTION
## Summary
- Cleaned up trump card display: smaller card (1.0x scale), subtle border, muted label positioned closer to the card
- Fixed bug where trick counts in the game log were doubled (incremented in both `gameHandlers.js` and `GameScene.js`)

## Test plan
- [ ] Verify trump card display looks cleaner during gameplay
- [ ] Verify trick counts in game log match actual tricks won

🤖 Generated with [Claude Code](https://claude.com/claude-code)