### PR TITLE
Fix card legality check incorrectly thinking player is leading

### DIFF
--- a/client/src/phaser/scenes/GameScene.js
+++ b/client/src/phaser/scenes/GameScene.js
@@ -993,11 +993,8 @@ export class GameScene extends Phaser.Scene {
     // Detect over-trump and show effect
     this.detectOverTrump();
 
-    // Increment played card index
-    this.state.playedCardIndex++;
-    if (this.state.playedCardIndex >= 4) {
-      this.state.playedCardIndex = 0;
-    }
+    // Note: playedCardIndex is already incremented by gameHandlers.js via addPlayedCard()
+    // Do NOT increment here to avoid double-counting
 
     // Initialize TrickManager if needed
     if (this.trickManager && myPosition) {


### PR DESCRIPTION
## Summary
- Fixed bug where `playedCardIndex` was incremented twice (in `gameHandlers.js` and `GameScene.js`), causing it to reset to 0 prematurely
- This made the client incorrectly think a player was leading when they were following, resulting in wrong card legality (couldn't play trump when void in led suit)

## Test plan
- [x] Start a 4-player game
- [x] Have player 1 lead a non-trump suit
- [x] Verify player 3 (who is void in that suit) can play any card including trump

🤖 Generated with [Claude Code](https://claude.com/claude-code)