### PR TITLE
Rework trick display with two-row layout and visual enhancements

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1686,6 +1686,10 @@ function initializeApp() {
         if (scene.trickManager) {
           scene.trickManager.setPlayerPosition(data.position);
           scene.trickManager.updatePlayPositions();
+          if (data.hand) {
+            scene.trickManager.setHandSize(data.hand.length);
+          }
+          scene.trickManager.createTrickBackgrounds();
         }
         if (scene.opponentManager) {
           scene.opponentManager.setPlayerPosition(data.position);
@@ -1840,6 +1844,13 @@ function initializeApp() {
       const scene = getGameScene();
       if (scene && scene.handleBidReceived) {
         scene.handleBidReceived(data);
+      }
+      // Update trick slot outlines based on bid
+      if (scene && scene.trickManager && data.position !== undefined && data.bid !== undefined) {
+        // Parse bid value - 'B', '2B', '3B', '4B' are bore bids (0 tricks)
+        const bidStr = String(data.bid);
+        const bidValue = bidStr.includes('B') ? 0 : parseInt(bidStr, 10) || 0;
+        scene.trickManager.addBid(data.position, bidValue);
       }
       // Note: Legacy code in displayCards() also handles bidReceived for bubbles/impact events
     },

--- a/client/src/phaser/managers/TrickManager.js
+++ b/client/src/phaser/managers/TrickManager.js
@@ -14,6 +14,26 @@ const DESIGN_WIDTH = 1920;
 const DESIGN_HEIGHT = 953;
 
 /**
+ * Trick display layout constants.
+ */
+const TRICK_SCALE = 1.0; // 33% bigger than previous 0.75
+const TRICKS_ROW_1 = 7; // Top row capacity
+const TRICK_HORIZONTAL_SPACING = 120; // Base px between stacks (slot width + 10px gap)
+const TRICK_ROW_SPACING = 86; // Base px between card rows (slotH + slotRowGap)
+const TRICK_START_X = 70; // Left margin
+const TEAM_BASE_Y = 95; // Offset from bottom for team row 1 center
+const OPP_BASE_Y = 95; // Offset from top for opponent row 0 center
+const SLOT_WIDTH = 54; // Slot width (tight fit around card)
+const SLOT_HEIGHT = 76; // Slot height (tight fit around card)
+const SLOT_PADDING = 4; // Tight padding inside container
+const SLOT_ROW_GAP = 10; // Vertical gap between slot rows
+const CONTAINER_COLOR = 0x1a1a1a; // Dark grey container
+const SLOT_COLOR = 0x333333; // Lighter dark grey slots
+const BID_OUTLINE_COLOR = 0xff4444; // Red for bid slots
+const WON_OUTLINE_COLOR = 0x44ff44; // Green for won trick slots
+const OUTLINE_WIDTH = 2; // Outline stroke width
+
+/**
  * TrickManager handles all trick-related sprite operations.
  */
 export class TrickManager {
@@ -44,6 +64,62 @@ export class TrickManager {
     // Track trick counts
     this._teamTrickCount = 0;
     this._oppTrickCount = 0;
+
+    // Background graphics
+    this._backgroundGraphics = null;
+
+    // Current hand size (for marking impossible trick slots)
+    this._handSize = 13;
+
+    // Bid totals for outline colors
+    this._teamBidTotal = 0;
+    this._oppBidTotal = 0;
+  }
+
+  /**
+   * Set the current hand size (max tricks possible).
+   * @param {number} size - Number of cards in the hand
+   */
+  setHandSize(size) {
+    this._handSize = size;
+    // Redraw backgrounds to update X marks
+    if (this._backgroundGraphics) {
+      this._drawBackgrounds();
+    }
+  }
+
+  /**
+   * Add a bid to the appropriate team total.
+   * @param {number} position - Position of the bidder (1-4)
+   * @param {number} bidValue - Numeric bid value
+   */
+  addBid(position, bidValue) {
+    if (!this._playerPosition) return;
+
+    // Check if bidder is on player's team (same parity)
+    const isMyTeam = position % 2 === this._playerPosition % 2;
+
+    if (isMyTeam) {
+      this._teamBidTotal += bidValue;
+    } else {
+      this._oppBidTotal += bidValue;
+    }
+
+    // Redraw backgrounds to update outlines
+    if (this._backgroundGraphics) {
+      this._drawBackgrounds();
+    }
+  }
+
+  /**
+   * Reset bid totals for new hand.
+   */
+  resetBids() {
+    this._teamBidTotal = 0;
+    this._oppBidTotal = 0;
+    if (this._backgroundGraphics) {
+      this._drawBackgrounds();
+    }
   }
 
   /**
@@ -65,6 +141,45 @@ export class TrickManager {
       screenWidth,
       screenHeight,
     };
+  }
+
+  /**
+   * Calculate position for a trick in the two-row layout.
+   *
+   * @param {number} trickNumber - Trick number (1-13)
+   * @param {boolean} isTeamTrick - Whether this is for the player's team
+   * @returns {Object} {x, y}
+   */
+  _getTrickPosition(trickNumber, isTeamTrick) {
+    const { x: scaleX, y: scaleY, screenHeight } = this.getScaleFactors();
+
+    // Calculate row and column
+    // Tricks 1-7 go in row 0 (top row), tricks 8-13 go in row 1 (bottom row)
+    const row = trickNumber <= TRICKS_ROW_1 ? 0 : 1;
+    const col = trickNumber <= TRICKS_ROW_1 ? trickNumber - 1 : trickNumber - TRICKS_ROW_1 - 1;
+
+    // Scale spacing with screen size
+    const spacing = (SLOT_WIDTH + 10) * scaleX;
+
+    // Starting x position with margin
+    // Row 1 (6 tricks) is centered under row 0 (7 tricks) - offset by half spacing
+    const rowOffset = row === 1 ? spacing / 2 : 0;
+    const x = TRICK_START_X * scaleX + col * spacing + rowOffset;
+
+    let y;
+    if (isTeamTrick) {
+      // Team tricks at bottom left
+      const baseY = screenHeight - TEAM_BASE_Y * scaleY;
+      // Row 0 (tricks 1-7) is ABOVE row 1 (smaller y value)
+      y = baseY - (1 - row) * TRICK_ROW_SPACING * scaleY;
+    } else {
+      // Opponent tricks at top left
+      const baseY = OPP_BASE_Y * scaleY;
+      // Row 0 at top, row 1 below it
+      y = baseY + row * TRICK_ROW_SPACING * scaleY;
+    }
+
+    return { x, y };
   }
 
   /**
@@ -177,24 +292,18 @@ export class TrickManager {
    */
   completeTrick(winnerPosition, isMyTeam) {
     const scene = this._scene;
-    const { x: scaleX, y: scaleY, screenWidth, screenHeight } = this.getScaleFactors();
-    const trickSpacing = 40 * scaleX;
 
-    // Determine stack position based on winner
-    let winningPosition;
+    // Increment count and get position using new two-row layout
+    let trickNumber;
     if (isMyTeam) {
       this._teamTrickCount++;
-      winningPosition = {
-        x: 20 + this._teamTrickCount * trickSpacing,
-        y: screenHeight - 100,
-      };
+      trickNumber = this._teamTrickCount;
     } else {
       this._oppTrickCount++;
-      winningPosition = {
-        x: 20 + this._oppTrickCount * trickSpacing,
-        y: 100,
-      };
+      trickNumber = this._oppTrickCount;
     }
+
+    const winningPosition = this._getTrickPosition(trickNumber, isMyTeam);
 
     // Copy trick cards for history
     const trickCards = [...this._currentTrick];
@@ -211,7 +320,7 @@ export class TrickManager {
           targets: card,
           x: winningPosition.x,
           y: winningPosition.y,
-          scale: 0.75,
+          scale: TRICK_SCALE,
           duration: 500,
           ease: 'Power2',
           onComplete: () => {
@@ -222,7 +331,7 @@ export class TrickManager {
         card.x = winningPosition.x;
         card.y = winningPosition.y;
         card.setDepth(200 + index);
-        card.setScale(0.75);
+        card.setScale(TRICK_SCALE);
       }
 
       // Make interactive for hover
@@ -230,11 +339,12 @@ export class TrickManager {
       card.originalDepth = 200 + index;
     });
 
-    // Store in history
+    // Store in history with trick number for resize handling
     if (isMyTeam) {
       this._teamTrickHistory.push({
         cards: trickCards,
         position: { ...winningPosition },
+        trickNumber,
       });
 
       // Add hover effects for team tricks
@@ -243,11 +353,17 @@ export class TrickManager {
       this._oppTrickHistory.push({
         cards: trickCards,
         position: { ...winningPosition },
+        trickNumber,
       });
     }
 
     // Clear current trick
     this._currentTrick = [];
+
+    // Redraw backgrounds to update outline colors
+    if (this._backgroundGraphics) {
+      this._drawBackgrounds();
+    }
   }
 
   /**
@@ -263,14 +379,14 @@ export class TrickManager {
         if (this.isVisible()) {
           scene.tweens.add({
             targets: card,
-            x: position.x + index * 20 * scaleX,
-            y: position.y - index * 5 * scaleY,
+            x: position.x + index * 30 * scaleX,
+            y: position.y - index * 8 * scaleY,
             duration: 200,
             ease: 'Power1',
           });
         } else {
-          card.x = position.x + index * 20 * scaleX;
-          card.y = position.y - index * 5 * scaleY;
+          card.x = position.x + index * 30 * scaleX;
+          card.y = position.y - index * 8 * scaleY;
         }
       });
     };
@@ -307,6 +423,197 @@ export class TrickManager {
   }
 
   /**
+   * Create background graphics for trick display areas.
+   * Shows dark containers with lighter slot boxes for all 13 trick positions.
+   */
+  createTrickBackgrounds() {
+    // Destroy existing graphics if any
+    if (this._backgroundGraphics) {
+      this._backgroundGraphics.destroy();
+    }
+
+    this._backgroundGraphics = this._scene.add.graphics();
+    this._backgroundGraphics.setDepth(50); // Below cards (200+)
+
+    this._drawBackgrounds();
+  }
+
+  /**
+   * Draw background containers and slot boxes.
+   */
+  _drawBackgrounds() {
+    if (!this._backgroundGraphics) return;
+
+    const { x: scaleX, y: scaleY, screenHeight } = this.getScaleFactors();
+    const graphics = this._backgroundGraphics;
+
+    graphics.clear();
+
+    // Fixed slot dimensions (match the fixed card scale)
+    const slotW = SLOT_WIDTH;
+    const slotH = SLOT_HEIGHT;
+    // Scaled spacing to match _getTrickPosition calculations
+    const spacing = (SLOT_WIDTH + 10) * scaleX;
+    const rowSpacing = TRICK_ROW_SPACING * scaleY;
+    const padding = SLOT_PADDING;
+
+    // Container dimensions - tight fit around slots (scaled width, fixed height for slots)
+    // Width: 6 gaps between 7 slots + 7 slot widths + padding
+    const containerWidth = 6 * spacing + slotW + padding * 2;
+    // Height: 2 rows of slots with scaled gap between
+    const containerHeight = slotH * 2 + rowSpacing - slotH + padding * 2;
+
+    // Draw both team and opponent areas
+    [true, false].forEach((isTeamTrick) => {
+      // Get position of first card (trick 1) to anchor container
+      const firstCardPos = this._getTrickPosition(1, isTeamTrick);
+
+      // Container X: left edge of first slot minus padding
+      const containerX = firstCardPos.x - slotW / 2 - padding;
+
+      // Container Y: top of row 0 minus padding
+      const containerY = firstCardPos.y - slotH / 2 - padding;
+
+      // Draw container background (rounded rectangle, same radius as slots)
+      graphics.fillStyle(CONTAINER_COLOR, 1);
+      graphics.fillRoundedRect(containerX, containerY, containerWidth, containerHeight, 4);
+
+      // Get bid and trick counts for this area
+      const bidTotal = isTeamTrick ? this._teamBidTotal : this._oppBidTotal;
+      const tricksWon = isTeamTrick ? this._teamTrickCount : this._oppTrickCount;
+
+      // Draw slot boxes with tight vertical spacing
+      graphics.fillStyle(SLOT_COLOR, 1);
+
+      // Row 0: 7 slots (tricks 1-7)
+      for (let col = 0; col < 7; col++) {
+        const trickNum = col + 1;
+        const slotX = firstCardPos.x + col * spacing - slotW / 2;
+        const slotY = firstCardPos.y - slotH / 2;
+        graphics.fillRoundedRect(slotX, slotY, slotW, slotH, 4);
+
+        // Draw colored outline based on bids and tricks won
+        this._drawSlotOutline(graphics, slotX, slotY, slotW, slotH, trickNum, bidTotal, tricksWon);
+
+        // Draw X if trick is impossible
+        if (trickNum > this._handSize) {
+          this._drawSlotX(graphics, slotX, slotY, slotW, slotH);
+        }
+      }
+
+      // Row 1: 6 slots (tricks 8-13, centered under row 0)
+      // Row spacing matches _getTrickPosition calculation
+      const row1Y = firstCardPos.y + rowSpacing - slotH / 2;
+      const row1Offset = spacing / 2; // Center under row of 7
+      for (let col = 0; col < 6; col++) {
+        const trickNum = col + 8;
+        const slotX = firstCardPos.x + col * spacing + row1Offset - slotW / 2;
+        const slotY = row1Y;
+        graphics.fillRoundedRect(slotX, slotY, slotW, slotH, 4);
+
+        // Draw colored outline based on bids and tricks won
+        this._drawSlotOutline(graphics, slotX, slotY, slotW, slotH, trickNum, bidTotal, tricksWon);
+
+        // Draw X if trick is impossible
+        if (trickNum > this._handSize) {
+          this._drawSlotX(graphics, slotX, slotY, slotW, slotH);
+        }
+      }
+    });
+  }
+
+  /**
+   * Draw a colored outline on a slot based on bid/won status.
+   */
+  _drawSlotOutline(graphics, slotX, slotY, slotW, slotH, trickNum, bidTotal, tricksWon) {
+    let outlineColor = null;
+
+    if (trickNum <= tricksWon && trickNum <= bidTotal) {
+      // Trick was bid AND won - green outline
+      outlineColor = WON_OUTLINE_COLOR;
+    } else if (trickNum <= bidTotal) {
+      // Trick bid but not won yet - red outline
+      outlineColor = BID_OUTLINE_COLOR;
+    }
+    // Overtricks (trickNum > bidTotal) get no outline
+
+    if (outlineColor !== null) {
+      graphics.lineStyle(OUTLINE_WIDTH, outlineColor, 1);
+      graphics.strokeRoundedRect(slotX, slotY, slotW, slotH, 4);
+    }
+  }
+
+  /**
+   * Draw an X mark on an impossible trick slot.
+   */
+  _drawSlotX(graphics, slotX, slotY, slotW, slotH) {
+    const xPadding = 12; // Padding from slot edges
+    const lineWidth = 3;
+
+    graphics.lineStyle(lineWidth, CONTAINER_COLOR, 1);
+
+    // Draw X from top-left to bottom-right
+    graphics.beginPath();
+    graphics.moveTo(slotX + xPadding, slotY + xPadding);
+    graphics.lineTo(slotX + slotW - xPadding, slotY + slotH - xPadding);
+    graphics.strokePath();
+
+    // Draw X from top-right to bottom-left
+    graphics.beginPath();
+    graphics.moveTo(slotX + slotW - xPadding, slotY + xPadding);
+    graphics.lineTo(slotX + xPadding, slotY + slotH - xPadding);
+    graphics.strokePath();
+  }
+
+  /**
+   * Reposition/redraw background graphics on resize.
+   */
+  repositionTrickBackgrounds() {
+    this._drawBackgrounds();
+  }
+
+  /**
+   * Reposition trick history cards during resize.
+   */
+  repositionTrickHistory() {
+    // Reposition team trick history
+    this._teamTrickHistory.forEach((trick, index) => {
+      const trickNumber = trick.trickNumber || index + 1;
+      const newPos = this._getTrickPosition(trickNumber, true);
+
+      // Update stored position
+      trick.position.x = newPos.x;
+      trick.position.y = newPos.y;
+
+      // Move all cards in this trick
+      trick.cards.forEach((card) => {
+        if (card && card.active) {
+          card.x = newPos.x;
+          card.y = newPos.y;
+        }
+      });
+    });
+
+    // Reposition opponent trick history
+    this._oppTrickHistory.forEach((trick, index) => {
+      const trickNumber = trick.trickNumber || index + 1;
+      const newPos = this._getTrickPosition(trickNumber, false);
+
+      // Update stored position
+      trick.position.x = newPos.x;
+      trick.position.y = newPos.y;
+
+      // Move all cards in this trick
+      trick.cards.forEach((card) => {
+        if (card && card.active) {
+          card.x = newPos.x;
+          card.y = newPos.y;
+        }
+      });
+    });
+  }
+
+  /**
    * Reposition current trick cards (for resize handling).
    */
   repositionCurrentTrick() {
@@ -321,6 +628,10 @@ export class TrickManager {
       card.x = this._playPositions[positionKey].x;
       card.y = this._playPositions[positionKey].y;
     });
+
+    // Also reposition trick history and backgrounds
+    this.repositionTrickHistory();
+    this.repositionTrickBackgrounds();
   }
 
   /**
@@ -363,11 +674,22 @@ export class TrickManager {
   }
 
   /**
-   * Clear all trick sprites.
+   * Clear background graphics.
+   */
+  clearBackgrounds() {
+    if (this._backgroundGraphics) {
+      this._backgroundGraphics.destroy();
+      this._backgroundGraphics = null;
+    }
+  }
+
+  /**
+   * Clear all trick sprites and backgrounds.
    */
   clearAll() {
     this.clearCurrentTrick();
     this.clearTrickHistory();
+    this.clearBackgrounds();
   }
 
   /**
@@ -377,6 +699,8 @@ export class TrickManager {
     this.clearAll();
     this._teamTrickCount = 0;
     this._oppTrickCount = 0;
+    this._teamBidTotal = 0;
+    this._oppBidTotal = 0;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Increase trick card scale from 0.75 to 1.0 (33% bigger)
- Display tricks in two rows: top row (7 tricks), bottom row (6 tricks centered)
- Add dark container background with lighter grey slot boxes for all 13 trick positions
- Show X marks on impossible trick slots based on hand size
- Add red outlines for bid slots, green outlines for won tricks (excluding overtricks)
- Implement responsive scaling for consistent display across different screen sizes
- Initialize trick backgrounds when cards are dealt (game start)

## Test plan
- [ ] Start a game and verify dark containers with 13 grey slots appear for both team and opponent areas
- [ ] Play through a hand and verify tricks fill top row first (1-7), then bottom row (8-13)
- [ ] Verify trick cards are 33% larger than before
- [ ] Test bidding and verify red outlines appear on bid slots
- [ ] Win tricks and verify green outlines replace red for slots that were bid on
- [ ] Verify overtricks (tricks beyond bid) do not get green outlines
- [ ] Test different hand sizes and verify X marks appear on impossible trick slots
- [ ] Resize window and verify all elements reposition correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)