### PR TITLE
Add hand indicator to game log and player stats to final score screen

### DIFF
--- a/client/src/ui/components/GameLog.js
+++ b/client/src/ui/components/GameLog.js
@@ -53,7 +53,33 @@ export function createGameLog({ onChatSubmit } = {}) {
     <div id="opp-tricks-value" style="font-size: 11px; color: #aaa;">Tricks: 0</div>
   `;
 
+  // Hand indicator (between the two score displays)
+  const handIndicator = document.createElement('div');
+  handIndicator.id = 'handIndicator';
+  handIndicator.style.cssText = `
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  `;
+  handIndicator.innerHTML = `
+    <div style="font-size: 10px; color: #888; margin-bottom: 2px;">Hand</div>
+    <div id="hand-indicator-value" style="
+      background: #1a1a1a;
+      color: #b0b0b0;
+      font-size: 18px;
+      font-weight: bold;
+      width: 36px;
+      height: 36px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 4px;
+    ">-</div>
+  `;
+
   scoreSection.appendChild(teamScoreDiv);
+  scoreSection.appendChild(handIndicator);
   scoreSection.appendChild(oppScoreDiv);
   container.appendChild(scoreSection);
 
@@ -203,6 +229,11 @@ export function createGameLog({ onChatSubmit } = {}) {
     messageArea.innerHTML = '';
   };
 
+  const updateHandIndicator = (handSize) => {
+    const el = container.querySelector('#hand-indicator-value');
+    if (el) el.textContent = handSize.toString();
+  };
+
   const destroy = () => {
     container.remove();
   };
@@ -290,6 +321,7 @@ export function createGameLog({ onChatSubmit } = {}) {
     updateScores,
     updateTricks,
     updateFullScore,
+    updateHandIndicator,
     clearMessages,
     destroy,
     chatInput,

--- a/client/src/ui/components/GameLog.test.js
+++ b/client/src/ui/components/GameLog.test.js
@@ -14,13 +14,22 @@ describe('createGameLog', () => {
   it('creates game log container', () => {
     gameLog = createGameLog();
     expect(gameLog.container).toBeDefined();
-    expect(gameLog.container.id).toBe('game-log');
+    expect(gameLog.container.id).toBe('gameFeed');
   });
 
   it('has score section', () => {
     gameLog = createGameLog();
-    const scoreSection = gameLog.container.querySelector('#score-section');
+    const scoreSection = gameLog.container.querySelector('#gameLogScore');
     expect(scoreSection).toBeTruthy();
+  });
+
+  it('has hand indicator', () => {
+    gameLog = createGameLog();
+    const handIndicator = gameLog.container.querySelector('#handIndicator');
+    expect(handIndicator).toBeTruthy();
+    const handValue = gameLog.container.querySelector('#hand-indicator-value');
+    expect(handValue).toBeTruthy();
+    expect(handValue.textContent).toBe('-');
   });
 
   it('has chat input', () => {
@@ -31,7 +40,7 @@ describe('createGameLog', () => {
 
   it('addMessage adds chat message', () => {
     gameLog = createGameLog();
-    const messageArea = gameLog.container.querySelector('#game-log-messages');
+    const messageArea = gameLog.container.querySelector('#gameFeedMessages');
 
     gameLog.addMessage('Alice', 'Hello!');
 
@@ -41,7 +50,7 @@ describe('createGameLog', () => {
 
   it('addSystemMessage adds system message', () => {
     gameLog = createGameLog();
-    const messageArea = gameLog.container.querySelector('#game-log-messages');
+    const messageArea = gameLog.container.querySelector('#gameFeedMessages');
 
     gameLog.addSystemMessage('Game started');
 
@@ -56,6 +65,24 @@ describe('createGameLog', () => {
 
     expect(gameLog.container.querySelector('#team-score-value').textContent).toBe('50');
     expect(gameLog.container.querySelector('#opp-score-value').textContent).toBe('30');
+  });
+
+  it('updateHandIndicator updates hand display', () => {
+    gameLog = createGameLog();
+    document.body.appendChild(gameLog.container);
+
+    gameLog.updateHandIndicator(12);
+
+    expect(gameLog.container.querySelector('#hand-indicator-value').textContent).toBe('12');
+  });
+
+  it('updateHandIndicator handles single digit hands', () => {
+    gameLog = createGameLog();
+    document.body.appendChild(gameLog.container);
+
+    gameLog.updateHandIndicator(1);
+
+    expect(gameLog.container.querySelector('#hand-indicator-value').textContent).toBe('1');
   });
 
   it('calls onChatSubmit when message sent', () => {
@@ -94,7 +121,7 @@ describe('createGameLog', () => {
 
   it('clearMessages clears message area', () => {
     gameLog = createGameLog();
-    const messageArea = gameLog.container.querySelector('#game-log-messages');
+    const messageArea = gameLog.container.querySelector('#gameFeedMessages');
 
     gameLog.addMessage('Test', 'message');
     expect(messageArea.textContent).toContain('Test');
@@ -107,24 +134,24 @@ describe('createGameLog', () => {
     gameLog = createGameLog();
     document.body.appendChild(gameLog.container);
 
-    expect(document.getElementById('game-log')).toBeTruthy();
+    expect(document.getElementById('gameFeed')).toBeTruthy();
 
     gameLog.destroy();
     gameLog = null;
 
-    expect(document.getElementById('game-log')).toBeFalsy();
+    expect(document.getElementById('gameFeed')).toBeFalsy();
   });
 });
 
 describe('showGameLog', () => {
   afterEach(() => {
-    document.getElementById('game-log')?.remove();
+    document.getElementById('gameFeed')?.remove();
   });
 
   it('appends game log to body', () => {
     const log = showGameLog();
 
-    expect(document.getElementById('game-log')).toBeTruthy();
+    expect(document.getElementById('gameFeed')).toBeTruthy();
 
     log.destroy();
   });

--- a/client/src/ui/components/ScoreModal.js
+++ b/client/src/ui/components/ScoreModal.js
@@ -118,10 +118,11 @@ export function formatGameEndMessages(options) {
  * @param {Object} options - Options
  * @param {number} options.teamScore - Final team score
  * @param {number} options.oppScore - Final opponent score
+ * @param {Object} options.playerStats - Player stats object { position: { username, totalBids, totalTricks, setsCaused } }
  * @param {Function} options.onReturnToLobby - Called when user clicks return button
  * @returns {Object} { overlay, destroy }
  */
-export function showFinalScoreOverlay({ teamScore, oppScore, onReturnToLobby }) {
+export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onReturnToLobby }) {
   // Determine winner message
   let resultMsg;
   let resultColor;
@@ -145,7 +146,7 @@ export function showFinalScoreOverlay({ teamScore, oppScore, onReturnToLobby }) 
     left: 0;
     width: 100vw;
     height: 100vh;
-    background: rgba(0, 0, 0, 0.7);
+    background: rgba(0, 0, 0, 0.85);
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -170,10 +171,73 @@ export function showFinalScoreOverlay({ teamScore, oppScore, onReturnToLobby }) 
   scoreDiv.style.cssText = `
     font-size: 24px;
     color: white;
-    margin-bottom: 40px;
+    margin-bottom: 30px;
   `;
   scoreDiv.textContent = `Final Score: ${teamScore} - ${oppScore}`;
   overlay.appendChild(scoreDiv);
+
+  // Player stats grid (if available)
+  if (playerStats) {
+    const statsContainer = document.createElement('div');
+    statsContainer.style.cssText = `
+      background: rgba(30, 30, 30, 0.9);
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 30px;
+      min-width: 400px;
+    `;
+
+    // Stats header
+    const statsHeader = document.createElement('div');
+    statsHeader.style.cssText = `
+      display: grid;
+      grid-template-columns: 2fr 1fr 1fr 1fr;
+      gap: 12px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid #444;
+      margin-bottom: 12px;
+      color: #888;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    `;
+    statsHeader.innerHTML = `
+      <div>Player</div>
+      <div style="text-align: center;">Bids</div>
+      <div style="text-align: center;">Tricks</div>
+      <div style="text-align: center;">Faults</div>
+    `;
+    statsContainer.appendChild(statsHeader);
+
+    // Player rows - order by position (1, 2, 3, 4)
+    for (let pos = 1; pos <= 4; pos++) {
+      const stats = playerStats[pos];
+      if (!stats) continue;
+
+      // Team color: positions 1,3 = team1 (blue-ish), positions 2,4 = team2 (red-ish)
+      const isTeam1 = pos === 1 || pos === 3;
+      const teamColor = isTeam1 ? '#63b3ed' : '#fc8181';
+
+      const playerRow = document.createElement('div');
+      playerRow.style.cssText = `
+        display: grid;
+        grid-template-columns: 2fr 1fr 1fr 1fr;
+        gap: 12px;
+        padding: 8px 0;
+        color: white;
+        font-size: 14px;
+      `;
+      playerRow.innerHTML = `
+        <div style="color: ${teamColor}; font-weight: 500;">${stats.username}</div>
+        <div style="text-align: center;">${stats.totalBids}</div>
+        <div style="text-align: center;">${stats.totalTricks}</div>
+        <div style="text-align: center; color: ${stats.setsCaused > 0 ? '#ef4444' : 'inherit'};">${stats.setsCaused}</div>
+      `;
+      statsContainer.appendChild(playerRow);
+    }
+
+    overlay.appendChild(statsContainer);
+  }
 
   // Return button
   const returnBtn = document.createElement('button');

--- a/server/game/GameState.js
+++ b/server/game/GameState.js
@@ -49,6 +49,18 @@ class GameState {
         // Hand stats (for player profiles)
         this.handStats = { totalHands: 0, team1Sets: 0, team2Sets: 0 };
 
+        // Per-player stats for final score screen
+        // position (1-4) → { totalBids, totalTricks, setsCaused }
+        this.playerStats = {
+            1: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+            2: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+            3: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+            4: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+        };
+
+        // Per-hand trick tracking (reset each hand) for determining set responsibility
+        this.handTricks = { 1: 0, 2: 0, 3: 0, 4: 0 };
+
         // Draw phase
         this.drawCards = [];
         this.drawIDs = [];
@@ -270,6 +282,14 @@ class GameState {
     recordBid(position, bid) {
         this.bids[position] = bid;
         this.playerBids[position - 1] = bid;
+
+        // Track total bids for player stats
+        // Bore bids (B, 2B, 3B, 4B) count as 0 tricks bid
+        const bidStr = String(bid);
+        const bidValue = bidStr.includes('B') ? 0 : parseInt(bidStr, 10) || 0;
+        if (this.playerStats[position]) {
+            this.playerStats[position].totalBids += bidValue;
+        }
     }
 
     getBidCount() {
@@ -303,6 +323,9 @@ class GameState {
 
         this.tricks = { team1: 0, team2: 0 };
         this.rainbows = { team1: 0, team2: 0 };
+
+        // Reset per-hand trick tracking
+        this.handTricks = { 1: 0, 2: 0, 3: 0, 4: 0 };
     }
 
     resetForNewGame() {
@@ -310,6 +333,12 @@ class GameState {
         this.dealer = 1;
         this.score = { team1: 0, team2: 0 };
         this.handStats = { totalHands: 0, team1Sets: 0, team2Sets: 0 };
+        this.playerStats = {
+            1: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+            2: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+            3: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+            4: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+        };
         this.resetForNewHand(1, 12);
 
         this.phase = 'waiting';


### PR DESCRIPTION
## Summary
- Add hand size indicator (12, 10, 8, etc.) between team scores in game log, updating each hand
- Add player stats grid to final score overlay showing each player's total bids, tricks won, and faults (sets caused)
- Fix profile stats (bids/game, tricks/game) to track individual player cumulative stats instead of broken team-level per-hand stats
- Add proper cleanup on return to lobby for avatars, play areas, and DOM backgrounds

## Changes
**Game Log:**
- New hand indicator element between team score displays
- Updates on game start, rejoin, and each new hand

**Final Score Screen:**
- Grid showing all 4 players with their game stats
- Columns: Player (team-colored), Bids, Tricks, Faults
- Faults highlighted in red when > 0

**Server Stats Tracking:**
- New `playerStats` object tracks per-player: totalBids, totalTricks, setsCaused
- New `handTricks` tracks individual trick wins per hand for fault detection
- Fixed `recordGameStats` to use individual stats for profile page

**Cleanup:**
- Proper cleanup of avatars, play zone, hand background on return to lobby

## Test plan
- [ ] Start a game and verify hand indicator shows correct hand size (12 initially)
- [ ] Play through multiple hands and verify indicator updates (12→10→8→...)
- [ ] Complete a game and verify final score screen shows player stats grid
- [ ] Verify faults column shows correct count for players who caused sets
- [ ] Click "Return to Lobby" and verify no visual artifacts remain
- [ ] Check profile page stats after a game to verify bids/game and tricks/game are reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)