### PR TITLE
Fix totalSets profile stat to use team sets instead of fault-based

### DIFF
--- a/server/socket/profileHandlers.js
+++ b/server/socket/profileHandlers.js
@@ -221,7 +221,8 @@ async function recordGameStats(game) {
         const playerStats = game.playerStats?.[position] || { totalBids: 0, totalTricks: 0, setsCaused: 0 };
         const playerBids = playerStats.totalBids;
         const playerTricks = playerStats.totalTricks;
-        const playerSets = playerStats.setsCaused;
+        // Total sets is team-based, not fault-based
+        const teamSets = isTeam1 ? game.handStats.team1Sets : game.handStats.team2Sets;
 
         try {
             await usersCollection.updateOne(
@@ -235,7 +236,7 @@ async function recordGameStats(game) {
                         'stats.totalTricksBid': playerBids,
                         'stats.totalTricksTaken': playerTricks,
                         'stats.totalHands': totalHands,
-                        'stats.totalSets': playerSets
+                        'stats.totalSets': teamSets
                     }
                 }
             );
@@ -247,7 +248,7 @@ async function recordGameStats(game) {
                 tricks: playerTricks,
                 bids: playerBids,
                 hands: totalHands,
-                sets: playerSets
+                sets: teamSets
             });
         } catch (error) {
             authLogger.error('Error recording game stats', {


### PR DESCRIPTION
## Summary
- Changed profile page's `totalSets` stat to use team-based sets (`handStats.team1Sets/team2Sets`) instead of fault-based (`playerStats.setsCaused`)
- This makes "Set Rate" reflect every time the player's team got set, regardless of individual fault
- The "Faults" column on the final score screen still uses `setsCaused` as intended

## Test plan
- [ ] Play a game where a teammate causes a set (not you)
- [ ] Verify the set is counted in your profile's Set Rate
- [ ] Verify "Faults" on final score screen still only shows fault-based sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)