### PR TITLE
Add leaderboard feature and new player statistics

### DIFF
--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -32,6 +32,9 @@ export const CLIENT_EVENTS = {
   // Profile
   GET_PROFILE: 'getProfile',
   UPDATE_PROFILE_PIC: 'updateProfilePic',
+
+  // Leaderboard
+  GET_LEADERBOARD: 'getLeaderboard',
 };
 
 // Server -> Client Events
@@ -100,4 +103,7 @@ export const SERVER_EVENTS = {
   // Profile
   PROFILE_RESPONSE: 'profileResponse',
   PROFILE_PIC_UPDATE_RESPONSE: 'profilePicUpdateResponse',
+
+  // Leaderboard
+  LEADERBOARD_RESPONSE: 'leaderboardResponse',
 };

--- a/client/src/handlers/index.js
+++ b/client/src/handlers/index.js
@@ -10,6 +10,7 @@ import { registerLobbyHandlers } from './lobbyHandlers.js';
 import { registerGameHandlers, cleanupGameHandlers as cleanupGame } from './gameHandlers.js';
 import { registerChatHandlers } from './chatHandlers.js';
 import { registerProfileHandlers } from './profileHandlers.js';
+import { registerLeaderboardHandlers } from './leaderboardHandlers.js';
 
 /**
  * Register all socket event handlers.
@@ -71,6 +72,9 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onProfilePicUpdateError,
     onCustomProfilePicUploaded,
     onCustomProfilePicUploadError,
+    // Leaderboard callbacks
+    onLeaderboardReceived,
+    onLeaderboardError,
   } = callbacks;
 
   // Register auth handlers
@@ -139,6 +143,12 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onCustomProfilePicUploaded,
     onCustomProfilePicUploadError,
   });
+
+  // Register leaderboard handlers
+  registerLeaderboardHandlers(socketManager, {
+    onLeaderboardReceived,
+    onLeaderboardError,
+  });
 }
 
 /**
@@ -154,3 +164,4 @@ export { registerLobbyHandlers } from './lobbyHandlers.js';
 export { registerGameHandlers } from './gameHandlers.js';
 export { registerChatHandlers } from './chatHandlers.js';
 export { registerProfileHandlers } from './profileHandlers.js';
+export { registerLeaderboardHandlers } from './leaderboardHandlers.js';

--- a/client/src/handlers/leaderboardHandlers.js
+++ b/client/src/handlers/leaderboardHandlers.js
@@ -1,0 +1,31 @@
+/**
+ * Leaderboard-related socket event handlers.
+ *
+ * Handles: leaderboardResponse
+ */
+
+/**
+ * Register leaderboard handlers.
+ *
+ * @param {SocketManager} socketManager - Socket manager instance
+ * @param {Object} callbacks - UI callbacks
+ * @param {Function} callbacks.onLeaderboardReceived - Called when leaderboard data is received
+ * @param {Function} callbacks.onLeaderboardError - Called on leaderboard fetch error
+ */
+export function registerLeaderboardHandlers(socketManager, callbacks = {}) {
+  const {
+    onLeaderboardReceived,
+    onLeaderboardError,
+  } = callbacks;
+
+  // Leaderboard response
+  socketManager.on('leaderboardResponse', (data) => {
+    if (data.success) {
+      console.log('Leaderboard received:', data.leaderboard.length, 'players');
+      onLeaderboardReceived?.(data.leaderboard);
+    } else {
+      console.warn('Leaderboard fetch failed:', data.message);
+      onLeaderboardError?.(data.message || 'Failed to fetch leaderboard');
+    }
+  });
+}

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -31,6 +31,7 @@ import { createRegisterScreen, showRegisterScreen } from './ui/screens/Register.
 import { showMainRoom, addMainRoomChatMessage, updateLobbyList, removeMainRoom, updateMainRoomOnlineCount, getMainRoomUserColors } from './ui/screens/MainRoom.js';
 import { showGameLobby, updateLobbyPlayersList, addLobbyChatMessage, removeGameLobby, getCurrentLobbyId, getIsPlayerReady, getLobbyUserColors } from './ui/screens/GameLobby.js';
 import { showProfilePage, updateProfilePicDisplay, updateCustomProfilePicDisplay, removeProfilePage, isProfilePageVisible } from './ui/screens/ProfilePage.js';
+import { showLeaderboardPage, removeLeaderboardPage, isLeaderboardPageVisible } from './ui/screens/LeaderboardPage.js';
 import { UIManager, SCREENS, getUIManager, initializeUIManager, resetUIManager } from './ui/UIManager.js';
 
 // Phaser
@@ -1965,6 +1966,10 @@ function initializeApp() {
             if (scene.cleanup) {
               scene.cleanup();
             }
+            // Clean up opponent manager (avatars, dealer button)
+            if (scene.opponentManager && scene.opponentManager.clearAll) {
+              scene.opponentManager.clearAll();
+            }
             // Clean up DOM backgrounds (play zone, hand background)
             if (scene.layoutManager && scene.layoutManager.cleanupDomBackgrounds) {
               scene.layoutManager.cleanupDomBackgrounds();
@@ -2016,6 +2021,11 @@ function initializeApp() {
       // Clean up DOM backgrounds
       if (scene && scene.layoutManager) {
         scene.layoutManager.cleanupDomBackgrounds();
+      }
+
+      // Clean up opponent manager (avatars, dealer button)
+      if (scene && scene.opponentManager && scene.opponentManager.clearAll) {
+        scene.opponentManager.clearAll();
       }
 
       // Clear all UI
@@ -2314,6 +2324,13 @@ function initializeApp() {
     },
     onCustomProfilePicUploadError: (message) => {
       showError(message || 'Failed to upload profile picture');
+    },
+    // Leaderboard callbacks
+    onLeaderboardReceived: (leaderboard) => {
+      showLeaderboardPage(leaderboard, socket);
+    },
+    onLeaderboardError: (message) => {
+      showError(message || 'Failed to load leaderboard');
     },
   });
 

--- a/client/src/ui/screens/LeaderboardPage.js
+++ b/client/src/ui/screens/LeaderboardPage.js
@@ -1,0 +1,419 @@
+/**
+ * Leaderboard Page Screen
+ *
+ * Modal overlay showing player stats in a sortable table.
+ */
+
+/**
+ * Module state - tracks current sort configuration.
+ */
+let currentSort = { column: 'winRate', ascending: false };
+let currentLeaderboard = null;
+let currentSocket = null;
+
+/**
+ * Get the appropriate profile picture source.
+ *
+ * @param {Object} player - Player data
+ * @returns {string} Image source (base64 or URL)
+ */
+function getProfilePicSrc(player) {
+  if (player.customProfilePic) {
+    return player.customProfilePic;
+  }
+  if (player.profilePic) {
+    return `assets/profile${player.profilePic}.png`;
+  }
+  return 'assets/profile1.png';
+}
+
+/**
+ * Format a stat value for display.
+ *
+ * @param {number} value - Raw stat value
+ * @param {string} type - Type of stat ('percent', 'decimal', 'ratio')
+ * @returns {string} Formatted stat string
+ */
+function formatStatValue(value, type) {
+  if (type === 'percent') {
+    return value.toFixed(1) + '%';
+  }
+  if (type === 'ratio') {
+    return value.toFixed(2);
+  }
+  return value.toFixed(1);
+}
+
+/**
+ * Sort the leaderboard data based on current sort settings.
+ *
+ * @param {Array} data - Leaderboard data
+ * @returns {Array} Sorted data
+ */
+function sortLeaderboard(data) {
+  const sorted = [...data];
+  sorted.sort((a, b) => {
+    const aVal = a[currentSort.column];
+    const bVal = b[currentSort.column];
+    const diff = currentSort.ascending ? aVal - bVal : bVal - aVal;
+    return diff;
+  });
+  return sorted;
+}
+
+/**
+ * Column configuration for the leaderboard table.
+ */
+const COLUMNS = [
+  { key: 'rank', label: '#', width: '40px', sortable: false },
+  { key: 'player', label: 'Player', width: '140px', sortable: false },
+  { key: 'winRate', label: 'Win %', width: '65px', sortable: true, type: 'percent', defaultAscending: false },
+  { key: 'pointsPerGame', label: 'Pts/Game', width: '75px', sortable: true, type: 'decimal', defaultAscending: false },
+  { key: 'bidsPerGame', label: 'Bids/Game', width: '80px', sortable: true, type: 'decimal', defaultAscending: false },
+  { key: 'tricksPerBid', label: 'Tricks/Bid', width: '80px', sortable: true, type: 'ratio', defaultAscending: true },
+  { key: 'setRate', label: 'Set %', width: '60px', sortable: true, type: 'percent', defaultAscending: true },
+  { key: 'drag', label: 'Drag', width: '55px', sortable: true, type: 'decimal', defaultAscending: true },
+  { key: 'avgHSI', label: 'HSI', width: '55px', sortable: true, type: 'decimal', defaultAscending: false },
+];
+
+/**
+ * Create a table header cell.
+ *
+ * @param {Object} column - Column configuration
+ * @param {Function} onSort - Sort handler
+ * @returns {HTMLElement} Header cell element
+ */
+function createHeaderCell(column, onSort) {
+  const th = document.createElement('th');
+  th.style.padding = '12px 8px';
+  th.style.textAlign = column.key === 'player' ? 'left' : 'center';
+  th.style.fontWeight = 'bold';
+  th.style.fontSize = '13px';
+  th.style.textTransform = 'uppercase';
+  th.style.borderBottom = '2px solid #4a5568';
+  th.style.position = 'sticky';
+  th.style.top = '0';
+  th.style.background = '#1a1a2e';
+  th.style.zIndex = '10';
+  th.style.width = column.width;
+
+  if (column.sortable) {
+    th.style.cursor = 'pointer';
+    th.style.userSelect = 'none';
+    th.style.transition = 'color 0.2s';
+
+    const isActive = currentSort.column === column.key;
+    th.style.color = isActive ? '#4ade80' : '#9ca3af';
+
+    const labelSpan = document.createElement('span');
+    labelSpan.innerText = column.label;
+    th.appendChild(labelSpan);
+
+    if (isActive) {
+      const arrow = document.createElement('span');
+      arrow.innerText = currentSort.ascending ? ' \u25B2' : ' \u25BC';
+      arrow.style.fontSize = '10px';
+      th.appendChild(arrow);
+    }
+
+    th.addEventListener('mouseenter', () => {
+      if (!isActive) th.style.color = '#60a5fa';
+    });
+    th.addEventListener('mouseleave', () => {
+      th.style.color = isActive ? '#4ade80' : '#9ca3af';
+    });
+    th.addEventListener('click', () => {
+      onSort(column.key);
+    });
+  } else {
+    th.style.color = '#9ca3af';
+    th.innerText = column.label;
+  }
+
+  return th;
+}
+
+/**
+ * Create a table data cell.
+ *
+ * @param {string|number} value - Cell value
+ * @param {string} align - Text alignment
+ * @returns {HTMLElement} Data cell element
+ */
+function createDataCell(value, align = 'center') {
+  const td = document.createElement('td');
+  td.style.padding = '10px 8px';
+  td.style.textAlign = align;
+  td.style.borderBottom = '1px solid #2d3748';
+  td.style.color = '#e5e7eb';
+  td.style.fontSize = '14px';
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    td.innerText = value;
+  } else {
+    td.appendChild(value);
+  }
+
+  return td;
+}
+
+/**
+ * Create a player cell with avatar and username.
+ *
+ * @param {Object} player - Player data
+ * @returns {HTMLElement} Player cell content
+ */
+function createPlayerCell(player) {
+  const container = document.createElement('div');
+  container.style.display = 'flex';
+  container.style.alignItems = 'center';
+  container.style.gap = '8px';
+  container.style.maxWidth = '100%';
+  container.style.overflow = 'hidden';
+
+  const avatar = document.createElement('img');
+  avatar.src = getProfilePicSrc(player);
+  avatar.style.width = '24px';
+  avatar.style.height = '24px';
+  avatar.style.borderRadius = '50%';
+  avatar.style.objectFit = 'cover';
+  avatar.style.flexShrink = '0';
+  avatar.alt = player.username;
+  container.appendChild(avatar);
+
+  const username = document.createElement('span');
+  username.innerText = player.username;
+  username.style.overflow = 'hidden';
+  username.style.textOverflow = 'ellipsis';
+  username.style.whiteSpace = 'nowrap';
+  username.style.minWidth = '0';
+  container.appendChild(username);
+
+  return container;
+}
+
+/**
+ * Render the table body with sorted data.
+ *
+ * @param {HTMLElement} tbody - Table body element
+ * @param {Array} data - Leaderboard data
+ */
+function renderTableBody(tbody, data) {
+  tbody.innerHTML = '';
+
+  const sortedData = sortLeaderboard(data);
+
+  sortedData.forEach((player, index) => {
+    const tr = document.createElement('tr');
+    tr.style.transition = 'background 0.2s';
+    tr.addEventListener('mouseenter', () => {
+      tr.style.background = 'rgba(255, 255, 255, 0.05)';
+    });
+    tr.addEventListener('mouseleave', () => {
+      tr.style.background = 'transparent';
+    });
+
+    // Rank
+    tr.appendChild(createDataCell(index + 1));
+
+    // Player (avatar + username)
+    tr.appendChild(createDataCell(createPlayerCell(player), 'left'));
+
+    // Stats columns
+    tr.appendChild(createDataCell(formatStatValue(player.winRate, 'percent')));
+    tr.appendChild(createDataCell(formatStatValue(player.pointsPerGame, 'decimal')));
+    tr.appendChild(createDataCell(formatStatValue(player.bidsPerGame, 'decimal')));
+    tr.appendChild(createDataCell(formatStatValue(player.tricksPerBid, 'ratio')));
+    tr.appendChild(createDataCell(formatStatValue(player.setRate, 'percent')));
+    tr.appendChild(createDataCell(formatStatValue(player.drag, 'decimal')));
+    tr.appendChild(createDataCell(formatStatValue(player.avgHSI, 'decimal')));
+
+    tbody.appendChild(tr);
+  });
+
+  // If no players, show message
+  if (sortedData.length === 0) {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = COLUMNS.length;
+    td.style.padding = '40px';
+    td.style.textAlign = 'center';
+    td.style.color = '#9ca3af';
+    td.style.fontStyle = 'italic';
+    td.innerText = 'No players have completed games yet.';
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  }
+}
+
+/**
+ * Show the leaderboard page.
+ *
+ * @param {Array} leaderboard - Leaderboard data
+ * @param {Object} socket - Socket instance
+ */
+export function showLeaderboardPage(leaderboard, socket) {
+  console.log('Showing leaderboard page...', leaderboard.length, 'players');
+
+  // Remove any existing leaderboard page
+  removeLeaderboardPage();
+
+  currentLeaderboard = leaderboard;
+  currentSocket = socket;
+  currentSort = { column: 'winRate', ascending: false };
+
+  // Create overlay
+  const overlay = document.createElement('div');
+  overlay.id = 'leaderboardPageOverlay';
+  overlay.style.position = 'fixed';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.right = '0';
+  overlay.style.bottom = '0';
+  overlay.style.background = 'rgba(0, 0, 0, 0.7)';
+  overlay.style.zIndex = '2000';
+  overlay.style.display = 'flex';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+
+  // Create modal container
+  const modal = document.createElement('div');
+  modal.id = 'leaderboardPageModal';
+  modal.style.background = '#1a1a2e';
+  modal.style.color = '#fff';
+  modal.style.padding = '25px';
+  modal.style.borderRadius = '12px';
+  modal.style.border = '2px solid #4a5568';
+  modal.style.width = '900px';
+  modal.style.maxWidth = '95vw';
+  modal.style.maxHeight = '90vh';
+  modal.style.boxSizing = 'border-box';
+  modal.style.fontFamily = 'Arial, sans-serif';
+  modal.style.display = 'flex';
+  modal.style.flexDirection = 'column';
+
+  // Header
+  const headerRow = document.createElement('div');
+  headerRow.style.display = 'flex';
+  headerRow.style.justifyContent = 'space-between';
+  headerRow.style.alignItems = 'center';
+  headerRow.style.marginBottom = '20px';
+  headerRow.style.flexShrink = '0';
+
+  const title = document.createElement('div');
+  title.innerText = 'Leaderboard';
+  title.style.fontSize = '24px';
+  title.style.fontWeight = 'bold';
+  title.style.color = '#4ade80';
+  headerRow.appendChild(title);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.innerText = 'X';
+  closeBtn.style.background = '#ef4444';
+  closeBtn.style.border = 'none';
+  closeBtn.style.borderRadius = '50%';
+  closeBtn.style.width = '36px';
+  closeBtn.style.height = '36px';
+  closeBtn.style.color = '#fff';
+  closeBtn.style.fontSize = '18px';
+  closeBtn.style.cursor = 'pointer';
+  closeBtn.style.fontWeight = 'bold';
+  closeBtn.addEventListener('click', () => {
+    removeLeaderboardPage();
+  });
+  closeBtn.addEventListener('mouseenter', () => {
+    closeBtn.style.background = '#dc2626';
+  });
+  closeBtn.addEventListener('mouseleave', () => {
+    closeBtn.style.background = '#ef4444';
+  });
+  headerRow.appendChild(closeBtn);
+
+  modal.appendChild(headerRow);
+
+  // Table container with vertical scroll only
+  const tableContainer = document.createElement('div');
+  tableContainer.style.flex = '1';
+  tableContainer.style.overflowY = 'auto';
+  tableContainer.style.overflowX = 'hidden';
+  tableContainer.style.maxHeight = '500px';
+  tableContainer.style.borderRadius = '8px';
+  tableContainer.style.border = '1px solid #2d3748';
+
+  // Create table
+  const table = document.createElement('table');
+  table.style.width = '100%';
+  table.style.borderCollapse = 'collapse';
+  table.style.tableLayout = 'fixed';
+
+  // Create table header
+  const thead = document.createElement('thead');
+  const headerTr = document.createElement('tr');
+
+  // Reference to tbody for re-rendering on sort
+  const tbody = document.createElement('tbody');
+
+  // Sort handler
+  const handleSort = (columnKey) => {
+    if (currentSort.column === columnKey) {
+      currentSort.ascending = !currentSort.ascending;
+    } else {
+      currentSort.column = columnKey;
+      // Use column's preferred default sort direction
+      const column = COLUMNS.find(c => c.key === columnKey);
+      currentSort.ascending = column?.defaultAscending ?? false;
+    }
+
+    // Re-render header to update sort indicators
+    headerTr.innerHTML = '';
+    COLUMNS.forEach((col) => {
+      headerTr.appendChild(createHeaderCell(col, handleSort));
+    });
+
+    // Re-render table body with new sort
+    renderTableBody(tbody, currentLeaderboard);
+  };
+
+  // Build header
+  COLUMNS.forEach((col) => {
+    headerTr.appendChild(createHeaderCell(col, handleSort));
+  });
+  thead.appendChild(headerTr);
+  table.appendChild(thead);
+
+  // Build body
+  renderTableBody(tbody, leaderboard);
+  table.appendChild(tbody);
+
+  tableContainer.appendChild(table);
+  modal.appendChild(tableContainer);
+
+  overlay.appendChild(modal);
+
+  // Close on overlay click (but not modal click)
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) {
+      removeLeaderboardPage();
+    }
+  });
+
+  document.body.appendChild(overlay);
+}
+
+/**
+ * Remove the leaderboard page.
+ */
+export function removeLeaderboardPage() {
+  const overlay = document.getElementById('leaderboardPageOverlay');
+  if (overlay) overlay.remove();
+  currentLeaderboard = null;
+}
+
+/**
+ * Check if leaderboard page is currently visible.
+ *
+ * @returns {boolean} True if leaderboard page is visible
+ */
+export function isLeaderboardPageVisible() {
+  return document.getElementById('leaderboardPageOverlay') !== null;
+}

--- a/client/src/ui/screens/MainRoom.js
+++ b/client/src/ui/screens/MainRoom.js
@@ -186,6 +186,28 @@ export function showMainRoom(data, socket) {
   rightContainer.style.alignItems = 'center';
   rightContainer.style.gap = '15px';
 
+  // Leaderboard button
+  const leaderboardBtn = document.createElement('button');
+  leaderboardBtn.innerText = 'Leaderboard';
+  leaderboardBtn.style.padding = '8px 16px';
+  leaderboardBtn.style.borderRadius = '6px';
+  leaderboardBtn.style.border = 'none';
+  leaderboardBtn.style.background = '#6366f1';
+  leaderboardBtn.style.color = '#fff';
+  leaderboardBtn.style.fontSize = '14px';
+  leaderboardBtn.style.fontWeight = 'bold';
+  leaderboardBtn.style.cursor = 'pointer';
+  leaderboardBtn.addEventListener('click', () => {
+    socket.emit('getLeaderboard');
+  });
+  leaderboardBtn.addEventListener('mouseenter', () => {
+    leaderboardBtn.style.background = '#4f46e5';
+  });
+  leaderboardBtn.addEventListener('mouseleave', () => {
+    leaderboardBtn.style.background = '#6366f1';
+  });
+  rightContainer.appendChild(leaderboardBtn);
+
   // Profile button
   const profileBtn = document.createElement('button');
   profileBtn.innerText = 'Profile';

--- a/client/src/ui/screens/ProfilePage.js
+++ b/client/src/ui/screens/ProfilePage.js
@@ -478,7 +478,7 @@ export function showProfilePage(profile, socket) {
 
   // Stats section
   const statsHeader = document.createElement('div');
-  statsHeader.innerText = 'Game Statistics';
+  statsHeader.innerText = 'Statistics';
   statsHeader.style.fontSize = '18px';
   statsHeader.style.fontWeight = 'bold';
   statsHeader.style.marginBottom = '15px';
@@ -518,6 +518,20 @@ export function showProfilePage(profile, socket) {
     ? ((stats.totalSets / stats.totalHands) * 100).toFixed(1) + '%'
     : '0%';
   statsGrid.appendChild(createStatItem('Set Rate', setRate));
+
+  // Row 4: Drag, Faults/Game, HSI
+  const drag = gamesPlayed > 0
+    ? ((stats.totalSetPoints || 0) / gamesPlayed).toFixed(1)
+    : '0';
+  statsGrid.appendChild(createStatItem('Drag', drag));
+  const faultsPerGame = gamesPlayed > 0
+    ? ((stats.totalFaults || 0) / gamesPlayed).toFixed(2)
+    : '0';
+  statsGrid.appendChild(createStatItem('Faults/Game', faultsPerGame));
+  const avgHSI = (stats.totalHands || 0) > 0
+    ? ((stats.totalHSI || 0) / stats.totalHands).toFixed(1)
+    : '0';
+  statsGrid.appendChild(createStatItem('HSI', avgHSI));
 
   modal.appendChild(statsGrid);
 

--- a/server/game/GameState.js
+++ b/server/game/GameState.js
@@ -50,12 +50,12 @@ class GameState {
         this.handStats = { totalHands: 0, team1Sets: 0, team2Sets: 0 };
 
         // Per-player stats for final score screen
-        // position (1-4) → { totalBids, totalTricks, setsCaused }
+        // position (1-4) → { totalBids, totalTricks, setsCaused, totalHSI }
         this.playerStats = {
-            1: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
-            2: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
-            3: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
-            4: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+            1: { totalBids: 0, totalTricks: 0, setsCaused: 0, totalHSI: 0 },
+            2: { totalBids: 0, totalTricks: 0, setsCaused: 0, totalHSI: 0 },
+            3: { totalBids: 0, totalTricks: 0, setsCaused: 0, totalHSI: 0 },
+            4: { totalBids: 0, totalTricks: 0, setsCaused: 0, totalHSI: 0 },
         };
 
         // Per-hand trick tracking (reset each hand) for determining set responsibility
@@ -284,11 +284,22 @@ class GameState {
         this.playerBids[position - 1] = bid;
 
         // Track total bids for player stats
-        // Bore bids (B, 2B, 3B, 4B) count as 0 tricks bid
+        // Bore bids (B, 2B, 3B, 4B) count as all tricks in the hand
         const bidStr = String(bid);
-        const bidValue = bidStr.includes('B') ? 0 : parseInt(bidStr, 10) || 0;
+        const bidValue = bidStr.includes('B') ? this.currentHand : parseInt(bidStr, 10) || 0;
         if (this.playerStats[position]) {
             this.playerStats[position].totalBids += bidValue;
+        }
+    }
+
+    /**
+     * Add HSI value to a player's stats
+     * @param {number} position - Player position (1-4)
+     * @param {number} hsi - HSI value to add
+     */
+    addHSI(position, hsi) {
+        if (this.playerStats[position]) {
+            this.playerStats[position].totalHSI += hsi;
         }
     }
 
@@ -334,10 +345,10 @@ class GameState {
         this.score = { team1: 0, team2: 0 };
         this.handStats = { totalHands: 0, team1Sets: 0, team2Sets: 0 };
         this.playerStats = {
-            1: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
-            2: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
-            3: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
-            4: { totalBids: 0, totalTricks: 0, setsCaused: 0 },
+            1: { totalBids: 0, totalTricks: 0, setsCaused: 0, totalHSI: 0 },
+            2: { totalBids: 0, totalTricks: 0, setsCaused: 0, totalHSI: 0 },
+            3: { totalBids: 0, totalTricks: 0, setsCaused: 0, totalHSI: 0 },
+            4: { totalBids: 0, totalTricks: 0, setsCaused: 0, totalHSI: 0 },
         };
         this.resetForNewHand(1, 12);
 

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -105,6 +105,9 @@ function setupSocketHandlers(io) {
         socket.on('uploadProfilePic', (data) =>
             asyncHandler('uploadProfilePic', profileHandlers.uploadProfilePic)(socket, io, data)
         );
+        socket.on('getLeaderboard', () =>
+            safeHandler(profileHandlers.getLeaderboard)(socket, io, {})
+        );
 
         // Disconnect - cleanup rate limiter and handle game state
         socket.on('disconnect', () => {


### PR DESCRIPTION
## Summary
- Add leaderboard page accessible from main room showing all players' stats in a sortable table
- Add three new statistics: Drag, Faults/Game, and HSI (Hand Strength Index)
- Fix bore bids to count as hand size for Bids/Game stat (was counting as 0)
- Fix avatar cleanup on game end
- Update profile page with new statistics

## New Features

### Leaderboard
- Accessible via "Leaderboard" button on main room (left of Profile button)
- Sortable columns with visual indicators (green highlight, arrow)
- Columns: Rank, Player, Win %, Pts/Game, Bids/Game, Tricks/Bid, Set %, Drag, HSI
- Different default sort directions per stat (higher-is-better vs lower-is-better)

### New Statistics
- **Drag**: Average points lost to sets per game
- **Faults/Game**: Average times player caused a set (bid more than taken when team was set)
- **HSI (Hand Strength Index)**: Average hand strength per hand
  - Non-trump: 2=0, 3=1, ... A=12
  - Trump: 2=14, 3=15, ... A=26
  - Jokers: LO=27, HI=28
  - Normalized to 13 cards
  - 1.25x void multiplier per missing non-trump suit (hands 9+ only)

## Test plan
- [ ] Log in and verify "Leaderboard" button appears in main room
- [ ] Click Leaderboard and verify modal displays with player stats
- [ ] Test sorting by clicking column headers
- [ ] Verify profile page shows new stats row (Drag, Faults/Game, HSI)
- [ ] Play a game and verify new stats are tracked correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)