### PR TITLE
Improve UI animations and trick display

### DIFF
--- a/client/src/phaser/config.js
+++ b/client/src/phaser/config.js
@@ -66,7 +66,7 @@ export const CARD_CONFIG = {
  * Animation durations in milliseconds.
  */
 export const ANIMATION_CONFIG = {
-  CARD_DEAL: 200,
+  CARD_DEAL: 500,
   CARD_PLAY: 300,
   CARD_COLLECT: 500,
   CARD_HOVER: 100,

--- a/client/src/phaser/managers/CardManager.js
+++ b/client/src/phaser/managers/CardManager.js
@@ -461,6 +461,25 @@ export class CardManager {
   }
 
   /**
+   * Extract a card sprite from hand without destroying it.
+   * Used for animating the card to the play area.
+   * @param {Object} card - Card data to find
+   * @returns {Phaser.GameObjects.Sprite|null} The sprite, or null if not found
+   */
+  extractCard(card) {
+    const index = this._handSprites.findIndex((s) => {
+      const c = s.getData('card');
+      return c && c.suit === card.suit && c.rank === card.rank;
+    });
+
+    if (index !== -1) {
+      const sprite = this._handSprites.splice(index, 1)[0];
+      return sprite;
+    }
+    return null;
+  }
+
+  /**
    * Add turn glow to the player's hand border.
    * Uses CSS class on the handBorderDom element for resize-safe glow.
    */


### PR DESCRIPTION
## Summary
- Add flip animation for opponent cards when played (move + flip run in parallel)
- Add smooth animation for player cards from hand to play area
- Make trick box dynamically sized based on team bid total with red/green border for bid progress
- Remove colored outlines, X marks, and position labels (UTG/CO/MP/BTN)
- Add fade/scale transitions for bid container and trick box
- Fix overtrump detection for 4th card in trick
- Move rainbow animation to show after bidding completes
- Remove unnecessary delays and adjust animation timings

## Test plan
- [ ] Play a game and verify opponent card flip animations work correctly
- [ ] Verify player card animations move smoothly from hand to play area
- [ ] Verify trick box starts at team bid size and grows as needed
- [ ] Verify trick box border is red when under bid, green when at/over bid
- [ ] Verify overtrump animation triggers on 4th card when applicable
- [ ] Verify rainbow animation shows after bidding, not before
- [ ] Verify no position labels appear under avatars

🤖 Generated with [Claude Code](https://claude.com/claude-code)