### PR TITLE
Bot lobby UI improvements

### DIFF
--- a/client/src/ui/screens/GameLobby.js
+++ b/client/src/ui/screens/GameLobby.js
@@ -60,15 +60,6 @@ export function updateLobbyPlayersList(container, players, currentUsername) {
     nameContainer.style.alignItems = 'center';
     nameContainer.style.gap = '6px';
 
-    // Add bot indicator if player is a bot
-    if (player.isBot) {
-      const botIcon = document.createElement('span');
-      botIcon.innerText = '\u{1F916}'; // Robot emoji
-      botIcon.style.fontSize = '14px';
-      botIcon.title = 'Bot Player';
-      nameContainer.appendChild(botIcon);
-    }
-
     const nameSpan = document.createElement('span');
     nameSpan.innerText = player.username;
     nameSpan.style.fontSize = '16px';
@@ -77,6 +68,11 @@ export function updateLobbyPlayersList(container, players, currentUsername) {
     }
     nameContainer.appendChild(nameSpan);
     playerRow.appendChild(nameContainer);
+
+    const rightSide = document.createElement('span');
+    rightSide.style.display = 'flex';
+    rightSide.style.alignItems = 'center';
+    rightSide.style.gap = '8px';
 
     const statusSpan = document.createElement('span');
     if (player.ready) {
@@ -87,7 +83,26 @@ export function updateLobbyPlayersList(container, players, currentUsername) {
       statusSpan.style.color = '#9ca3af';
     }
     statusSpan.style.fontSize = '14px';
-    playerRow.appendChild(statusSpan);
+    rightSide.appendChild(statusSpan);
+
+    // Add remove button for bot players (hide once ready)
+    if (player.isBot && !player.ready) {
+      const removeBtn = document.createElement('button');
+      removeBtn.innerText = '✕';
+      removeBtn.title = 'Remove bot';
+      removeBtn.style.background = 'none';
+      removeBtn.style.border = 'none';
+      removeBtn.style.color = '#ef4444';
+      removeBtn.style.cursor = 'pointer';
+      removeBtn.style.fontSize = '16px';
+      removeBtn.style.fontWeight = 'bold';
+      removeBtn.style.padding = '0 4px';
+      removeBtn.style.lineHeight = '1';
+      removeBtn.dataset.botSocketId = player.socketId;
+      rightSide.appendChild(removeBtn);
+    }
+
+    playerRow.appendChild(rightSide);
 
     container.appendChild(playerRow);
   });
@@ -207,6 +222,13 @@ export function showGameLobby(lobbyData, socket, username) {
   playersDiv.style.background = 'rgba(0, 0, 0, 0.3)';
   playersDiv.style.borderRadius = '8px';
   updateLobbyPlayersList(playersDiv, lobbyData.players, username);
+  // Delegated click handler for bot remove buttons
+  playersDiv.addEventListener('click', (e) => {
+    const removeBtn = e.target.closest('[data-bot-socket-id]');
+    if (removeBtn) {
+      socket.emit('removeBot', { botSocketId: removeBtn.dataset.botSocketId });
+    }
+  });
   container.appendChild(playersDiv);
 
   // Chat area

--- a/server/game/GameManager.js
+++ b/server/game/GameManager.js
@@ -539,7 +539,7 @@ class GameManager {
      * @param {string} botName - Bot username (default: "Mary")
      * @returns {Object} - { success, botPlayer, lobby, error? }
      */
-    addBotToLobby(lobbyId, botName = 'Mary') {
+    addBotToLobby(lobbyId, botName = '🤖 Mary') {
         const lobby = this.lobbies.get(lobbyId);
         if (!lobby) {
             return { success: false, error: 'Lobby not found' };

--- a/server/game/bot/BotController.js
+++ b/server/game/bot/BotController.js
@@ -20,7 +20,7 @@ class BotController {
      * @param {string} username - Bot name (default: "Mary")
      * @returns {BotPlayer}
      */
-    createBot(username = 'Mary') {
+    createBot(username = '🤖 Mary') {
         return new BotPlayer(username);
     }
 

--- a/server/game/bot/BotPlayer.js
+++ b/server/game/bot/BotPlayer.js
@@ -14,7 +14,7 @@ class BotPlayer {
      * Create a new bot player
      * @param {string} username - Bot's display name (e.g., "Mary")
      */
-    constructor(username = 'Mary') {
+    constructor(username = '🤖 Mary') {
         this.socketId = `bot:${username.toLowerCase()}:${uuidv4()}`;
         this.username = username;
         this.gameId = null;


### PR DESCRIPTION
## Summary

- **Robot emoji in bot names** — Bots now display as "🤖 Mary" instead of "Mary", making them visually distinct from human players with the same name
- **Remove bot button** — Added a red "✕" button next to each bot in the lobby player list, wired to the existing `removeBot` server endpoint
- **Hide remove button when ready** — Once bots are marked ready, the remove button disappears to prevent accidental removal

## Test plan

- [x] Bot displays as "🤖 Mary" in lobby, game, and chat
- [x] Multiple bots numbered correctly (🤖 Mary, 🤖 Mary 2, etc.)
- [x] Clicking ✕ removes the bot from the lobby
- [x] ✕ button hidden after bots are marked ready
- [x] No duplicate robot emoji in lobby list

🤖 Generated with [Claude Code](https://claude.com/claude-code)