### PR TITLE
Add bot personalities: Sharon, Danny, Mike, and Zach

### DIFF
--- a/server/game/bot/BotPlayer.js
+++ b/server/game/bot/BotPlayer.js
@@ -12,15 +12,19 @@ const {
 class BotPlayer {
     /**
      * Create a new bot player
-     * @param {string} username - Bot's display name (e.g., "Mary")
+     * @param {string} username - Bot's display name (e.g., "🤖 Mary")
+     * @param {string} personality - Personality key (e.g., 'sharon')
      */
-    constructor(username = '🤖 Mary') {
+    constructor(username = '🤖 Mary', personality = 'mary') {
         this.socketId = `bot:${username.toLowerCase()}:${uuidv4()}`;
         this.username = username;
+        this.personality = personality;
         this.gameId = null;
         this.position = null;
         this.pic = null;
         this.cardMemory = null;
+        // Zach's partner tracking: array of { bid, tricks } per completed hand
+        this.partnerHistory = [];
     }
 
     /**
@@ -134,7 +138,16 @@ class BotPlayer {
      * @returns {string} - Bid value
      */
     decideBid(hand, trump, existingBids, handSize, gameContext) {
-        return calculateOptimalBid(hand, trump, this.position, existingBids, handSize, this.getMemorySnapshot(), gameContext);
+        return calculateOptimalBid(hand, trump, this.position, existingBids, handSize, this.getMemorySnapshot(), gameContext, this.personality, this.partnerHistory);
+    }
+
+    /**
+     * Record partner's bid and tricks for a completed hand (used by Zach's adaptive strategy)
+     * @param {number} bid - Partner's bid value for the hand
+     * @param {number} tricks - Partner's tricks won for the hand
+     */
+    recordPartnerHand(bid, tricks) {
+        this.partnerHistory.push({ bid, tricks });
     }
 
     /**

--- a/server/game/bot/index.js
+++ b/server/game/bot/index.js
@@ -5,9 +5,11 @@
 const BotPlayer = require('./BotPlayer');
 const botController = require('./BotController');
 const BotStrategy = require('./BotStrategy');
+const personalities = require('./personalities');
 
 module.exports = {
     BotPlayer,
     botController,
-    BotStrategy
+    BotStrategy,
+    personalities
 };

--- a/server/game/bot/personalities.js
+++ b/server/game/bot/personalities.js
@@ -1,0 +1,29 @@
+/**
+ * Bot personality definitions.
+ * Each personality modifies Mary's base strategy with behavioral variations.
+ */
+
+const PERSONALITIES = {
+    mary:   { displayName: 'Mary',   bidStyle: 'neutral' },
+    sharon: { displayName: 'Sharon', bidStyle: 'conservative' },
+    danny:  { displayName: 'Danny',  bidStyle: 'calculated-aggressive' },
+    mike:   { displayName: 'Mike',   bidStyle: 'overconfident' },
+    zach:   { displayName: 'Zach',   bidStyle: 'adaptive' }
+};
+
+const PERSONALITY_LIST = Object.keys(PERSONALITIES);
+
+/**
+ * Get display name for a personality key
+ * @param {string} personality - Personality key (e.g., 'sharon')
+ * @returns {string} Display name (e.g., 'Sharon')
+ */
+function getDisplayName(personality) {
+    return PERSONALITIES[personality]?.displayName || 'Mary';
+}
+
+module.exports = {
+    PERSONALITIES,
+    PERSONALITY_LIST,
+    getDisplayName
+};

--- a/server/socket/lobbyHandlers.js
+++ b/server/socket/lobbyHandlers.js
@@ -7,7 +7,8 @@ const gameManager = require('../game/GameManager');
 const Deck = require('../game/Deck');
 const { socketLogger } = require('../utils/logger');
 const { delay } = require('../utils/timing');
-const { botController } = require('../game/bot');
+const { botController, personalities } = require('../game/bot');
+const { getDisplayName } = personalities;
 
 /**
  * Handle player marking themselves as ready
@@ -59,10 +60,11 @@ async function playerReady(socket, io) {
         if (startResult.success) {
             const game = startResult.game;
 
-            // Register bots with bot controller
+            // Register bots with bot controller (reveal real personality names)
             for (const player of lobby.players) {
                 if (player.isBot) {
-                    const bot = botController.createBot(player.username);
+                    const realName = `🤖 ${getDisplayName(player.personality)}`;
+                    const bot = botController.createBot(realName, player.personality);
                     bot.socketId = player.socketId; // Use existing socket ID
                     botController.registerBot(game.gameId, bot);
                 }


### PR DESCRIPTION
## Summary

- Adds 4 new bot personalities built on Mary's base strategy with unique bidding behavior and chat reactions
- **Sharon**: Underbids strong hands by 1-2; says "puppy's feet" when clubs is trump and "diamonds are a girl's best friend" when diamonds is trump (5s delay so it's not missed)
- **Danny**: Calculated risk-taker — rounds up bids when hand strength is 0.25+ above the floor
- **Mike**: Overconfident — ~25% random chance of overbidding by 1; says "I thought I bid X" when his team gets set
- **Zach**: Adaptive — tracks partner's bid accuracy across hands, compensates with conservative lean; says "well at least I got my X" when team is set but he made his bid
- Bot names hidden in lobby (shown as "🤖 Bot") and revealed at game start to prevent selection gaming
- Each lobby gets unique personalities (no duplicates)

## Test plan

- [x] All 177 server tests pass (16 new `applyBidModifier` tests added)
- [ ] Manual test: add 3 bots, verify lobby shows generic names, real names appear after draw phase
- [ ] Manual test: play hands with clubs/diamonds trump, verify Sharon's chat appears ~5s after cards shown
- [ ] Manual test: get Mike's team set, verify "I thought I bid X" chat
- [ ] Manual test: get Zach's team set when Zach made his bid, verify "well at least I got my X" chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)