### PR TITLE
Update README for bot personalities and increase bid delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ bab-online/
 │   │   ├── rules.js                # Pure game logic functions
 │   │   └── bot/                    # Bot player system
 │   │       ├── BotPlayer.js        # Bot player class with card memory
-│   │       ├── BotController.js    # Bot lifecycle management
+│   │       ├── BotController.js    # Bot lifecycle and personality hooks
 │   │       ├── BotStrategy.js      # AI strategy functions
+│   │       ├── personalities.js    # Bot personality definitions
 │   │       └── __tests__/          # Bot strategy tests
 │   ├── socket/
 │   │   ├── index.js                # Socket event routing
@@ -161,7 +162,9 @@ The server runs on `http://localhost:3000` by default.
 1. **Sign up/Sign in** - Create an account (auto-logs in) or log in
 2. **Main Room** - Chat globally, browse game lobbies, or create a new game
 3. **Game Lobby** - Wait for 4 players, chat, and click "Ready" when prepared
-   - Click "+ Add Bot" to add AI players (up to 3 bots named "🤖 Mary")
+   - Click "+ Add Bot" to add AI players (up to 3 bots with unique personalities)
+   - Bot names are hidden in lobby and revealed at game start
+   - Personalities: Mary (balanced), Sharon (conservative), Danny (calculated risk-taker), Mike (overconfident), Zach (adaptive)
    - Click "✕" next to a bot to remove it before readying up
    - Bots auto-ready when lobby is full
 4. **Draw Phase** - Draw cards from deck to determine seating positions; teams announced
@@ -191,7 +194,7 @@ The server uses a modular architecture with clear separation of concerns:
 - **GameState** - Encapsulated state for each game instance
 - **Deck** - Card deck with Fisher-Yates shuffle
 - **rules.js** - Pure functions for game logic (testable)
-- **BotController / BotStrategy** - AI bot system with hand-size-aware bidding and card memory
+- **BotController / BotStrategy** - AI bot system with 5 personalities, hand-size-aware bidding, card memory, and in-game chat
 - **Socket handlers** - Organized by domain (auth, queue, game, chat, profile)
 
 ### Client Architecture

--- a/server/game/bot/BotPlayer.js
+++ b/server/game/bot/BotPlayer.js
@@ -184,7 +184,7 @@ class BotPlayer {
             case 'draw':
                 return 500 + Math.random() * 500; // 500-1000ms
             case 'bid':
-                return 300 + Math.random() * 500; // 300-800ms
+                return 1000 + Math.random() * 1000; // 1000-2000ms
             case 'play':
                 return 800 + Math.random() * 700; // 800-1500ms
             default:


### PR DESCRIPTION
## Summary

- Update README: add `personalities.js` to project structure, document 5 bot personalities and hidden lobby names in How to Play section
- Increase bot bidding delay from 300-800ms to 1-2s for more natural pacing

Follow-up to #101 (merged before these changes were pushed).

## Test plan

- [x] Server tests pass
- [ ] Verify bot bid timing feels natural (~1-2s delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)