### PR TITLE
Add resignation system, lazy/leave modes, and spectator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,24 @@ The server runs on `http://localhost:3000` by default.
 6. **Play** - Take turns playing cards, following suit when possible
 7. **Score** - Points awarded based on bids vs tricks taken (shown in game log)
 
+### Mid-Game Commands
+
+Type these in the game log chat input (autocomplete appears when you type `/`):
+
+| Command | Effect |
+|---------|--------|
+| `/lazy` | A bot takes over for you temporarily. You stay in the game as a spectator. |
+| `/active` | Take back control from the bot. |
+| `/leave` | Bot takes over and you exit to the main lobby. You can rejoin later. |
+
+### Spectating
+
+Browse in-progress games in the main room lobby panel and click **Spectate** to watch. Spectators can see tricks, bids, scores, and chat — but not player hands. Type `/leave` to exit back to the lobby.
+
+### Disconnection & Resignation
+
+If a player disconnects, a 60-second grace period starts. If they don't return, any remaining player can click to replace them with a bot. The game only aborts if all human players disconnect.
+
 ### Card Rankings
 - High Joker (highest)
 - Low Joker
@@ -190,12 +208,12 @@ Client (Phaser/ES6) ←→ Socket.IO ←→ Server (Node/Express) ←→ MongoDB
 
 The server uses a modular architecture with clear separation of concerns:
 
-- **GameManager** - Singleton managing queue and active games
-- **GameState** - Encapsulated state for each game instance
+- **GameManager** - Singleton managing queue, active games, and in-progress game listing
+- **GameState** - Encapsulated state for each game instance (includes resignation, lazy mode, and spectator tracking)
 - **Deck** - Card deck with Fisher-Yates shuffle
 - **rules.js** - Pure functions for game logic (testable)
 - **BotController / BotStrategy** - AI bot system with 5 personalities, hand-size-aware bidding, card memory, and in-game chat
-- **Socket handlers** - Organized by domain (auth, queue, game, chat, profile)
+- **Socket handlers** - Organized by domain (auth, queue, game, chat, profile, reconnect)
 
 ### Client Architecture
 
@@ -224,8 +242,10 @@ The client uses ES6 modules with Vite bundling and proper lifecycle management:
 | `draw` | Draw card during draw phase |
 | `playerBid` | Submit bid |
 | `playCard` | Play a card |
-| `chatMessage` | Send in-game chat message |
+| `chatMessage` | Send in-game chat (also handles `/lazy`, `/active`, `/leave`) |
 | `rejoinGame` | Reconnect to game after disconnect |
+| `forceResign` | Replace disconnected player with a bot |
+| `joinAsSpectator` | Join an in-progress game as spectator |
 | `getProfile` | Fetch user profile and stats |
 | `updateProfilePic` | Change profile picture |
 | `getLeaderboard` | Fetch leaderboard data |
@@ -248,6 +268,11 @@ The client uses ES6 modules with Vite bundling and proper lifecycle management:
 | `gameEnd` | Game finished with final scores |
 | `rejoinSuccess` | Successfully reconnected to game |
 | `activeGameFound` | Active game found on sign-in |
+| `resignationAvailable` | Disconnected player's grace period expired |
+| `playerResigned` | Player replaced by bot |
+| `playerLazyMode` | Player entered lazy mode (bot playing) |
+| `playerActiveMode` | Player took back control from bot |
+| `spectatorJoined` | Spectator joined the game |
 | `profileResponse` | User profile data |
 | `leaderboardResponse` | Leaderboard data |
 

--- a/claude.md
+++ b/claude.md
@@ -18,275 +18,133 @@ A 4-player online multiplayer trick-taking card game (Back Alley Bridge). Player
 ```
 bab-online/
 ├── client/
-│   ├── src/                        # Modular ES6 client code (Vite)
-│   │   ├── main.js                 # Entry point, bridge to legacy code
-│   │   ├── constants/
-│   │   │   ├── events.js           # Socket event name constants
-│   │   │   └── ranks.js            # RANK_VALUES, suit orders, hand progression
-│   │   ├── utils/
-│   │   │   ├── positions.js        # team(), rotate(), getPlayerName()
-│   │   │   ├── cards.js            # getCardImageKey(), sortHand(), getSuitOrder()
-│   │   │   └── colors.js           # hashToHue(), generateDistinctColor()
-│   │   ├── rules/
-│   │   │   └── legality.js         # isLegalMove(), sameSuit(), isTrumpTight()
-│   │   ├── state/
-│   │   │   └── GameState.js        # Client state singleton with events
-│   │   ├── socket/
-│   │   │   └── SocketManager.js    # Connection with listener tracking
-│   │   ├── ui/
-│   │   │   ├── UIManager.js        # Main UI lifecycle manager
-│   │   │   ├── components/         # Modal, Toast, BidUI, GameLog, ChatBubble, ScoreModal, PlayerQueue
-│   │   │   └── screens/            # SignIn, Register, MainRoom, GameLobby
+│   ├── src/
+│   │   ├── main.js                 # Entry point, wires callbacks to GameScene
+│   │   ├── constants/              # events.js, ranks.js
+│   │   ├── utils/                  # positions.js, cards.js, colors.js
+│   │   ├── rules/                  # legality.js - card play validation
+│   │   ├── state/                  # GameState.js - client state singleton
+│   │   ├── socket/                 # SocketManager.js - connection management
+│   │   ├── handlers/               # Socket event handlers (auth, game, chat, lobby)
 │   │   ├── phaser/
-│   │   │   ├── config.js           # Phaser game configuration
 │   │   │   ├── PhaserGame.js       # Game instance wrapper
-│   │   │   ├── scenes/
-│   │   │   │   └── GameScene.js    # Main game scene with handler methods
-│   │   │   └── managers/
-│   │   │       ├── CardManager.js  # Card sprite management
-│   │   │       ├── TrickManager.js # Trick display and animations
-│   │   │       ├── OpponentManager.js # Opponent avatars and cards
-│   │   │       ├── EffectsManager.js  # Visual effects (rainbow, etc.)
-│   │   │       ├── DrawManager.js  # Draw phase UI and animations
-│   │   │       ├── BidManager.js   # Bidding UI and bubbles
-│   │   │       └── LayoutManager.js # Positioning and resize logic
-│   │   └── handlers/
-│   │       ├── index.js            # Socket event handler registration
-│   │       ├── authHandlers.js     # Authentication event handlers
-│   │       ├── gameHandlers.js     # Game event handlers
-│   │       ├── chatHandlers.js     # Chat event handlers
-│   │       └── lobbyHandlers.js    # Lobby event handlers
-│   ├── styles/
-│   │   └── components.css          # All UI component styles
-│   ├── vite.config.js              # Vite build configuration
-│   ├── index.html                  # Entry point
+│   │   │   ├── scenes/GameScene.js # Main game scene
+│   │   │   └── managers/           # Card, Trick, Opponent, Effects, Draw, Bid, Layout
+│   │   └── ui/
+│   │       ├── UIManager.js        # DOM lifecycle management
+│   │       ├── components/         # Modal, Toast, BidUI, GameLog, ChatBubble, ScoreModal
+│   │       └── screens/            # SignIn, Register, MainRoom, GameLobby
+│   ├── styles/components.css       # All UI styles
 │   └── assets/                     # Card images, backgrounds
 ├── server/
 │   ├── index.js                    # Entry point
-│   ├── config/
-│   │   └── index.js                # Server configuration
 │   ├── game/
 │   │   ├── Deck.js                 # Card deck with shuffle
 │   │   ├── GameState.js            # Per-game state + room management
-│   │   ├── GameManager.js          # Queue, lobby, and game coordination
+│   │   ├── GameManager.js          # Queue, lobby, game coordination, in-progress listing
 │   │   ├── rules.js                # Pure game logic functions
 │   │   └── bot/                    # Bot player system
-│   │       ├── index.js            # Module exports
-│   │       ├── BotPlayer.js        # Bot player class
-│   │       ├── BotController.js    # Singleton managing all bots
-│   │       └── BotStrategy.js      # Pure strategy functions
+│   │       ├── BotPlayer.js        # Bot player class with card memory
+│   │       ├── BotController.js    # Singleton managing bot lifecycle
+│   │       ├── BotStrategy.js      # Pure strategy functions
+│   │       └── personalities.js    # Bot personality definitions
 │   ├── socket/
 │   │   ├── index.js                # Socket event routing
-│   │   ├── authHandlers.js         # signIn, signUp (with auto-login)
-│   │   ├── mainRoomHandlers.js     # Main room chat and lobby browsing
-│   │   ├── queueHandlers.js        # joinQueue (creates/joins lobby)
+│   │   ├── authHandlers.js         # signIn, signUp
+│   │   ├── mainRoomHandlers.js     # Main room, lobby browser, spectator join
+│   │   ├── queueHandlers.js        # joinQueue, disconnect grace period
 │   │   ├── lobbyHandlers.js        # playerReady, lobbyChat, leaveLobby
-│   │   ├── gameHandlers.js         # playCard, playerBid, draw
+│   │   ├── gameHandlers.js         # playCard, playerBid, draw, forceResign
 │   │   ├── reconnectHandlers.js    # rejoinGame for mid-game reconnection
-│   │   ├── chatHandlers.js         # chatMessage (in-game)
+│   │   ├── chatHandlers.js         # chatMessage, slash commands (/lazy, /active, /leave)
+│   │   ├── profileHandlers.js      # Profile and leaderboard events
 │   │   ├── validators.js           # Joi validation schemas
 │   │   ├── errorHandler.js         # Handler wrappers with rate limiting
 │   │   └── rateLimiter.js          # Per-socket rate limiting
-│   ├── routes/
-│   │   └── index.js                # Express routes, /health endpoint
-│   ├── middleware/
-│   │   └── requestLogger.js        # Request logging middleware
-│   ├── utils/
-│   │   ├── timing.js               # Async delay utilities
-│   │   ├── logger.js               # Winston logger setup
-│   │   ├── errors.js               # Custom error classes
-│   │   └── shutdown.js             # Graceful shutdown handlers
+│   ├── routes/index.js             # Express routes, /health
+│   ├── utils/                      # timing.js, logger.js, errors.js, shutdown.js
 │   └── database.js                 # MongoDB connection
 ├── docs/
 │   ├── RULES.md                    # Complete game rules
 │   └── todos/                      # Improvement roadmap
-├── scripts/
-│   └── build-atlas.js              # Sprite atlas builder
-├── .github/
-│   └── workflows/
-│       └── ci.yml                  # GitHub Actions CI pipeline
-├── package.json
-├── docker-compose.yml              # Docker Compose configuration
-├── Dockerfile.local                # Local Docker configuration
-├── railway.toml                    # Railway deployment config
-├── .nvmrc                          # Node version (18+)
-└── .env
+└── scripts/build-atlas.js          # Sprite atlas builder
 ```
-
-## Key Files
-
-### Server
-- `server/index.js` - Entry point, Express/Socket.IO setup
-- `server/game/rules.js` - Pure functions: `determineWinner()`, `isLegalMove()`, `calculateScore()`, `isRainbow()`
-- `server/game/GameState.js` - Encapsulated game state class
-- `server/game/GameManager.js` - Singleton managing queue, lobbies, and active games
-- `server/game/bot/BotController.js` - Singleton managing bot lifecycle and actions
-- `server/game/bot/BotPlayer.js` - Bot player class with decision methods
-- `server/game/bot/BotStrategy.js` - Pure strategy functions for bidding and card play
-- `server/socket/gameHandlers.js` - Game event handlers
-- `server/socket/lobbyHandlers.js` - Lobby handlers including bot management
-- `server/socket/mainRoomHandlers.js` - Main room and lobby browser handlers
-
-### Client
-- `client/src/main.js` - Entry point, exposes all modules via window.ModernUtils bridge, wires callbacks to GameScene
-- `client/src/state/GameState.js` - Client state singleton with event emitter
-- `client/src/socket/SocketManager.js` - Socket with listener tracking for cleanup
-- `client/src/rules/legality.js` - Card play legality checking (isLegalMove)
-- `client/src/phaser/PhaserGame.js` - Game instance wrapper
-- `client/src/phaser/scenes/GameScene.js` - Main game scene, instantiates managers, handles events
-- `client/src/phaser/managers/CardManager.js` - Card sprite management
-- `client/src/phaser/managers/TrickManager.js` - Trick display, play positions, trick history
-- `client/src/phaser/managers/OpponentManager.js` - Opponent avatars and card backs
-- `client/src/phaser/managers/EffectsManager.js` - Visual effects (rainbow animation)
-- `client/src/phaser/managers/DrawManager.js` - Draw phase deck and card selection
-- `client/src/phaser/managers/BidManager.js` - Bid UI, bore buttons, bid bubbles
-- `client/src/phaser/managers/LayoutManager.js` - Centralized positioning and resize calculations
-- `client/src/ui/UIManager.js` - UI lifecycle management
-- `client/src/ui/components/` - Modal, Toast, BidUI, GameLog, ChatBubble, ScoreModal, PlayerQueue
-- `client/src/ui/screens/` - SignIn, Register, MainRoom, GameLobby
-- `client/src/handlers/` - Socket event handlers (index, auth, game, chat, lobby)
 
 ## Architecture Patterns
 
 - **Communication**: Socket.io bidirectional WebSocket
 - **State**: Server-authoritative, `GameState` class per game instance
-- **Client State**: `GameState` singleton replaces 50+ globals
-- **Event Callbacks**: Socket events flow through `gameHandlers.js` → main.js callbacks → `GameScene.handleX()` → Phaser managers
-- **State Validation**: Server validates all actions (`validateTurn`, `validateCardPlay`, `validateBid`)
-- **Input Validation**: Joi schemas validate all socket event data (`validators.js`)
-- **Error Handling**: All handlers wrapped with try/catch, validation errors sent to client (`errorHandler.js`)
-- **Rate Limiting**: Per-socket limits prevent spam/abuse (`rateLimiter.js`)
-- **Socket Rooms**: Game events broadcast only to game participants via `game.broadcast()`
+- **Client State**: `GameState` singleton with event emitter (`handChanged`, `bidChanged`)
+- **Event Callbacks**: Socket events → `handlers/*.js` → `main.js` callbacks → `GameScene.handleX()` → Phaser managers
+- **Validation**: Server validates all actions; Joi schemas validate all socket event data
+- **Socket Rooms**: Game events broadcast only to game participants + spectators via `game.broadcast()`
 - **Optimistic Updates**: Client updates UI immediately, rolls back on server rejection
-- **Socket Cleanup**: `SocketManager` tracks listeners, prevents memory leaks
-- **Reconnection**: 30-second grace period for disconnected players to rejoin via `rejoinGame` event
+- **Socket Cleanup**: `SocketManager` tracks listeners via `onGame()`, cleaned up between games
 - **UI**: Phaser for game canvas, `UIManager` for DOM lifecycle
-- **Animations**: Phaser tweens (Power2 easing, 200-500ms durations)
 - **Game Logic**: Pure functions in `rules.js` for testability
-- **Responsive Layout**: Dynamic game container width (full in lobby, restricted during game for game log)
-- **Turn Indicator**: CSS-based glow effect (`.turn-glow` class) for proper resize handling
 
 ## Game Flow
 
-1. Authentication (signIn/signUp) → MongoDB users collection; auto-login after registration
-2. Main Room → Global chat, browse/create game lobbies
-3. Game Lobby → 4 players chat and click "Ready" when prepared; can add bot players via "+ Add Bot" button
-4. All 4 ready → Transition to draw phase (bots auto-ready when lobby is full)
-5. Draw phase → Players draw cards to determine positions; teams announced (1&3 vs 2&4)
-6. Hand progression (12→10→8→6→4→2→1→3→5→7→9→11→13) with bidding then playing phases
-7. Trick evaluation, scoring displayed in game log; rainbow bonuses (4-card hand only)
-8. Game end → Final scores in game log, return to main room
+1. Authentication (signIn/signUp) → MongoDB users collection
+2. Main Room → Global chat, browse game lobbies, spectate in-progress games
+3. Game Lobby → 4 players chat and ready up; can add bot players (5 personalities)
+4. Draw phase → Players draw cards to determine positions; teams announced (1&3 vs 2&4)
+5. Hand progression (12→10→8→6→4→2→1→3→5→7→9→11→13) with bidding then playing
+6. Game end → Final scores, return to main room
 
 ## Key Socket Events
 
-**Client → Server**: `signIn`, `signUp`, `joinMainRoom`, `mainRoomChat`, `createLobby`, `joinLobby`, `playerReady`, `lobbyChat`, `leaveLobby`, `addBot`, `removeBot`, `draw`, `playerBid`, `playCard`, `chatMessage`, `rejoinGame`
+**Client → Server**: `signIn`, `signUp`, `joinMainRoom`, `mainRoomChat`, `createLobby`, `joinLobby`, `playerReady`, `lobbyChat`, `leaveLobby`, `addBot`, `removeBot`, `draw`, `playerBid`, `playCard`, `chatMessage`, `rejoinGame`, `forceResign`, `joinAsSpectator`
 
-**Server → Client**: `mainRoomJoined`, `mainRoomMessage`, `lobbiesUpdated`, `lobbyCreated`, `lobbyJoined`, `playerReadyUpdate`, `lobbyMessage`, `lobbyPlayerLeft`, `allPlayersReady`, `startDraw`, `playerDrew`, `youDrew`, `teamsAnnounced`, `positionUpdate`, `createUI`, `gameStart`, `bidReceived`, `doneBidding`, `cardPlayed`, `updateTurn`, `trickComplete`, `handComplete`, `gameEnd`, `rainbow`, `rejoinSuccess`, `rejoinFailed`, `playerDisconnected`, `playerReconnected`, `activeGameFound`
+**Server → Client**: `mainRoomJoined`, `mainRoomMessage`, `lobbiesUpdated`, `lobbyCreated`, `lobbyJoined`, `playerReadyUpdate`, `lobbyMessage`, `lobbyPlayerLeft`, `allPlayersReady`, `startDraw`, `playerDrew`, `youDrew`, `teamsAnnounced`, `positionUpdate`, `createUI`, `gameStart`, `bidReceived`, `doneBidding`, `cardPlayed`, `updateTurn`, `trickComplete`, `handComplete`, `gameEnd`, `rainbow`, `rejoinSuccess`, `rejoinFailed`, `playerDisconnected`, `playerReconnected`, `activeGameFound`, `resignationAvailable`, `playerResigned`, `playerLazyMode`, `playerActiveMode`, `gameLogEntry`, `leftGame`, `spectatorJoined`
 
-## Development Commands
+## Disconnection, Resignation & Bot Takeover
 
-```bash
-npm run dev           # Development server with hot reload (port 3000)
-npm start             # Production server
-npm test              # Run server tests (Jest)
-npm run test:watch    # Jest watch mode
-npm run test:coverage # Jest with coverage report
-npm run test:client   # Run client tests (Vitest)
-npm run test:client:watch  # Vitest watch mode
-npm run build:client  # Build client modules (Vite)
-npm run build:atlas   # Generate sprite atlas
-npm run dev:client    # Vite dev server (port 5173, proxies to :3000)
-```
+When a player disconnects mid-game:
+1. Server marks player as disconnected, starts **60-second** grace period
+2. Other players see "[username] disconnected - waiting for reconnection..."
+3. If player reconnects within 60 seconds: normal rejoin via `rejoinGame`
+4. If grace period expires: remaining players see a prompt to replace with a bot (`resignationAvailable`)
+5. Any player clicks "Replace with bot" → `forceResign` → bot takes over the hand
+6. Game stats are attributed to the original human player, not the bot
+7. Game only aborts if ALL human players disconnect
 
-Server runs on port 3000. Requires Node.js 18+.
+### Cross-Browser Reconnection
+Server stores `activeGameId` in MongoDB user document. On sign-in, checks for active game and emits `activeGameFound`.
 
-## Common Tasks
+## Slash Commands (In-Game)
 
-### Game Logic Changes
-- **Rules**: `server/game/rules.js` - `determineWinner()`, `isLegalMove()`, `calculateScore()`
-- **State**: `server/game/GameState.js` - game state management
-- **Flow**: `server/socket/gameHandlers.js` - `playCard()`, `playerBid()`
+Players type these in the game log chat input (autocomplete appears when typing `/`):
 
-### UI Changes
-- **Styles**: `client/styles/components.css` - CSS classes for all UI
-- **Components**: `client/src/ui/components/` - Modal, Toast, BidUI, GameLog
-- **Screens**: `client/src/ui/screens/` - SignIn, Register
-- **Cards**: `client/src/phaser/managers/CardManager.js` - card sprites
+| Command | Behavior |
+|---------|----------|
+| `/lazy` | Bot takes over temporarily. Player stays as spectator (can see hand/chat, bot plays). Avatar switches to bot. |
+| `/active` | Take back control from bot. Avatar switches back. Only works for original players, not spectators. |
+| `/leave` | Bot takes over + player exits to main lobby. Can rejoin later and `/active` to resume. |
 
-### Adding Socket Events
-1. Add handler in `server/socket/gameHandlers.js` (or appropriate handler file)
-2. Register in `server/socket/index.js`
-3. Add listener in `client/src/handlers/index.js`
-4. Add cleanup in `cleanupGameListeners()` for game-specific events
+Slash commands are intercepted in `chatHandlers.js` on the server. The `GameLog.js` component provides autocomplete with single-match auto-submit on Enter.
 
-### Adding Card Assets
-1. Place PNG in `client/assets/`
-2. Add to `loadCardAssets()` in `GameScene.js`
-3. Update `getCardTextureKey()` in `CardManager.js` if needed
+### Lazy Mode State
+- `GameState.lazyPlayers`: tracks `position → { botSocketId, botUsername, originalUsername, ... }`
+- `triggerBotIfNeeded()` checks both `isBot()` and `isLazy()` to schedule bot actions
+- Same bot personality persists across lazy/active cycles per position
 
-## Scoring Rules
+## Spectator System
 
-- Made bid: `+(bid × 10 × multiplier) + (tricks - bid) + (rainbows × 10)`
-- Missed bid: `-(bid × 10 × multiplier) + (rainbows × 10)`
-- Rainbow = 4-card hand containing all 4 suits (+10 points bonus)
-- Bore multipliers: B (2x), 2B (4x), 3B (8x), 4B (16x)
+Players can join in-progress games from the main room lobby panel:
+- `MainRoom.js` shows in-progress games (from `gameManager.getInProgressGames()`) with "Spectate" button
+- `joinAsSpectator` event → server sends full game state (no hand data) → client sets up read-only view
+- Spectators see tricks, bids, scores, game log; can chat (marked as spectator)
+- `/leave` exits spectator to main lobby; `/lazy` and `/active` are blocked for spectators
+- All `lobbiesUpdated` emissions include `inProgressGames` for the main room display
 
-## Game State
+## Server Game State (`server/game/GameState.js`)
 
-### Server (`server/game/GameState.js`)
-```javascript
-class GameState {
-    // Core state
-    gameId, roomName, players, positions, hands, currentHand, dealer,
-    bidding, bids, team1Mult, team2Mult, currentTurn, leadPosition,
-    currentTrick, trump, trumpBroken, team1Tricks, team2Tricks,
-    team1Score, team2Score, team1Rainbows, team2Rainbows
-
-    // Validation methods
-    validateTurn(socketId)           // Returns { valid, error? }
-    validateCardPlay(socketId, card) // Validates turn, phase, card ownership, trick state
-    validateBid(socketId, bid)       // Validates turn, phase, bid value
-    validateGameState()              // Full consistency check, returns { valid, errors[] }
-
-    // Room management (Socket.IO rooms for targeted broadcasts)
-    joinToRoom(io, socketId)         // Add player to game room
-    leaveRoom(io, socketId)          // Remove player from room
-    joinAllToRoom(io)                // Add all players to room
-    leaveAllFromRoom(io)             // Remove all (on game end)
-    broadcast(io, event, data)       // Send to all players in game
-    sendToPlayer(io, socketId, event, data) // Send to specific player
-
-    // Debug logging (development mode only)
-    logAction(action, details)       // Log state changes
-    logState()                       // Log current state summary
-    logValidation(action, result)    // Log failed validations
-}
-```
-
-### Client (`client/src/state/GameState.js`)
-```javascript
-class GameState {
-    // Core state
-    playerId, username, position, pic, myCards, currentHand,
-    trump, dealer, phase, currentTurn, isBidding, leadCard,
-    playedCards, trumpBroken, bids, teamTricks, oppTricks,
-    teamScore, oppScore, players
-
-    // Optimistic updates (instant UI feedback before server confirms)
-    optimisticPlayCard(card)   // Remove card locally, returns boolean
-    confirmCardPlay()          // Clear pending state on success
-    rollbackCardPlay()         // Restore card on server rejection
-    optimisticBid(bid)         // Record bid locally
-    confirmBid() / rollbackBid()
-    hasPendingAction()         // Check if waiting for server
-
-    // Event system (for reactive UI updates)
-    on(event, callback)        // Subscribe, returns unsubscribe function
-    off(event, callback)       // Unsubscribe
-    _emit(event, data)         // Notify listeners
-    // Events: 'handChanged', 'bidChanged'
-}
-```
+Key fields beyond core game state:
+- `resignedPlayers`: `position → { username, pic, resignedAt }` — original human info for stats
+- `lazyPlayers`: `position → { botSocketId, botUsername, originalUsername, originalSocketId, ... }`
+- `spectators`: Map of `socketId → { username, pic }`
+- Key methods: `resignPlayer()`, `enableLazyMode()`, `disableLazyMode()`, `addSpectator()`, `removeSpectator()`, `isLazy()`, `isSpectator()`, `getOriginalPlayer()`
 
 ## Card Data Structure
 
@@ -296,111 +154,54 @@ class GameState {
 
 Deck: 52 standard cards + 2 jokers (HI and LO)
 
-## Key Classes
+## Scoring Rules
 
-### GameManager (server)
-Singleton managing lobbies, queue, and active games. Methods: `joinQueue()` (creates/joins lobby), `createLobby()`, `setPlayerReady()`, `addLobbyMessage()`, `leaveLobby()`, `startGameFromLobby()`, `createGame()`, `getPlayerGame()`, `getPlayerLobby()`, `handleDisconnect()`, `updatePlayerGameMapping()`, `checkGameAbort()`, `addBotToLobby()`, `removeBotFromLobby()`, `setBotsReady()`, `isBot()`
+- Made bid: `+(bid × 10 × multiplier) + (tricks - bid) + (rainbows × 10)`
+- Missed bid: `-(bid × 10 × multiplier) + (rainbows × 10)`
+- Rainbow = 4-card hand containing all 4 suits (+10 points bonus)
+- Bore multipliers: B (2x), 2B (4x), 3B (8x), 4B (16x)
 
-### Reconnection Flow
-When a player disconnects mid-game:
-1. Server marks player as disconnected, starts 30-second grace period timer
-2. Other players see "[username] disconnected - waiting for reconnection..."
-3. If player refreshes/reconnects within 30 seconds:
-   - Client sends `rejoinGame` with stored `gameId` and `username` from sessionStorage
-   - Server finds game, validates player, updates socket mapping
-   - Client receives `rejoinSuccess` with full game state (hand, trump, scores, etc.)
-   - Client waits for Phaser scene to be ready, then rebuilds UI
-4. If grace period expires, game is aborted for all players
+## Bot System
 
-### Cross-Browser Reconnection
-Players can rejoin from a different browser/device:
-1. Server stores `activeGameId` in MongoDB user document when game starts
-2. On sign-in, server checks if user has an active game
-3. If found, emits `activeGameFound` event with gameId
-4. Client prompts user to rejoin or shows auto-rejoin flow
+5 personalities: Mary (balanced), Sharon (conservative), Danny (calculated risk-taker), Mike (overconfident), Zach (adaptive). Defined in `server/game/bot/personalities.js`.
 
-### SocketManager (`client/src/socket/SocketManager.js`)
-Singleton for socket connection with listener tracking. Methods: `connect()`, `on()`, `onGame()`, `off()`, `offAll()`, `emit()`, `cleanupGameListeners()`. Game listeners registered via `onGame()` are automatically cleaned up between games.
-
-### GameScene (`client/src/phaser/scenes/GameScene.js`)
-Main Phaser scene that coordinates all game visuals. Instantiates and manages all Phaser managers (CardManager, TrickManager, OpponentManager, EffectsManager, DrawManager, BidManager, LayoutManager). Has handler methods for each socket event (e.g., `handleStartDraw()`, `handleBidReceived()`, `handleCardPlayed()`). These are called from main.js callbacks via `getGameScene()`.
-
-### CardManager (`client/src/phaser/managers/CardManager.js`)
-Manages card sprites in Phaser. Methods: `setScene()`, `createCard()`, `displayHand()`, `playCard()`, `updatePositions()`, `collectTrick()`, `clear()`. Handles card positioning, animations, and trick collection.
-
-### Phaser Managers
-- **DrawManager** - Deck display, card click handling, draw animations, teams announcement overlay
-- **BidManager** - Bid button grid (0-N + B/2B/3B/4B), bore button state management, bid bubbles
-- **TrickManager** - Play positions, card-to-center animations, trick collection stacks, hover fan-out
-- **OpponentManager** - DOM-based avatars with CSS glow, opponent card back displays
-- **EffectsManager** - Rainbow animation effect
-- **LayoutManager** - Centralized positioning calculations, resize handling, scale factors
-
-### UI Components (`client/src/ui/components/`)
-- **Modal.js** - `createModal()`, `confirm()`, `alert()` - promise-based modal dialogs
-- **Toast.js** - `showToast()`, `showError()`, `showSuccess()` - notification toasts
-- **BidUI.js** - `createBidUI()`, `showBidUI()`, `createBidBubble()` - bidding interface
-- **GameLog.js** - `createGameLog()`, `showGameLog()` - game feed and chat
-- **ChatBubble.js** - Individual chat message display
-- **ScoreModal.js** - End-of-game score display
-- **PlayerQueue.js** - Lobby player queue display
-
-### UI Screens (`client/src/ui/screens/`)
-- **SignIn.js** - Sign-in form screen
-- **Register.js** - Registration form screen
-- **MainRoom.js** - Main room with chat and lobby browser
-- **GameLobby.js** - Pre-game lobby with ready state and "+ Add Bot" button
-
-### Bot System (`server/game/bot/`)
-Bot players that can be added to lobbies when human players aren't available.
-
-**BotController** - Singleton managing all active bots:
-- `createBot(name)` - Create new bot instance
-- `registerBot(gameId, bot)` - Register bot for a game
-- `getBot(gameId, socketId)` - Get bot by socket ID
-- `scheduleBotAction(io, game, actionType)` - Schedule bot turn with delay
-- `scheduleBotDraw(io, game, socketId, order)` - Schedule bot draw
-- `processBotBid(io, game, bot)` - Execute bot bid
-- `processBotPlay(io, game, bot)` - Execute bot card play
-- `cleanupGame(gameId)` - Remove bots when game ends
-
-**BotPlayer** - Individual bot instance:
-- Uses virtual socket ID: `bot:name:uuid` (e.g., `bot:mary:abc123`)
-- `decideDraw(remaining)` - Random deck index
-- `decideBid(hand, trump, bids, handSize)` - Optimal bid calculation
-- `decideCard(hand, played, lead, leadPos, trump, broken)` - Optimal card selection
-- `getActionDelay(actionType)` - Random delay (500-1500ms)
-
-**BotStrategy** - Pure strategy functions:
-- `evaluateHand(hand, trump)` - Count high cards, trump length, voids
-- `calculateOptimalBid(strength, position, partnerBid, handSize)` - Bidding logic
-- `selectOptimalCard(hand, played, lead, leadPos, trump, broken, position)` - Card selection
-- `selectLead(hand, trump, broken)` - Leading card selection
-- `selectFollow(hand, played, lead, leadPos, trump, position)` - Following card selection
-
-**Bot Behavior**:
 - Bots use `isBot: true` flag, identified by `socketId.startsWith('bot:')`
 - Auto-ready when lobby fills to 4 players
-- Strategic bidding: jokers (2pts), aces (1pt), kings (0.5pt), trump length bonus
 - Partner-aware play: positions 1&3 and 2&4 are partners
-- Random delays simulate human thinking time
-- Multiple bots get numbered names (Mary, Mary 2, Mary 3)
+- Card memory tracking for strategic play
+- Random delays simulate human thinking time (500-1500ms)
+- Used for lobby fill, resignation replacement, and lazy mode
 
-### Socket Infrastructure (server)
+## Development Commands
 
-**validators.js** - Joi validation schemas for socket events:
-- `signIn`, `signUp` - Auth validation
-- `lobbyChat` - Lobby chat validation
-- `playCard`, `playerBid`, `draw` - Game action validation
-- `chatMessage` - In-game chat validation
-- Usage: `validate('playCard', data)` returns validated data or throws `ValidationError`
+```bash
+npm run dev           # Development server with hot reload (port 3000)
+npm start             # Production server
+npm test              # Run server tests (Jest)
+npm run test:client   # Run client tests (Vitest)
+npm run build:client  # Build client modules (Vite)
+npm run build:atlas   # Generate sprite atlas
+npm run dev:client    # Vite dev server (port 5173, proxies to :3000)
+```
 
-**errorHandler.js** - Handler wrappers:
-- `asyncHandler(schemaName, handler)` - Wraps async handlers with validation, rate limiting, error handling
-- `syncHandler(schemaName, handler)` - Same for sync handlers
-- `safeHandler(handler)` - Simple wrapper without validation/rate limiting
+Server runs on port 3000. Requires Node.js 18+.
 
-**rateLimiter.js** - Per-socket rate limiting:
-- Configurable limits per event type (e.g., `signIn: 5/min`, `chatMessage: 10/10s`)
-- `check(socketId, event)` - Returns true if allowed
-- `clearSocket(socketId)` - Cleanup on disconnect
+## Common Tasks
+
+### Adding Socket Events
+1. Add handler in appropriate `server/socket/*.js` file
+2. Register in `server/socket/index.js`
+3. Add client listener in `client/src/handlers/*.js`
+4. **Critical**: Wire callback through `client/src/handlers/index.js` — destructure from callbacks object AND pass to the correct `register*Handlers()` call
+5. Add cleanup in `cleanupGameListeners()` for game-specific events
+
+### Game Logic Changes
+- **Rules**: `server/game/rules.js` — pure functions
+- **State**: `server/game/GameState.js` — game state management
+- **Flow**: `server/socket/gameHandlers.js` — `playCard()`, `playerBid()`
+
+### UI Changes
+- **Styles**: `client/styles/components.css`
+- **Components**: `client/src/ui/components/`
+- **Screens**: `client/src/ui/screens/`
+- **Cards**: `client/src/phaser/managers/CardManager.js`

--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -102,6 +102,7 @@ export const SERVER_EVENTS = {
   PLAYER_ACTIVE_MODE: 'playerActiveMode',
   GAME_LOG_ENTRY: 'gameLogEntry',
   LEFT_GAME: 'leftGame',
+  RESTORE_PLAYER_STATE: 'restorePlayerState',
   SPECTATOR_JOINED: 'spectatorJoined',
 
   // Connection

--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -28,6 +28,8 @@ export const CLIENT_EVENTS = {
   PLAY_CARD: 'playCard',
   CHAT_MESSAGE: 'chatMessage',
   REJOIN_GAME: 'rejoinGame',
+  FORCE_RESIGN: 'forceResign',
+  JOIN_AS_SPECTATOR: 'joinAsSpectator',
 
   // Profile
   GET_PROFILE: 'getProfile',
@@ -92,6 +94,15 @@ export const SERVER_EVENTS = {
   PLAYER_ASSIGNED: 'playerAssigned',
   ABORT_GAME: 'abortGame',
   ROOM_FULL: 'roomFull',
+
+  // Resignation & Lazy Mode
+  RESIGNATION_AVAILABLE: 'resignationAvailable',
+  PLAYER_RESIGNED: 'playerResigned',
+  PLAYER_LAZY_MODE: 'playerLazyMode',
+  PLAYER_ACTIVE_MODE: 'playerActiveMode',
+  GAME_LOG_ENTRY: 'gameLogEntry',
+  LEFT_GAME: 'leftGame',
+  SPECTATOR_JOINED: 'spectatorJoined',
 
   // Connection
   CONNECT: 'connect',

--- a/client/src/handlers/gameHandlers.js
+++ b/client/src/handlers/gameHandlers.js
@@ -46,6 +46,13 @@ export function registerGameHandlers(socketManager, callbacks = {}) {
     onPlayerReconnected,
     onRejoinSuccess,
     onRejoinFailed,
+    // Resignation & Lazy Mode
+    onResignationAvailable,
+    onPlayerResigned,
+    onPlayerLazyMode,
+    onPlayerActiveMode,
+    onGameLogEntry,
+    onLeftGame,
   } = callbacks;
 
   const state = getGameState();
@@ -356,6 +363,43 @@ export function registerGameHandlers(socketManager, callbacks = {}) {
     socketManager.clearGameId();
 
     onRejoinFailed?.(data);
+  });
+
+  // ==================== RESIGNATION & LAZY MODE ====================
+
+  // Resignation available (disconnected player's grace period expired)
+  socketManager.onGame(SERVER_EVENTS.RESIGNATION_AVAILABLE, (data) => {
+    console.log(`⏰ Resignation available for P${data.position} (${data.username})`);
+    onResignationAvailable?.(data);
+  });
+
+  // Player resigned (bot taking over)
+  socketManager.onGame(SERVER_EVENTS.PLAYER_RESIGNED, (data) => {
+    console.log(`🔄 Player resigned: P${data.position} ${data.oldUsername} → ${data.botUsername}`);
+    onPlayerResigned?.(data);
+  });
+
+  // Player entered lazy mode
+  socketManager.onGame(SERVER_EVENTS.PLAYER_LAZY_MODE, (data) => {
+    console.log(`😴 Player entered lazy mode: P${data.position}`);
+    onPlayerLazyMode?.(data);
+  });
+
+  // Player returned to active mode
+  socketManager.onGame(SERVER_EVENTS.PLAYER_ACTIVE_MODE, (data) => {
+    console.log(`🎮 Player returned to active: P${data.position}`);
+    onPlayerActiveMode?.(data);
+  });
+
+  // Game log entry (system message broadcast)
+  socketManager.onGame(SERVER_EVENTS.GAME_LOG_ENTRY, (data) => {
+    onGameLogEntry?.(data);
+  });
+
+  // Player left game (via /leave command)
+  socketManager.onGame(SERVER_EVENTS.LEFT_GAME, (data) => {
+    console.log('🚪 Left game (lazy leave)');
+    onLeftGame?.(data);
   });
 }
 

--- a/client/src/handlers/gameHandlers.js
+++ b/client/src/handlers/gameHandlers.js
@@ -53,6 +53,7 @@ export function registerGameHandlers(socketManager, callbacks = {}) {
     onPlayerActiveMode,
     onGameLogEntry,
     onLeftGame,
+    onRestorePlayerState,
   } = callbacks;
 
   const state = getGameState();
@@ -400,6 +401,12 @@ export function registerGameHandlers(socketManager, callbacks = {}) {
   socketManager.onGame(SERVER_EVENTS.LEFT_GAME, (data) => {
     console.log('🚪 Left game (lazy leave)');
     onLeftGame?.(data);
+  });
+
+  // Restore player state (spectator → active player transition)
+  socketManager.onGame(SERVER_EVENTS.RESTORE_PLAYER_STATE, (data) => {
+    console.log('🔄 Restoring player state from spectator mode');
+    onRestorePlayerState?.(data);
   });
 }
 

--- a/client/src/handlers/index.js
+++ b/client/src/handlers/index.js
@@ -40,6 +40,8 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onLobbyPlayerJoined,
     onLeftLobby,
     onAllPlayersReady,
+    // Spectator callbacks
+    onSpectatorJoined,
     // Game callbacks
     onPositionUpdate,
     onGameStart,
@@ -63,6 +65,13 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onPlayerReconnected,
     onRejoinSuccess,
     onRejoinFailed,
+    // Resignation & Lazy Mode callbacks
+    onResignationAvailable,
+    onPlayerResigned,
+    onPlayerLazyMode,
+    onPlayerActiveMode,
+    onGameLogEntry,
+    onLeftGame,
     // Chat callbacks
     onChatMessage,
     // Profile callbacks
@@ -101,6 +110,7 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onLobbyPlayerJoined,
     onLeftLobby,
     onAllPlayersReady,
+    onSpectatorJoined,
   });
 
   // Register game handlers
@@ -127,6 +137,12 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onPlayerReconnected,
     onRejoinSuccess,
     onRejoinFailed,
+    onResignationAvailable,
+    onPlayerResigned,
+    onPlayerLazyMode,
+    onPlayerActiveMode,
+    onGameLogEntry,
+    onLeftGame,
   });
 
   // Register chat handlers

--- a/client/src/handlers/index.js
+++ b/client/src/handlers/index.js
@@ -72,6 +72,7 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onPlayerActiveMode,
     onGameLogEntry,
     onLeftGame,
+    onRestorePlayerState,
     // Chat callbacks
     onChatMessage,
     // Profile callbacks
@@ -143,6 +144,7 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onPlayerActiveMode,
     onGameLogEntry,
     onLeftGame,
+    onRestorePlayerState,
   });
 
   // Register chat handlers

--- a/client/src/handlers/lobbyHandlers.js
+++ b/client/src/handlers/lobbyHandlers.js
@@ -31,6 +31,8 @@ export function registerLobbyHandlers(socketManager, callbacks = {}) {
     onLobbyPlayerJoined,
     onLeftLobby,
     onAllPlayersReady,
+    // Spectator callbacks
+    onSpectatorJoined,
   } = callbacks;
 
   const state = getGameState();
@@ -104,5 +106,12 @@ export function registerLobbyHandlers(socketManager, callbacks = {}) {
   socketManager.on(SERVER_EVENTS.ALL_PLAYERS_READY, (data) => {
     console.log('🎉 All players ready:', data);
     onAllPlayersReady?.(data);
+  });
+
+  // ==================== SPECTATOR HANDLERS ====================
+
+  socketManager.on(SERVER_EVENTS.SPECTATOR_JOINED, (data) => {
+    console.log('👁️ Spectator joined game:', data);
+    onSpectatorJoined?.(data);
   });
 }

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -2662,6 +2662,8 @@ function initializeApp() {
         scene.scene.restart();
       }
       resetGameState();
+      // Clear gameId so mainRoomJoined handler doesn't ignore the transition
+      sessionStorage.removeItem('gameId');
       socket.emit("joinMainRoom");
     },
     onGameLogEntry: (data) => {

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1728,12 +1728,9 @@ function initializeApp() {
 
     // Spectator callback
     onSpectatorJoined: (data) => {
-      console.log('👁️ Spectator joined game:', data);
-
       // If this is the full game state (not just a notification about another spectator)
       if (data.players && data.trump) {
         try {
-        console.log('👁️ Full spectator state received, setting up view...');
         // Remove main room UI
         removeMainRoom();
 
@@ -1746,8 +1743,6 @@ function initializeApp() {
         const sockets = data.players.map(p => p.socketId);
         const usernames = data.players.map(p => ({ username: p.username, socketId: p.socketId }));
         const pics = data.players.map(p => p.pic);
-
-        console.log('👁️ Player data:', { positions, sockets, usernames, pics });
 
         gameState.setPlayerData({
           position: positions,
@@ -1762,11 +1757,9 @@ function initializeApp() {
         // Set up the game scene for spectating
         const waitForScene = () => {
           const scene = getGameScene();
-          console.log('👁️ waitForScene: scene=', !!scene, 'cardManager=', !!(scene && scene.cardManager));
           if (scene && scene.cardManager) {
             try {
               // Create game UI (game log panel)
-              console.log('👁️ Creating game feed...');
               window.createGameFeedFromLegacy(false);
 
               // Restore game log
@@ -1797,13 +1790,11 @@ function initializeApp() {
 
               // Display trump card
               if (data.trump && scene.displayTrumpCard) {
-                console.log('👁️ Displaying trump card:', data.trump);
                 scene.displayTrumpCard(data.trump);
               }
 
               // Display opponent hands (no player hand for spectators)
               if (scene.handleDisplayOpponentHands) {
-                console.log('👁️ Displaying opponent hands, playerData:', gameState.playerData);
                 scene.handleDisplayOpponentHands(
                   data.currentHand, // approximate card count
                   data.dealer,
@@ -1847,7 +1838,6 @@ function initializeApp() {
               // Add game container in-game class
               document.getElementById('game-container')?.classList.add('in-game');
 
-              console.log('👁️ Spectator view setup complete!');
               window.addToGameFeedFromLegacy?.("Joined as spectator!");
             } catch (err) {
               console.error('👁️ Error setting up spectator view:', err);

--- a/client/src/phaser/managers/CardManager.js
+++ b/client/src/phaser/managers/CardManager.js
@@ -446,6 +446,24 @@ export class CardManager {
   }
 
   /**
+   * Enable or disable all card interaction (for spectator/lazy mode).
+   * @param {boolean} enabled - Whether cards should be interactive
+   */
+  setInteractive(enabled) {
+    this._interactionDisabled = !enabled;
+    this._handSprites.forEach((sprite) => {
+      if (!sprite || !sprite.active) return;
+      if (enabled) {
+        sprite.setInteractive();
+      } else {
+        sprite.disableInteractive();
+        sprite.setTint(0xaaaaaa);
+        sprite.setData('isLegal', false);
+      }
+    });
+  }
+
+  /**
    * Reposition hand cards (for resize handling).
    */
   repositionHand() {

--- a/client/src/phaser/managers/OpponentManager.js
+++ b/client/src/phaser/managers/OpponentManager.js
@@ -469,6 +469,51 @@ export class OpponentManager {
   }
 
   /**
+   * Update player info (name + pic) for a given position.
+   * Used when a bot takes over (resignation, lazy mode) or player resumes (active mode).
+   *
+   * @param {number} position - Game position (1-4)
+   * @param {Object} info - { username, pic }
+   */
+  updatePlayerInfo(position, { username, pic }) {
+    if (!this._playerPosition) return;
+
+    // Determine which opponent slot this position maps to
+    const partnerPos = team(this._playerPosition);
+    const opp1Pos = rotate(this._playerPosition);
+    const opp2Pos = rotate(rotate(rotate(this._playerPosition)));
+
+    let opponentId = null;
+    if (position === partnerPos) opponentId = 'partner';
+    else if (position === opp1Pos) opponentId = 'opp1';
+    else if (position === opp2Pos) opponentId = 'opp2';
+
+    if (!opponentId) return; // This is the local player's own position
+
+    const dom = this._avatarDoms[opponentId];
+    if (!dom) return;
+
+    // Update the image
+    const img = dom.querySelector('.opponent-avatar-img');
+    if (img) {
+      if (pic && typeof pic === 'string' && pic.startsWith('data:image')) {
+        img.src = pic;
+      } else if (pic && typeof pic === 'number') {
+        img.src = `assets/profile${pic}.png`;
+      } else {
+        img.src = 'assets/profile1.png';
+      }
+      img.alt = username;
+    }
+
+    // Update the label
+    const label = dom.querySelector('div:last-child');
+    if (label) {
+      label.textContent = username;
+    }
+  }
+
+  /**
    * Remove a card from an opponent's hand (when they play).
    *
    * @param {string} opponentId - 'partner', 'opp1', or 'opp2'

--- a/client/src/phaser/scenes/GameScene.js
+++ b/client/src/phaser/scenes/GameScene.js
@@ -1533,6 +1533,64 @@ export class GameScene extends Phaser.Scene {
   }
 
   /**
+   * Handle resignationAvailable event.
+   * Shows a modal asking if the player wants to replace the disconnected player with a bot.
+   * @param {Object} data - { position, username }
+   */
+  handleResignationAvailable(data) {
+    console.log('🎮 GameScene.handleResignationAvailable()');
+    this.callbacks.onResignationAvailable?.(data);
+  }
+
+  /**
+   * Handle playerResigned event.
+   * Updates opponent avatar when a bot takes over.
+   * @param {Object} data - { position, oldUsername, botUsername, botPic }
+   */
+  handlePlayerResigned(data) {
+    console.log('🎮 GameScene.handlePlayerResigned()');
+    if (this.opponentManager) {
+      this.opponentManager.updatePlayerInfo(data.position, {
+        username: data.botUsername,
+        pic: data.botPic
+      });
+    }
+    this.callbacks.onPlayerResigned?.(data);
+  }
+
+  /**
+   * Handle playerLazyMode event.
+   * Updates opponent avatar when a bot takes over in lazy mode.
+   * @param {Object} data - { position, botUsername, botPic }
+   */
+  handlePlayerLazyMode(data) {
+    console.log('🎮 GameScene.handlePlayerLazyMode()');
+    if (this.opponentManager) {
+      this.opponentManager.updatePlayerInfo(data.position, {
+        username: data.botUsername,
+        pic: data.botPic
+      });
+    }
+    this.callbacks.onPlayerLazyMode?.(data);
+  }
+
+  /**
+   * Handle playerActiveMode event.
+   * Restores player avatar when they take back control.
+   * @param {Object} data - { position, username, pic }
+   */
+  handlePlayerActiveMode(data) {
+    console.log('🎮 GameScene.handlePlayerActiveMode()');
+    if (this.opponentManager) {
+      this.opponentManager.updatePlayerInfo(data.position, {
+        username: data.username,
+        pic: data.pic
+      });
+    }
+    this.callbacks.onPlayerActiveMode?.(data);
+  }
+
+  /**
    * Handle abortGame event.
    * @param {Object} data - Abort reason
    */

--- a/client/src/ui/components/GameLog.js
+++ b/client/src/ui/components/GameLog.js
@@ -135,7 +135,7 @@ export function createGameLog({ onChatSubmit } = {}) {
     const query = text.toLowerCase();
     const matches = SLASH_COMMANDS.filter(cmd => cmd.command.startsWith(query));
 
-    if (matches.length === 0 || text === matches[0]?.command) {
+    if (matches.length === 0) {
       autocompleteDropdown.style.display = 'none';
       return;
     }

--- a/server/socket/chatHandlers.js
+++ b/server/socket/chatHandlers.js
@@ -224,9 +224,8 @@ function chatMessage(socket, io, data) {
                     gameManager.updatePlayerGameMapping(null, socket.id, activeGame.gameId);
                     // Now run normal active command (disables lazy, broadcasts playerActiveMode)
                     handleActiveCommand(socket, io, activeGame, position);
-                    // Send full game state so client can rebuild with hand
-                    const clientState = activeGame.getClientState(socket.id);
-                    socket.emit('rejoinSuccess', clientState);
+                    // Send full game state so client can transition from spectator to player
+                    socket.emit('restorePlayerState', activeGame.getClientState(socket.id));
                 } else {
                     activeGame.sendToPlayer(io, socket.id, 'error', { message: "Spectators can't use /active" });
                 }

--- a/server/socket/chatHandlers.js
+++ b/server/socket/chatHandlers.js
@@ -4,35 +4,247 @@
 
 const gameManager = require('../game/GameManager');
 const { socketLogger } = require('../utils/logger');
+const { botController, personalities } = require('../game/bot');
+const { PERSONALITY_LIST, getDisplayName } = personalities;
+
+/**
+ * Process slash commands from chat input
+ * @returns {boolean} true if message was a slash command (don't broadcast as chat)
+ */
+function handleSlashCommand(socket, io, game, position, message) {
+    const command = message.trim().toLowerCase();
+
+    if (command === '/lazy') {
+        return handleLazyCommand(socket, io, game, position);
+    } else if (command === '/active') {
+        return handleActiveCommand(socket, io, game, position);
+    } else if (command === '/leave') {
+        return handleLeaveCommand(socket, io, game, position);
+    }
+
+    // Unknown slash command
+    game.sendToPlayer(io, socket.id, 'error', { message: `Unknown command: ${message.trim().split(' ')[0]}` });
+    return true; // Still don't broadcast as chat
+}
+
+function handleLazyCommand(socket, io, game, position) {
+    // Check if player is a spectator
+    if (game.isSpectator(socket.id)) {
+        game.sendToPlayer(io, socket.id, 'error', { message: "Spectators can't use /lazy" });
+        return true;
+    }
+
+    // Check if already in lazy mode
+    if (game.isLazy(position)) {
+        game.sendToPlayer(io, socket.id, 'error', { message: 'Already in lazy mode. Use /active to take back control.' });
+        return true;
+    }
+
+    // Check if this position was resigned (can't lazy a bot-replaced position)
+    if (game.isResigned(position)) {
+        game.sendToPlayer(io, socket.id, 'error', { message: 'This position has been resigned.' });
+        return true;
+    }
+
+    // Pick personality — reuse assigned one if exists, otherwise pick random
+    let personality = game.assignedPersonality[position];
+    if (!personality) {
+        personality = PERSONALITY_LIST[Math.floor(Math.random() * PERSONALITY_LIST.length)];
+    }
+    const displayName = getDisplayName(personality);
+    const botUsername = `🤖 ${displayName}`;
+
+    // Create bot instance
+    const bot = botController.createBot(botUsername, personality);
+    const botPic = Math.floor(Math.random() * 82) + 1;
+    bot.position = position;
+    bot.pic = botPic;
+
+    // Register bot with controller
+    botController.registerBot(game.gameId, bot);
+
+    // Initialize bot card memory
+    bot.resetCardMemory(game.currentHand, game.trump);
+
+    // Enable lazy mode on game state
+    game.enableLazyMode(position, bot.socketId, bot.username, botPic, personality);
+
+    // Broadcast playerLazyMode event
+    const player = game.getPlayerByPosition(position);
+    game.broadcast(io, 'playerLazyMode', {
+        position,
+        botUsername: bot.username,
+        botPic,
+        originalUsername: game.lazyPlayers[position]?.originalUsername
+    });
+
+    // Add game log entry
+    const originalUsername = game.lazyPlayers[position]?.originalUsername || 'Unknown';
+    game.addLogEntry(`${originalUsername} entered lazy mode. ${bot.username} is playing.`, null, 'system');
+    game.broadcast(io, 'gameLogEntry', {
+        message: `${originalUsername} entered lazy mode. ${bot.username} is playing.`,
+        type: 'system'
+    });
+
+    socketLogger.info('Player entered lazy mode', {
+        gameId: game.gameId, position, botUsername: bot.username
+    });
+
+    // If it's this player's turn, trigger bot action
+    if (game.currentTurn === position) {
+        const { triggerBotIfNeeded } = require('./gameHandlers');
+        const actionType = game.bidding ? 'bid' : 'play';
+        triggerBotIfNeeded(io, game, actionType);
+    }
+
+    return true;
+}
+
+function handleActiveCommand(socket, io, game, position) {
+    // Check if player is a spectator
+    if (game.isSpectator(socket.id)) {
+        game.sendToPlayer(io, socket.id, 'error', { message: "Spectators can't use /active" });
+        return true;
+    }
+
+    // Check if actually in lazy mode
+    if (!game.isLazy(position)) {
+        game.sendToPlayer(io, socket.id, 'error', { message: 'Not in lazy mode.' });
+        return true;
+    }
+
+    const lazyInfo = game.getLazyBot(position);
+    const originalUsername = lazyInfo?.originalUsername || 'Unknown';
+    const originalPic = lazyInfo?.originalPic;
+
+    // Clean up the bot from controller
+    if (lazyInfo?.botSocketId) {
+        const gameBots = botController.gamesBots.get(game.gameId);
+        if (gameBots) {
+            gameBots.delete(lazyInfo.botSocketId);
+        }
+    }
+
+    // Disable lazy mode on game state (restores original player info)
+    game.disableLazyMode(position);
+
+    // Broadcast playerActiveMode event
+    game.broadcast(io, 'playerActiveMode', {
+        position,
+        username: originalUsername,
+        pic: originalPic
+    });
+
+    // Add game log entry
+    game.addLogEntry(`${originalUsername} is back in control.`, null, 'system');
+    game.broadcast(io, 'gameLogEntry', {
+        message: `${originalUsername} is back in control.`,
+        type: 'system'
+    });
+
+    socketLogger.info('Player returned to active mode', {
+        gameId: game.gameId, position, username: originalUsername
+    });
+
+    return true;
+}
+
+function handleLeaveCommand(socket, io, game, position) {
+    // Spectators just leave
+    if (game.isSpectator(socket.id)) {
+        game.removeSpectator(socket.id);
+        game.leaveRoom(io, socket.id);
+        socket.emit('leftGame');
+        socket.emit('joinMainRoom');
+        return true;
+    }
+
+    // If not already lazy, enable lazy mode first
+    if (!game.isLazy(position)) {
+        handleLazyCommand(socket, io, game, position);
+    }
+
+    // Leave the game room (but stay associated via lazyPlayers for rejoin)
+    game.leaveRoom(io, socket.id);
+
+    // Send player to main room
+    socket.emit('leftGame');
+
+    socketLogger.info('Player left game (lazy)', {
+        gameId: game.gameId, position
+    });
+
+    return true;
+}
 
 function chatMessage(socket, io, data) {
     const game = gameManager.getPlayerGame(socket.id);
 
+    // Also check if user is a spectator in any game
+    let spectatorGame = null;
     if (!game) {
+        // Check all games for spectator status
+        for (const [, g] of gameManager.games) {
+            if (g.isSpectator(socket.id)) {
+                spectatorGame = g;
+                break;
+            }
+        }
+    }
+
+    const activeGame = game || spectatorGame;
+
+    if (!activeGame) {
         // Not in a game, can't chat
         socketLogger.debug('Chat rejected: not in a game', { socketId: socket.id });
         return;
     }
 
-    const position = game.getPositionBySocketId(socket.id);
-
-    if (!position) {
-        socketLogger.debug('Chat rejected: no position', { socketId: socket.id });
-        return;
+    // Handle slash commands
+    if (data.message.startsWith('/')) {
+        const position = activeGame.getPositionBySocketId(socket.id);
+        // Spectators can only use /leave
+        if (activeGame.isSpectator(socket.id)) {
+            const command = data.message.trim().toLowerCase();
+            if (command === '/leave') {
+                handleLeaveCommand(socket, io, activeGame, null);
+            } else if (command === '/lazy' || command === '/active') {
+                activeGame.sendToPlayer(io, socket.id, 'error', { message: `Spectators can't use ${command}` });
+            } else {
+                activeGame.sendToPlayer(io, socket.id, 'error', { message: `Unknown command: ${data.message.trim().split(' ')[0]}` });
+            }
+            return;
+        }
+        if (position && handleSlashCommand(socket, io, activeGame, position, data.message)) {
+            return;
+        }
     }
 
+    const position = activeGame.getPositionBySocketId(socket.id);
+
     // Get player info for username
-    const player = game.getPlayerByPosition(position);
-    const username = player ? player.username : 'Unknown';
+    let username;
+    if (activeGame.isSpectator(socket.id)) {
+        const spectator = activeGame.spectators.get(socket.id);
+        username = spectator?.username || 'Spectator';
+    } else {
+        if (!position) {
+            socketLogger.debug('Chat rejected: no position', { socketId: socket.id });
+            return;
+        }
+        const player = activeGame.getPlayerByPosition(position);
+        username = player ? player.username : 'Unknown';
+    }
 
     // Add to game log for reconnection persistence
-    game.addLogEntry(`${username}: ${data.message}`, position, 'chat');
+    activeGame.addLogEntry(`${username}: ${data.message}`, position, 'chat');
 
     // Broadcast to players in the same game only
-    game.broadcast(io, 'chatMessage', {
+    activeGame.broadcast(io, 'chatMessage', {
         position,
         message: data.message,
-        username
+        username,
+        isSpectator: activeGame.isSpectator(socket.id)
     });
 }
 

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -53,6 +53,9 @@ function setupSocketHandlers(io) {
         socket.on('getLobbies', () =>
             safeHandler(mainRoomHandlers.getLobbies)(socket, io, {})
         );
+        socket.on('joinAsSpectator', (data) =>
+            asyncHandler('joinAsSpectator', mainRoomHandlers.joinAsSpectator)(socket, io, data)
+        );
 
         // Lobby events
         socket.on('playerReady', () =>
@@ -83,6 +86,9 @@ function setupSocketHandlers(io) {
         );
         socket.on('playCard', (data) =>
             asyncHandler('playCard', gameHandlers.playCard)(socket, io, data)
+        );
+        socket.on('forceResign', (data) =>
+            asyncHandler('forceResign', gameHandlers.forceResign)(socket, io, data)
         );
 
         // Chat events - with validation

--- a/server/socket/lobbyHandlers.js
+++ b/server/socket/lobbyHandlers.js
@@ -198,12 +198,14 @@ function leaveLobby(socket, io) {
     socket.emit('mainRoomJoined', {
         messages: mainRoomResult.messages,
         lobbies: mainRoomResult.lobbies,
-        onlineCount: mainRoomResult.onlineCount
+        onlineCount: mainRoomResult.onlineCount,
+        inProgressGames: gameManager.getInProgressGames()
     });
 
     // Notify main room of updated lobby list
     io.to('mainRoom').emit('lobbiesUpdated', {
-        lobbies: gameManager.getAllLobbies()
+        lobbies: gameManager.getAllLobbies(),
+        inProgressGames: gameManager.getInProgressGames()
     });
 
     // If lobby was deleted (no players left), nothing more to do
@@ -276,7 +278,8 @@ function addBot(socket, io) {
 
     // Also update main room lobby list
     io.to('mainRoom').emit('lobbiesUpdated', {
-        lobbies: gameManager.getAllLobbies()
+        lobbies: gameManager.getAllLobbies(),
+        inProgressGames: gameManager.getInProgressGames()
     });
 }
 
@@ -318,7 +321,8 @@ function removeBot(socket, io, data) {
 
     // Also update main room lobby list
     io.to('mainRoom').emit('lobbiesUpdated', {
-        lobbies: gameManager.getAllLobbies()
+        lobbies: gameManager.getAllLobbies(),
+        inProgressGames: gameManager.getInProgressGames()
     });
 }
 

--- a/server/socket/profileHandlers.js
+++ b/server/socket/profileHandlers.js
@@ -204,16 +204,20 @@ async function recordGameStats(game) {
     // Determine winner based on final scores
     const team1Won = game.score.team1 > game.score.team2;
 
-    // Get all players
+    // Get all players — use original human player info for resigned positions
     const players = [
-        { position: 1, player: game.getPlayerByPosition(1) },
-        { position: 2, player: game.getPlayerByPosition(2) },
-        { position: 3, player: game.getPlayerByPosition(3) },
-        { position: 4, player: game.getPlayerByPosition(4) }
+        { position: 1, player: game.getOriginalPlayer(1) },
+        { position: 2, player: game.getOriginalPlayer(2) },
+        { position: 3, player: game.getOriginalPlayer(3) },
+        { position: 4, player: game.getOriginalPlayer(4) }
     ];
 
     for (const { position, player } of players) {
         if (!player || !player.username) continue;
+
+        // Skip bots (they don't have DB records)
+        // But don't skip resigned positions — those have original human usernames
+        if (!game.isResigned(position) && game.isBot(game.positions[position])) continue;
 
         const isTeam1 = position === 1 || position === 3;
         const isWinner = (isTeam1 && team1Won) || (!isTeam1 && !team1Won);

--- a/server/socket/queueHandlers.js
+++ b/server/socket/queueHandlers.js
@@ -99,6 +99,14 @@ function handleDisconnect(socket, io) {
         // Notify other players that someone disconnected
         result.game.broadcast(io, 'playerDisconnected', { position, username });
 
+        // Add game log entry so players see it in the feed
+        const dcMessage = `${username} disconnected. Waiting for reconnection...`;
+        result.game.addLogEntry(dcMessage, null, 'system');
+        result.game.broadcast(io, 'gameLogEntry', {
+            message: dcMessage,
+            type: 'system'
+        });
+
         // Start a timer to abort if they don't reconnect
         // Clear any existing timer for this game (in case multiple disconnects)
         if (pendingAbortTimers.has(result.gameId)) {
@@ -133,6 +141,10 @@ function handleDisconnect(socket, io) {
                             position: pos,
                             username: dcUsername
                         });
+
+                        const expiredMsg = `${dcUsername} failed to reconnect. You may replace them with a bot.`;
+                        checkResult.game.addLogEntry(expiredMsg, null, 'system');
+                        checkResult.game.broadcast(io, 'gameLogEntry', { message: expiredMsg, type: 'system' });
                     }
                 }
             }

--- a/server/socket/reconnectHandlers.js
+++ b/server/socket/reconnectHandlers.js
@@ -82,6 +82,10 @@ async function rejoinGame(socket, io, data) {
 
         // Notify other players
         game.broadcast(io, 'playerReconnected', { position, username });
+
+        const rcMessage = `${username} reconnected.`;
+        game.addLogEntry(rcMessage, null, 'system');
+        game.broadcast(io, 'gameLogEntry', { message: rcMessage, type: 'system' });
         return;
     }
 
@@ -112,6 +116,10 @@ async function rejoinGame(socket, io, data) {
         position: existingPlayer.position,
         username
     });
+
+    const rcMessage = `${username} reconnected.`;
+    game.addLogEntry(rcMessage, null, 'system');
+    game.broadcast(io, 'gameLogEntry', { message: rcMessage, type: 'system' });
 }
 
 module.exports = {

--- a/server/socket/validators.js
+++ b/server/socket/validators.js
@@ -65,6 +65,16 @@ const schemas = {
         username: Joi.string().min(1).max(50).required()
     }),
 
+    // Resignation
+    forceResign: Joi.object({
+        position: Joi.number().integer().min(1).max(4).required()
+    }),
+
+    // Spectator
+    joinAsSpectator: Joi.object({
+        gameId: Joi.string().uuid().required()
+    }),
+
     // Profile
     updateProfilePic: Joi.object({
         profilePic: Joi.number().integer().min(1).max(82).required()


### PR DESCRIPTION
## Summary

- **Resignation system**: When a player disconnects, 60s grace period starts. After expiry, remaining players can replace the disconnected player with a random bot. Game only aborts if ALL humans disconnect.
- **Slash commands**: Players can type `/lazy` (bot takes over temporarily), `/active` (take back control), or `/leave` (bot takes over, exit to lobby, rejoin anytime). Autocomplete dropdown appears when typing `/` with single-match auto-submit on Enter.
- **Spectator system**: In-progress games shown in main room with "Spectate" button. Spectators see tricks, bids, scores, and game log but NOT player hands. Can chat and use `/leave` to exit.

### Server changes (11 files)
- `GameState.js`: Added `resignedPlayers`, `lazyPlayers`, `spectators` tracking with full CRUD methods
- `queueHandlers.js`: 60s grace period, `resignationAvailable` broadcast instead of abort
- `gameHandlers.js`: `forceResign` handler, `triggerBotIfNeeded` supports lazy mode
- `chatHandlers.js`: Slash command interception (`/lazy`, `/active`, `/leave`), spectator chat
- `mainRoomHandlers.js`: `joinAsSpectator` handler, in-progress games list
- `reconnectHandlers.js`: Lazy rejoin support (player who `/left` can rejoin)
- `profileHandlers.js`: Stats attributed to original human player after resignation
- `GameManager.js`: `getInProgressGames()`, spectator disconnect cleanup
- `validators.js`: `forceResign` and `joinAsSpectator` schemas
- `index.js`: New event registrations
- `lobbyHandlers.js`: Include `inProgressGames` in lobby updates

### Client changes (10 files)
- `events.js`: New event constants for resignation, lazy mode, spectator
- `handlers/index.js`: Wire new callbacks through to handler modules
- `gameHandlers.js`: Listeners for resignation/lazy/active/gameLog/leftGame events
- `lobbyHandlers.js`: Listener for spectatorJoined event
- `main.js`: Callbacks for all new events — resignation modal, lazy mode UI, spectator view setup
- `OpponentManager.js`: `updatePlayerInfo()` for avatar swaps on resign/lazy
- `CardManager.js`: `setInteractive()` to disable cards in spectator/lazy mode
- `GameScene.js`: Handler methods for resign/lazy/active events
- `GameLog.js`: Slash command autocomplete with single-match auto-submit
- `MainRoom.js`: In-progress games section with Spectate button

## Test plan
- [x] `npm test` — all 214 server tests pass
- [x] Spectate button appears for in-progress games in main room
- [x] Clicking Spectate shows game view with scores, opponents, and game log
- [x] Slash command autocomplete works with partial match auto-submit
- [ ] Disconnect a player → 60s timer → resignation popup → bot takes over
- [ ] `/lazy` → bot plays, `/active` → player resumes
- [ ] `/leave` → exit to lobby, rejoin later → find self in lazy mode
- [ ] Stats attributed to original human after resignation
- [ ] Spectator chat works with spectator indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)