### PR TITLE
Widen leaderboard modal to fit all columns

### DIFF
--- a/client/src/ui/screens/LeaderboardPage.js
+++ b/client/src/ui/screens/LeaderboardPage.js
@@ -289,7 +289,7 @@ export function showLeaderboardPage(leaderboard, socket) {
   modal.style.padding = '25px';
   modal.style.borderRadius = '12px';
   modal.style.border = '2px solid #4a5568';
-  modal.style.width = '900px';
+  modal.style.width = '960px';
   modal.style.maxWidth = '95vw';
   modal.style.maxHeight = '90vh';
   modal.style.boxSizing = 'border-box';


### PR DESCRIPTION
## Summary
- Bumps leaderboard modal width from 900px to 960px to prevent column crowding after the Games column was added in #107

## Test plan
- [ ] Open leaderboard and verify all columns display without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)