### PR TITLE
Fix /leave re-entry: lazy player rejoin from main room

### DIFF
--- a/server/game/GameState.js
+++ b/server/game/GameState.js
@@ -198,6 +198,9 @@ class GameState {
         const oldSocketId = this.positions[position];
         if (!oldSocketId) return null;
 
+        // Already at this socket — nothing to transfer
+        if (oldSocketId === newSocketId) return oldSocketId;
+
         const player = this.players.get(oldSocketId);
         if (!player) return null;
 


### PR DESCRIPTION
## Summary
- **Server**: Detect lazy players in `joinAsSpectator` and route through `rejoinSuccess` with `isLazy` flag instead of generic spectator path, so they see their hand and can `/active` back
- **Server**: Guard `updatePlayerSocket` against self-transfer (`old === new` socketId) which was destroying the hand data when `/leave` didn't disconnect the socket
- **Client**: Handle `isLazy` in `processRejoinOrRestore` (disable cards, show spectating banner), add missing `.in-game` class + player info box for rejoin, null out `cardManager` before scene restart to fix timing issue, clear `isLazy` on `/active` restore

## Test plan
- [ ] Start game with bots, type `/leave`, verify main room shows with game listed as in-progress
- [ ] Click "Spectate" on own game — verify game UI appears with cards (dimmed), bot avatar, green "Spectating" banner
- [ ] Type `/active` — verify avatar restores, cards become interactive, banner disappears, game is playable
- [ ] Test with page refresh during lazy mode: sign back in, verify auto-rejoin shows game with lazy mode active
- [ ] Run `npm test` and `npm run test:client` for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)