### PR TITLE
Fix bot avatars reverting to original player on next hand

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -2137,6 +2137,16 @@ function initializeApp() {
           scene.effectsManager.setPlayerPosition(data.position);
         }
 
+        // Update player data if included (reflects bot takeovers)
+        if (data.playerInfo) {
+          gameState.setPlayerData({
+            positions: data.playerInfo.map(p => p.position),
+            sockets: data.players,
+            usernames: data.playerInfo.map(p => ({ username: p.username })),
+            pics: data.playerInfo.map(p => p.pic),
+          });
+        }
+
         // Display avatars and dealer button immediately (not cards)
         if (scene.opponentManager && data.hand) {
           scene.opponentManager.displayDealerButton(data.dealer);

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -444,6 +444,15 @@ async function startHand(game, io) {
         hsiValues[position] = hsi;
     }
 
+    // Build current player info (reflects bot takeovers via lazy/resign)
+    const playerInfo = [];
+    for (let pos = 1; pos <= 4; pos++) {
+        const p = game.getPlayerByPosition(pos);
+        if (p) {
+            playerInfo.push({ position: pos, username: p.username, pic: p.pic });
+        }
+    }
+
     // Send game start to all players (each gets their own hand and position)
     for (const socketId of socketIds) {
         const playerPosition = game.getPositionBySocketId(socketId);
@@ -457,7 +466,8 @@ async function startHand(game, io) {
             dealer: game.dealer,
             position: playerPosition,  // Include player's position to avoid race condition
             currentHand: game.currentHand,  // Hand index for hand indicator
-            hsiValues  // HSI for all players to display under avatars
+            hsiValues,  // HSI for all players to display under avatars
+            playerInfo  // Current player info for avatar updates
         });
     }
 
@@ -776,6 +786,15 @@ async function cleanupNextHand(game, io, dealer, handSize) {
         hsiValues[position] = hsi;
     }
 
+    // Build current player info (reflects bot takeovers via lazy/resign)
+    const playerInfo = [];
+    for (let pos = 1; pos <= 4; pos++) {
+        const p = game.getPlayerByPosition(pos);
+        if (p) {
+            playerInfo.push({ position: pos, username: p.username, pic: p.pic });
+        }
+    }
+
     // Send new hand to all players (each gets their own hand and position)
     for (const socketId of socketIds) {
         const playerPosition = game.getPositionBySocketId(socketId);
@@ -789,7 +808,8 @@ async function cleanupNextHand(game, io, dealer, handSize) {
             dealer: game.dealer,
             position: playerPosition,  // Include player's position to fix bid UI bug
             currentHand: game.currentHand,  // Hand index for hand indicator
-            hsiValues  // HSI for all players to display under avatars
+            hsiValues,  // HSI for all players to display under avatars
+            playerInfo  // Current player info for avatar updates
         });
     }
 


### PR DESCRIPTION
## Summary
- Include `playerInfo` in `gameStart` events so clients refresh cached player data each hand
- Fixes bug where bot avatars (from `/lazy`, `/leave`, or disconnect+resignation) reverted to the original player's name/pic when the next hand was dealt
- Affects both `startHand()` and `cleanupNextHand()` server-side, and the `onGameStart` client handler

## Test plan
- [x] Start a game, use `/lazy` — bot avatar appears correctly
- [x] Wait for next hand — bot avatar persists (previously reverted)
- [x] Use `/active` to resume — avatar reverts to human
- [x] Test disconnect + "Replace with bot" — same correct behavior across hands
- [x] Test `/leave` then rejoin + `/active` — avatars correct throughout
- [x] All 214 server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)