### PR TITLE
Fix HSI, bids/tricks header, and won tricks indicator on reconnect/active (#114)

### DIFF
--- a/server/game/GameState.js
+++ b/server/game/GameState.js
@@ -78,6 +78,9 @@ class GameState {
         // Assigned bot personality per position (persists across lazy/active cycles)
         this.assignedPersonality = {};
 
+        // HSI values for current hand (position → hsi), stored for reconnection
+        this.hsiValues = {};
+
         // Spectators: socketId → { username, pic }
         this.spectators = new Map();
 
@@ -269,6 +272,7 @@ class GameState {
             isTrumpBroken: this.isTrumpBroken,
             players: playerInfo,
             gameLog: this.getGameLog(),
+            hsiValues: this.hsiValues,
             resignedPositions: Object.keys(this.resignedPlayers).map(Number),
             lazyPositions: Object.keys(this.lazyPlayers).map(Number),
             isLazy: this.isLazy(position)

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -444,6 +444,9 @@ async function startHand(game, io) {
         hsiValues[position] = hsi;
     }
 
+    // Store HSI values on game state for reconnection
+    game.hsiValues = hsiValues;
+
     // Build current player info (reflects bot takeovers via lazy/resign)
     const playerInfo = [];
     for (let pos = 1; pos <= 4; pos++) {
@@ -785,6 +788,9 @@ async function cleanupNextHand(game, io, dealer, handSize) {
         game.addHSI(position, hsi);
         hsiValues[position] = hsi;
     }
+
+    // Store HSI values on game state for reconnection
+    game.hsiValues = hsiValues;
 
     // Build current player info (reflects bot takeovers via lazy/resign)
     const playerInfo = [];


### PR DESCRIPTION
## Summary
- **HSI**: Store calculated HSI values on `GameState` so `getClientState()` includes them for rejoining clients
- **Game log header bids**: Reconstruct position-keyed bids from `playerBids` array on rejoin (server overwrites `game.bids` to `{team1, team2}` format after bidding, which broke client's `_updateTeamBids()`)
- **Game log header tricks**: Convert server's `tricks.team1/team2` to team/opp perspective based on player position on rejoin
- **Won tricks indicator**: Call `setBidTotals()` and `createTrickBackgrounds()` on rejoin when past bidding phase, with correct trick counts

## Test plan
- [ ] Start a 4-player game with bots, play past bidding into trick play
- [ ] Disconnect and reconnect — verify HSI, bids/tricks header, and won tricks boxes all appear correctly
- [ ] Use `/lazy` then `/active` — verify same three elements restore
- [ ] Use `/leave`, rejoin from main room, then `/active` — verify same
- [ ] Run `npm test` and `npm run test:client` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)