### PR TITLE
Show all 4 players as opponents in spectator view

### DIFF
--- a/client/src/phaser/managers/LayoutManager.js
+++ b/client/src/phaser/managers/LayoutManager.js
@@ -229,7 +229,7 @@ export class LayoutManager {
    * Create DOM background elements (play zone, hand background, border).
    * Only creates if they don't exist.
    */
-  createDomBackgrounds() {
+  createDomBackgrounds({ skipHandArea = false } = {}) {
     const container = document.getElementById('game-container');
     if (!container) return;
 
@@ -247,8 +247,8 @@ export class LayoutManager {
       console.log('📍 LayoutManager: Play zone DOM created');
     }
 
-    // Create hand background DOM element
-    if (!document.getElementById('handBackgroundDom')) {
+    // Create hand background DOM element (skip for spectators)
+    if (!skipHandArea && !document.getElementById('handBackgroundDom')) {
       const handBgDom = document.createElement('div');
       handBgDom.id = 'handBackgroundDom';
       handBgDom.style.position = 'absolute';

--- a/client/src/ui/components/ChatBubble.js
+++ b/client/src/ui/components/ChatBubble.js
@@ -5,6 +5,8 @@
  * Uses DOM elements for better text rendering and simpler styling.
  */
 
+import { getGameState } from '../../state/GameState.js';
+
 /**
  * Base design dimensions for scaling.
  */
@@ -48,6 +50,8 @@ function getTailClass(positionKey) {
   switch (positionKey) {
     case 'partner':
       return 'tail-left'; // Bubble to the right, tail points left toward avatar
+    case 'bottom':
+      return 'tail-down'; // Bubble above, tail points down toward avatar
     case 'opp1':
     case 'opp2':
     case 'me':
@@ -161,6 +165,7 @@ export function getBubblePosition(playerPosition, messagePosition) {
     opp2: { x: Math.min(screenWidth - 130, centerX + 550 * scaleX), y: centerY - 40 },
     partner: { x: centerX, y: centerY - 400 * scaleY },
     me: { x: window.innerWidth - 405, y: window.innerHeight - 300 },
+    bottom: { x: centerX, y: centerY + 400 * scaleY },
   };
 
   // Determine relative position
@@ -172,7 +177,9 @@ export function getBubblePosition(playerPosition, messagePosition) {
   } else if (messagePosition === playerPosition + 2 || messagePosition === playerPosition - 2) {
     positionKey = 'partner';
   } else if (messagePosition === playerPosition) {
-    positionKey = 'me';
+    // Pure spectators see their view position as 'bottom'
+    const state = getGameState();
+    positionKey = (state.isSpectator && !state.isLazy) ? 'bottom' : 'me';
   }
 
   if (!positionKey) return null;
@@ -214,6 +221,7 @@ export function repositionBubbles(playerPosition) {
       opp2: { x: Math.min(screenWidth - 130, centerX + 550 * scaleX), y: centerY - 40 },
       partner: { x: centerX, y: centerY - 400 * scaleY },
       me: { x: window.innerWidth - 405, y: window.innerHeight - 300 },
+      bottom: { x: centerX, y: centerY + 400 * scaleY },
     };
 
     const pos = positions[positionKey];


### PR DESCRIPTION
## Summary
- When a pure spectator joins a game, all 4 players now render as opponent-style displays (avatar + name + face-down cards) with no empty hand area at the bottom
- Lazy mode players are unaffected — they continue seeing their own card table
- Spectator rejoin (refresh) now correctly restores trick win indicators, bid counters in the game header, and trick counts

## Changes
- **OpponentManager**: Added `bottom` slot with spectator mode flag, `_getSlotKeys()` helper, and updated all slot-iterating methods
- **GameScene**: Routes position 1 to `bottom` for pure spectators; skips card manager turn glow; handles card play animations from bottom slot
- **main.js**: Sets spectator mode on OpponentManager, skips hand area and player info box, restores bids/tricks/trick backgrounds on spectator join
- **LayoutManager**: `createDomBackgrounds()` accepts `{ skipHandArea }` option
- **ChatBubble**: Added `bottom` position to bubble positioning and repositioning

## Test plan
- [ ] Start a game with bots, spectate from another browser — all 4 players show as opponents with card backs + avatars
- [ ] Cards animate correctly when each position plays (including position 1 → bottom slot)
- [ ] Turn glow cycles through all 4 avatars correctly
- [ ] Bid/chat bubbles appear near correct avatars including bottom
- [ ] Dealer button positions correctly for all 4 positions
- [ ] Refresh while spectating — trick indicators and bid counters restore correctly
- [ ] `/lazy` from a player — their view still shows their own hand
- [ ] Window resize — bottom position repositions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)