### PR TITLE
Filter slash commands for spectators (#116)

### DIFF
--- a/client/src/phaser/managers/CardManager.test.js
+++ b/client/src/phaser/managers/CardManager.test.js
@@ -2,6 +2,18 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { CardManager } from './CardManager.js';
 import { CARD_CONFIG } from '../config.js';
 
+// Mock global Phaser (loaded via script tag in production, not available in test)
+globalThis.Phaser = {
+  Geom: {
+    Rectangle: class Rectangle {
+      constructor(x, y, width, height) {
+        this.x = x; this.y = y; this.width = width; this.height = height;
+      }
+      static Contains() { return true; }
+    },
+  },
+};
+
 // Mock Phaser scene
 function createMockScene() {
   const sprites = [];

--- a/client/src/ui/components/GameLog.js
+++ b/client/src/ui/components/GameLog.js
@@ -5,6 +5,7 @@
  */
 
 import { getUsernameColor } from '../../utils/colors.js';
+import { getGameState } from '../../state/GameState.js';
 
 /**
  * Create game log component.
@@ -104,11 +105,21 @@ export function createGameLog({ onChatSubmit } = {}) {
   sendBtn.textContent = 'Send';
 
   // Slash command autocomplete
-  const SLASH_COMMANDS = [
+  const ALL_SLASH_COMMANDS = [
     { command: '/lazy', description: 'Have a bot play for you' },
     { command: '/active', description: 'Take back control from bot' },
     { command: '/leave', description: 'Exit to lobby (bot plays, rejoin anytime)' },
   ];
+  const SPECTATOR_SLASH_COMMANDS = [
+    { command: '/leave', description: 'Exit spectating' },
+  ];
+  const getSlashCommands = () => {
+    const gameState = getGameState();
+    if (gameState.isSpectator && !gameState.isLazy) {
+      return SPECTATOR_SLASH_COMMANDS;
+    }
+    return ALL_SLASH_COMMANDS;
+  };
 
   const autocompleteDropdown = document.createElement('div');
   autocompleteDropdown.className = 'slash-autocomplete';
@@ -133,7 +144,7 @@ export function createGameLog({ onChatSubmit } = {}) {
     }
 
     const query = text.toLowerCase();
-    const matches = SLASH_COMMANDS.filter(cmd => cmd.command.startsWith(query));
+    const matches = getSlashCommands().filter(cmd => cmd.command.startsWith(query));
 
     if (matches.length === 0) {
       autocompleteDropdown.style.display = 'none';
@@ -178,7 +189,7 @@ export function createGameLog({ onChatSubmit } = {}) {
       // If typing a partial slash command with a single match, submit the full command
       if (message.startsWith('/') && message !== '/') {
         const query = message.toLowerCase();
-        const matches = SLASH_COMMANDS.filter(cmd => cmd.command.startsWith(query));
+        const matches = getSlashCommands().filter(cmd => cmd.command.startsWith(query));
         if (matches.length === 1) {
           message = matches[0].command;
         }

--- a/server/socket/chatHandlers.js
+++ b/server/socket/chatHandlers.js
@@ -227,12 +227,10 @@ function chatMessage(socket, io, data) {
                     // Send full game state so client can transition from spectator to player
                     socket.emit('restorePlayerState', activeGame.getClientState(socket.id));
                 } else {
-                    activeGame.sendToPlayer(io, socket.id, 'error', { message: "Spectators can't use /active" });
+                    return; // Pure spectator can't use /active, silently ignore
                 }
-            } else if (command === '/lazy') {
-                activeGame.sendToPlayer(io, socket.id, 'error', { message: "Spectators can't use /lazy" });
             } else {
-                activeGame.sendToPlayer(io, socket.id, 'error', { message: `Unknown command: ${data.message.trim().split(' ')[0]}` });
+                return; // Silently ignore /lazy, unknown commands for pure spectators
             }
             return;
         }


### PR DESCRIPTION
## Summary
- Pure spectators now only see `/leave` in autocomplete (with "Exit spectating" description) instead of all 3 slash commands
- `/lazy`, `/active`, and unknown commands from pure spectators are silently ignored on the server instead of showing error toasts
- Lazy-mode players who used `/leave` and rejoined as spectators still see `/active` and `/leave` as before
- Fixes 5 pre-existing CardManager test failures by adding `Phaser.Geom.Rectangle` mock

## Test plan
- [ ] Spectate a game → type `/` in chat → only `/leave` shows in autocomplete
- [ ] Manually type `/lazy` or `/active` as spectator → no error toast, silently ignored
- [ ] `/leave` as spectator → correctly exits to main room
- [ ] As a player, use `/leave` → rejoin as spectator → should see `/active` and `/leave` in autocomplete (because `isLazy` is true)
- [ ] `npm run test:client` — 234/234 pass
- [ ] `npm test` — 214/214 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)