### PR TITLE
Add tournament mode with 4-round competitive play

### DIFF
--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -31,6 +31,19 @@ export const CLIENT_EVENTS = {
   FORCE_RESIGN: 'forceResign',
   JOIN_AS_SPECTATOR: 'joinAsSpectator',
 
+  // Tournament
+  CREATE_TOURNAMENT: 'createTournament',
+  JOIN_TOURNAMENT: 'joinTournament',
+  LEAVE_TOURNAMENT: 'leaveTournament',
+  TOURNAMENT_READY: 'tournamentReady',
+  TOURNAMENT_UNREADY: 'tournamentUnready',
+  BEGIN_TOURNAMENT: 'beginTournament',
+  BEGIN_NEXT_ROUND: 'beginNextRound',
+  TOURNAMENT_CHAT: 'tournamentChat',
+  SPECTATE_TOURNAMENT: 'spectateTournament',
+  SPECTATE_TOURNAMENT_GAME: 'spectateTournamentGame',
+  RETURN_TO_TOURNAMENT: 'returnToTournament',
+
   // Profile
   GET_PROFILE: 'getProfile',
   UPDATE_PROFILE_PIC: 'updateProfilePic',
@@ -118,4 +131,19 @@ export const SERVER_EVENTS = {
 
   // Leaderboard
   LEADERBOARD_RESPONSE: 'leaderboardResponse',
+
+  // Tournament
+  TOURNAMENT_CREATED: 'tournamentCreated',
+  TOURNAMENT_JOINED: 'tournamentJoined',
+  TOURNAMENT_PLAYER_JOINED: 'tournamentPlayerJoined',
+  TOURNAMENT_PLAYER_LEFT: 'tournamentPlayerLeft',
+  TOURNAMENT_READY_UPDATE: 'tournamentReadyUpdate',
+  TOURNAMENT_MESSAGE: 'tournamentMessage',
+  TOURNAMENT_ROUND_START: 'tournamentRoundStart',
+  TOURNAMENT_GAME_ASSIGNMENT: 'tournamentGameAssignment',
+  TOURNAMENT_GAME_COMPLETE: 'tournamentGameComplete',
+  TOURNAMENT_ROUND_COMPLETE: 'tournamentRoundComplete',
+  TOURNAMENT_COMPLETE: 'tournamentComplete',
+  TOURNAMENT_LEFT: 'tournamentLeft',
+  ACTIVE_TOURNAMENT_FOUND: 'activeTournamentFound',
 };

--- a/client/src/handlers/index.js
+++ b/client/src/handlers/index.js
@@ -11,6 +11,7 @@ import { registerGameHandlers, cleanupGameHandlers as cleanupGame } from './game
 import { registerChatHandlers } from './chatHandlers.js';
 import { registerProfileHandlers } from './profileHandlers.js';
 import { registerLeaderboardHandlers } from './leaderboardHandlers.js';
+import { registerTournamentHandlers } from './tournamentHandlers.js';
 
 /**
  * Register all socket event handlers.
@@ -85,6 +86,20 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     // Leaderboard callbacks
     onLeaderboardReceived,
     onLeaderboardError,
+    // Tournament callbacks
+    onTournamentCreated,
+    onTournamentJoined,
+    onTournamentPlayerJoined,
+    onTournamentPlayerLeft,
+    onTournamentReadyUpdate,
+    onTournamentMessage,
+    onTournamentRoundStart,
+    onTournamentGameAssignment,
+    onTournamentGameComplete,
+    onTournamentRoundComplete,
+    onTournamentComplete,
+    onTournamentLeft,
+    onActiveTournamentFound,
   } = callbacks;
 
   // Register auth handlers
@@ -167,6 +182,23 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onLeaderboardReceived,
     onLeaderboardError,
   });
+
+  // Register tournament handlers
+  registerTournamentHandlers(socketManager, {
+    onTournamentCreated,
+    onTournamentJoined,
+    onTournamentPlayerJoined,
+    onTournamentPlayerLeft,
+    onTournamentReadyUpdate,
+    onTournamentMessage,
+    onTournamentRoundStart,
+    onTournamentGameAssignment,
+    onTournamentGameComplete,
+    onTournamentRoundComplete,
+    onTournamentComplete,
+    onTournamentLeft,
+    onActiveTournamentFound,
+  });
 }
 
 /**
@@ -183,3 +215,4 @@ export { registerGameHandlers } from './gameHandlers.js';
 export { registerChatHandlers } from './chatHandlers.js';
 export { registerProfileHandlers } from './profileHandlers.js';
 export { registerLeaderboardHandlers } from './leaderboardHandlers.js';
+export { registerTournamentHandlers } from './tournamentHandlers.js';

--- a/client/src/handlers/tournamentHandlers.js
+++ b/client/src/handlers/tournamentHandlers.js
@@ -1,0 +1,100 @@
+/**
+ * Tournament socket event handlers.
+ *
+ * Handles: tournamentCreated, tournamentJoined, tournamentPlayerJoined,
+ *          tournamentPlayerLeft, tournamentReadyUpdate, tournamentMessage,
+ *          tournamentRoundStart, tournamentGameAssignment, tournamentGameComplete,
+ *          tournamentRoundComplete, tournamentComplete, tournamentLeft,
+ *          activeTournamentFound
+ */
+
+import { SERVER_EVENTS } from '../constants/events.js';
+
+/**
+ * Register tournament handlers.
+ *
+ * @param {SocketManager} socketManager - Socket manager instance
+ * @param {Object} callbacks - UI callbacks
+ */
+export function registerTournamentHandlers(socketManager, callbacks = {}) {
+  const {
+    onTournamentCreated,
+    onTournamentJoined,
+    onTournamentPlayerJoined,
+    onTournamentPlayerLeft,
+    onTournamentReadyUpdate,
+    onTournamentMessage,
+    onTournamentRoundStart,
+    onTournamentGameAssignment,
+    onTournamentGameComplete,
+    onTournamentRoundComplete,
+    onTournamentComplete,
+    onTournamentLeft,
+    onActiveTournamentFound,
+  } = callbacks;
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_CREATED, (data) => {
+    console.log('Tournament created:', data);
+    onTournamentCreated?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_JOINED, (data) => {
+    console.log('Tournament joined:', data);
+    onTournamentJoined?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_PLAYER_JOINED, (data) => {
+    console.log('Tournament player joined:', data);
+    onTournamentPlayerJoined?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_PLAYER_LEFT, (data) => {
+    console.log('Tournament player left:', data);
+    onTournamentPlayerLeft?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_READY_UPDATE, (data) => {
+    console.log('Tournament ready update:', data);
+    onTournamentReadyUpdate?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_MESSAGE, (data) => {
+    console.log('Tournament message:', data);
+    onTournamentMessage?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_ROUND_START, (data) => {
+    console.log('Tournament round start:', data);
+    onTournamentRoundStart?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_GAME_ASSIGNMENT, (data) => {
+    console.log('Tournament game assignment:', data);
+    onTournamentGameAssignment?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_GAME_COMPLETE, (data) => {
+    console.log('Tournament game complete:', data);
+    onTournamentGameComplete?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_ROUND_COMPLETE, (data) => {
+    console.log('Tournament round complete:', data);
+    onTournamentRoundComplete?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_COMPLETE, (data) => {
+    console.log('Tournament complete:', data);
+    onTournamentComplete?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_LEFT, (data) => {
+    console.log('Tournament left:', data);
+    onTournamentLeft?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.ACTIVE_TOURNAMENT_FOUND, (data) => {
+    console.log('Active tournament found:', data);
+    onActiveTournamentFound?.(data);
+  });
+}

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -2952,11 +2952,13 @@ function initializeApp() {
     // Tournament callbacks
     onTournamentCreated: (data) => {
       gameState.tournamentId = data.tournamentId;
+      removeMainRoom();
       uiManager.showScreen(SCREENS.TOURNAMENT_LOBBY, data);
     },
 
     onTournamentJoined: (data) => {
       gameState.tournamentId = data.tournamentId;
+      removeMainRoom();
       uiManager.showScreen(SCREENS.TOURNAMENT_LOBBY, data);
     },
 

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -2360,8 +2360,9 @@ function initializeApp() {
     // Draw phase - handled by DrawManager
     onStartDraw: (data) => {
       console.log('🎴 onStartDraw callback');
-      // Remove waiting screen
+      // Remove waiting screen and tournament lobby
       uiManager.removeWaitingScreen();
+      removeTournamentLobby();
 
       // Use DrawManager via scene handler
       const scene = getGameScene();
@@ -2389,10 +2390,11 @@ function initializeApp() {
     },
     onCreateUI: (data) => {
       console.log('🎨 onCreateUI callback');
-      // Remove waiting screen and lobby/main room UI
+      // Remove waiting screen and lobby/main room/tournament UI
       uiManager.removeWaitingScreen();
       removeMainRoom();
       removeGameLobby();
+      removeTournamentLobby();
 
       // Clean up draw phase via DrawManager with fade transition
       const scene = getGameScene();

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -3024,7 +3024,7 @@ function initializeApp() {
 
     onTournamentLeft: () => {
       gameState.tournamentId = null;
-      // Main room transition is handled by the mainRoomJoined event
+      removeTournamentLobby();
     },
 
     onActiveTournamentFound: (data) => {

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -2027,8 +2027,9 @@ function initializeApp() {
       // If this is the full game state (not just a notification about another spectator)
       if (data.players && data.trump) {
         try {
-        // Remove main room UI
+        // Remove main room and tournament lobby UI
         removeMainRoom();
+        removeTournamentLobby();
 
         // Mark as spectator in game state
         gameState.isSpectator = true;

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -32,6 +32,8 @@ import { showMainRoom, addMainRoomChatMessage, updateLobbyList, removeMainRoom, 
 import { showGameLobby, updateLobbyPlayersList, addLobbyChatMessage, removeGameLobby, getCurrentLobbyId, getIsPlayerReady, getLobbyUserColors } from './ui/screens/GameLobby.js';
 import { showProfilePage, updateProfilePicDisplay, updateCustomProfilePicDisplay, removeProfilePage, isProfilePageVisible } from './ui/screens/ProfilePage.js';
 import { showLeaderboardPage, removeLeaderboardPage, isLeaderboardPageVisible } from './ui/screens/LeaderboardPage.js';
+import { showTournamentLobby, removeTournamentLobby, addTournamentChatMessage, updateTournamentPlayers, updateTournamentScoreboardUI, updateTournamentRoundIndicator, updateTournamentActiveGames, setTournamentPhase } from './ui/screens/TournamentLobby.js';
+import { showTournamentResultsOverlay, removeTournamentResultsOverlay } from './ui/components/TournamentScoreboard.js';
 import { UIManager, SCREENS, getUIManager, initializeUIManager, resetUIManager } from './ui/UIManager.js';
 
 // Phaser
@@ -1861,6 +1863,10 @@ function initializeApp() {
         console.log(`Active game found: ${data.activeGameId}, attempting to rejoin...`);
         sessionStorage.setItem('gameId', data.activeGameId);
         socket.emit('rejoinGame', { gameId: data.activeGameId, username: data.username });
+      } else if (data.activeTournamentId) {
+        console.log(`Active tournament found: ${data.activeTournamentId}, rejoining...`);
+        gameState.tournamentId = data.activeTournamentId;
+        socket.emit('joinTournament', { tournamentId: data.activeTournamentId });
       } else {
         // Go to main room
         socket.emit('joinMainRoom');
@@ -1959,7 +1965,7 @@ function initializeApp() {
       addMainRoomChatMessage(data.username, data.message);
     },
     onLobbiesUpdated: (data) => {
-      updateLobbyList(data.lobbies, socket, data.inProgressGames);
+      updateLobbyList(data.lobbies, socket, data.inProgressGames, data.tournaments);
     },
     onMainRoomPlayerJoined: (data) => {
       updateMainRoomOnlineCount(data.onlineCount);
@@ -2544,11 +2550,16 @@ function initializeApp() {
       const { teamName, oppName } = getTeamNames(position, playerData);
       window.updateGameLogScoreFromLegacy(teamName, oppName, teamScore, oppScore);
 
+      // Determine return flow: tournament game returns to tournament, normal game to main room
+      const isTournamentGame = !!data.tournamentId || !!gameState.tournamentId;
+      const savedTournamentId = data.tournamentId || gameState.tournamentId;
+
       // Show final score overlay
       showFinalScoreOverlay({
         teamScore: teamScore,
         oppScore: oppScore,
         playerStats: data.playerStats,
+        buttonText: isTournamentGame ? 'Return to Tournament' : undefined,
         onReturnToLobby: () => {
           // Remove game feed/log
           let gameFeed = document.getElementById("gameFeed");
@@ -2583,8 +2594,15 @@ function initializeApp() {
             scene.scene.restart();
           }
           // Reset game state for next game
+          const tournamentId = savedTournamentId;
           resetGameState();
-          socket.emit("joinMainRoom");
+
+          if (isTournamentGame && tournamentId) {
+            gameState.tournamentId = tournamentId;
+            socket.emit("returnToTournament");
+          } else {
+            socket.emit("joinMainRoom");
+          }
         }
       });
 
@@ -2930,6 +2948,89 @@ function initializeApp() {
     onLeaderboardError: (message) => {
       showError(message || 'Failed to load leaderboard');
     },
+
+    // Tournament callbacks
+    onTournamentCreated: (data) => {
+      gameState.tournamentId = data.tournamentId;
+      uiManager.showScreen(SCREENS.TOURNAMENT_LOBBY, data);
+    },
+
+    onTournamentJoined: (data) => {
+      gameState.tournamentId = data.tournamentId;
+      uiManager.showScreen(SCREENS.TOURNAMENT_LOBBY, data);
+    },
+
+    onTournamentPlayerJoined: (data) => {
+      updateTournamentPlayers(data.players, gameState.username);
+    },
+
+    onTournamentPlayerLeft: (data) => {
+      updateTournamentPlayers(data.players, gameState.username);
+      if (data.newCreator) {
+        showInfo(`${data.newCreator} is now the tournament host`);
+      }
+    },
+
+    onTournamentReadyUpdate: (data) => {
+      updateTournamentPlayers(data.players, gameState.username);
+    },
+
+    onTournamentMessage: (data) => {
+      addTournamentChatMessage(data.username, data.message, data.isSpectator);
+    },
+
+    onTournamentRoundStart: (data) => {
+      updateTournamentRoundIndicator(data.roundNumber, data.totalRounds);
+      setTournamentPhase('round_active');
+    },
+
+    onTournamentGameAssignment: (data) => {
+      // Store tournament context for game end flow
+      gameState.tournamentId = data.tournamentId;
+      console.log(`Assigned to tournament game: ${data.gameId} (round ${data.roundNumber})`);
+    },
+
+    onTournamentGameComplete: (data) => {
+      // Update active games in tournament lobby (if visible)
+      if (data.activeGames) {
+        updateTournamentActiveGames(data.activeGames, socket);
+      }
+      if (data.scoreboard) {
+        updateTournamentScoreboardUI(data.scoreboard, data.currentRound, data.totalRounds);
+      }
+    },
+
+    onTournamentRoundComplete: (data) => {
+      setTournamentPhase('between_rounds');
+      if (data.scoreboard) {
+        updateTournamentScoreboardUI(data.scoreboard, data.currentRound, data.totalRounds);
+      }
+      updateTournamentRoundIndicator(data.currentRound, data.totalRounds);
+    },
+
+    onTournamentComplete: (data) => {
+      const winner = data.scoreboard && data.scoreboard.length > 0
+        ? data.scoreboard[0].username : null;
+      showTournamentResultsOverlay({
+        scoreboard: data.scoreboard,
+        winner,
+        onReturn: () => {
+          gameState.tournamentId = null;
+          removeTournamentLobby();
+          socket.emit('joinMainRoom');
+        }
+      });
+    },
+
+    onTournamentLeft: () => {
+      gameState.tournamentId = null;
+      // Main room transition is handled by the mainRoomJoined event
+    },
+
+    onActiveTournamentFound: (data) => {
+      gameState.tournamentId = data.tournamentId;
+      uiManager.showScreen(SCREENS.TOURNAMENT_LOBBY, data);
+    },
   });
 
   // Note: window.socket and window.socketManager are already set at module level above
@@ -3047,6 +3148,10 @@ socket.on('restoreSessionResponse', (data) => {
       console.log(`Active game found: ${data.activeGameId}, attempting to rejoin...`);
       sessionStorage.setItem('gameId', data.activeGameId);
       socket.emit('rejoinGame', { gameId: data.activeGameId, username: data.username });
+    } else if (data.activeTournamentId) {
+      console.log(`Active tournament found: ${data.activeTournamentId}, rejoining...`);
+      gameState.tournamentId = data.activeTournamentId;
+      socket.emit('joinTournament', { tournamentId: data.activeTournamentId });
     } else {
       // Go to main room
       console.log('Session restored, joining main room');

--- a/client/src/state/GameState.js
+++ b/client/src/state/GameState.js
@@ -41,6 +41,7 @@ export class GameState {
 
     // Game info
     this.gameId = null;
+    this.tournamentId = null;
     this.phase = PHASE.NONE;
     this.currentHand = 0;
     this.dealer = null;

--- a/client/src/ui/UIManager.js
+++ b/client/src/ui/UIManager.js
@@ -9,8 +9,10 @@ import { showSignInScreen } from './screens/SignIn.js';
 import { showRegisterScreen } from './screens/Register.js';
 import { showMainRoom, removeMainRoom } from './screens/MainRoom.js';
 import { showGameLobby, removeGameLobby } from './screens/GameLobby.js';
+import { showTournamentLobby, removeTournamentLobby } from './screens/TournamentLobby.js';
 import { removePlayerQueue } from './components/PlayerQueue.js';
 import { removeFinalScoreOverlay } from './components/ScoreModal.js';
+import { removeTournamentResultsOverlay } from './components/TournamentScoreboard.js';
 
 /**
  * Available screen types.
@@ -21,6 +23,7 @@ export const SCREENS = {
   REGISTER: 'register',
   MAIN_ROOM: 'mainRoom',
   GAME_LOBBY: 'gameLobby',
+  TOURNAMENT_LOBBY: 'tournamentLobby',
   GAME: 'game',
 };
 
@@ -39,6 +42,7 @@ class UIManager {
       [SCREENS.REGISTER]: this._cleanupRegister.bind(this),
       [SCREENS.MAIN_ROOM]: this._cleanupMainRoom.bind(this),
       [SCREENS.GAME_LOBBY]: this._cleanupGameLobby.bind(this),
+      [SCREENS.TOURNAMENT_LOBBY]: this._cleanupTournamentLobby.bind(this),
       [SCREENS.GAME]: this._cleanupGame.bind(this),
     };
   }
@@ -100,6 +104,9 @@ class UIManager {
       case SCREENS.GAME_LOBBY:
         this._showGameLobby(data);
         break;
+      case SCREENS.TOURNAMENT_LOBBY:
+        this._showTournamentLobby(data);
+        break;
       case SCREENS.GAME:
         this._showGame(data);
         break;
@@ -149,6 +156,14 @@ class UIManager {
     showGameLobby(data, this._socket, this._username);
   }
 
+  _showTournamentLobby(data) {
+    if (!this._socket) {
+      console.warn('UIManager: Socket not initialized');
+      return;
+    }
+    showTournamentLobby(data, this._socket, this._username);
+  }
+
   _showGame(data) {
     // Game screen is managed by Phaser, just clean up other UI
     this._cleanupAllOverlays();
@@ -182,6 +197,10 @@ class UIManager {
     removeGameLobby();
   }
 
+  _cleanupTournamentLobby() {
+    removeTournamentLobby();
+  }
+
   _cleanupGame() {
     // Remove game-specific UI elements
     const gameFeed = document.getElementById('gameFeed');
@@ -207,8 +226,10 @@ class UIManager {
   _cleanupAllOverlays() {
     removeMainRoom();
     removeGameLobby();
+    removeTournamentLobby();
     removePlayerQueue();
     removeFinalScoreOverlay();
+    removeTournamentResultsOverlay();
 
     // Remove vignettes
     document.querySelectorAll('.vignette').forEach((el) => el.remove());

--- a/client/src/ui/components/ScoreModal.js
+++ b/client/src/ui/components/ScoreModal.js
@@ -122,7 +122,7 @@ export function formatGameEndMessages(options) {
  * @param {Function} options.onReturnToLobby - Called when user clicks return button
  * @returns {Object} { overlay, destroy }
  */
-export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onReturnToLobby }) {
+export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onReturnToLobby, buttonText }) {
   // Determine winner message
   let resultMsg;
   let resultColor;
@@ -241,7 +241,7 @@ export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onRetu
 
   // Return button
   const returnBtn = document.createElement('button');
-  returnBtn.textContent = 'Return to Lobby';
+  returnBtn.textContent = buttonText || 'Return to Lobby';
   returnBtn.style.cssText = `
     padding: 16px 32px;
     font-size: 18px;

--- a/client/src/ui/components/TournamentScoreboard.js
+++ b/client/src/ui/components/TournamentScoreboard.js
@@ -1,0 +1,211 @@
+/**
+ * Tournament Scoreboard Component
+ *
+ * Reusable scoreboard table and final results overlay.
+ */
+
+/**
+ * Create a tournament scoreboard table element.
+ *
+ * @param {Array} scoreboard - Sorted array of { username, totalScore, roundScores }
+ * @param {number} currentRound - Current round number (1-4)
+ * @param {number} totalRounds - Total rounds (4)
+ * @returns {HTMLElement} Scoreboard container div
+ */
+export function createTournamentScoreboard(scoreboard, currentRound, totalRounds) {
+  const container = document.createElement('div');
+  container.className = 'tournament-scoreboard';
+  container.style.cssText = `
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 8px;
+    padding: 15px;
+    overflow-x: auto;
+  `;
+
+  if (!scoreboard || scoreboard.length === 0) {
+    const emptyMsg = document.createElement('div');
+    emptyMsg.style.color = '#9ca3af';
+    emptyMsg.style.textAlign = 'center';
+    emptyMsg.style.padding = '10px';
+    emptyMsg.textContent = 'No scores yet';
+    container.appendChild(emptyMsg);
+    return container;
+  }
+
+  const table = document.createElement('table');
+  table.style.cssText = `
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+  `;
+
+  // Header
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  headerRow.style.borderBottom = '1px solid #4a5568';
+
+  const headers = ['#', 'Player'];
+  for (let r = 1; r <= totalRounds; r++) {
+    headers.push(`R${r}`);
+  }
+  headers.push('Total');
+
+  headers.forEach((text, i) => {
+    const th = document.createElement('th');
+    th.textContent = text;
+    th.style.cssText = `
+      padding: 8px 6px;
+      text-align: ${i <= 1 ? 'left' : 'center'};
+      color: #9ca3af;
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      font-weight: normal;
+    `;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  // Body
+  const tbody = document.createElement('tbody');
+  scoreboard.forEach((entry, index) => {
+    const row = document.createElement('tr');
+    row.style.borderBottom = '1px solid #374151';
+
+    // Rank
+    const rankTd = document.createElement('td');
+    rankTd.textContent = index + 1;
+    rankTd.style.cssText = 'padding: 8px 6px; color: #9ca3af;';
+    if (index === 0 && currentRound > 0) {
+      rankTd.style.color = '#fbbf24';
+      rankTd.style.fontWeight = 'bold';
+    }
+    row.appendChild(rankTd);
+
+    // Player name
+    const nameTd = document.createElement('td');
+    nameTd.textContent = entry.username;
+    nameTd.style.cssText = 'padding: 8px 6px; color: #fff; font-weight: 500;';
+    if (index === 0 && currentRound > 0) {
+      nameTd.style.color = '#fbbf24';
+    }
+    row.appendChild(nameTd);
+
+    // Round scores
+    for (let r = 0; r < totalRounds; r++) {
+      const td = document.createElement('td');
+      td.style.cssText = 'padding: 8px 6px; text-align: center; color: #e5e7eb;';
+      if (entry.roundScores && entry.roundScores[r] !== undefined) {
+        td.textContent = entry.roundScores[r];
+      } else {
+        td.textContent = '-';
+        td.style.color = '#6b7280';
+      }
+      row.appendChild(td);
+    }
+
+    // Total
+    const totalTd = document.createElement('td');
+    totalTd.textContent = entry.totalScore;
+    totalTd.style.cssText = 'padding: 8px 6px; text-align: center; color: #4ade80; font-weight: bold;';
+    row.appendChild(totalTd);
+
+    tbody.appendChild(row);
+  });
+
+  table.appendChild(tbody);
+  container.appendChild(table);
+  return container;
+}
+
+/**
+ * Show full-screen tournament results overlay.
+ *
+ * @param {Object} options
+ * @param {Array} options.scoreboard - Final sorted scoreboard
+ * @param {string} options.winner - Winner's username
+ * @param {Function} options.onReturn - Called when user clicks return
+ */
+export function showTournamentResultsOverlay({ scoreboard, winner, onReturn }) {
+  removeTournamentResultsOverlay();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'tournamentResultsOverlay';
+  overlay.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.9);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+  `;
+
+  // Title
+  const title = document.createElement('div');
+  title.textContent = 'Tournament Complete!';
+  title.style.cssText = `
+    font-size: 36px;
+    font-weight: bold;
+    color: #fbbf24;
+    margin-bottom: 10px;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+  `;
+  overlay.appendChild(title);
+
+  // Winner
+  if (winner) {
+    const winnerDiv = document.createElement('div');
+    winnerDiv.textContent = `Winner: ${winner}`;
+    winnerDiv.style.cssText = `
+      font-size: 24px;
+      color: #4ade80;
+      margin-bottom: 30px;
+    `;
+    overlay.appendChild(winnerDiv);
+  }
+
+  // Scoreboard
+  const scoreboardEl = createTournamentScoreboard(scoreboard, 4, 4);
+  scoreboardEl.style.maxWidth = '600px';
+  scoreboardEl.style.width = '90vw';
+  scoreboardEl.style.marginBottom = '30px';
+  overlay.appendChild(scoreboardEl);
+
+  // Return button
+  const returnBtn = document.createElement('button');
+  returnBtn.textContent = 'Return to Lobby';
+  returnBtn.style.cssText = `
+    padding: 16px 32px;
+    font-size: 18px;
+    font-weight: bold;
+    background: #dc2626;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.2s;
+  `;
+  returnBtn.onmouseover = () => { returnBtn.style.background = '#b91c1c'; };
+  returnBtn.onmouseout = () => { returnBtn.style.background = '#dc2626'; };
+  returnBtn.onclick = () => {
+    removeTournamentResultsOverlay();
+    onReturn?.();
+  };
+  overlay.appendChild(returnBtn);
+
+  document.body.appendChild(overlay);
+}
+
+/**
+ * Remove tournament results overlay.
+ */
+export function removeTournamentResultsOverlay() {
+  const overlay = document.getElementById('tournamentResultsOverlay');
+  if (overlay) overlay.remove();
+}

--- a/client/src/ui/screens/TournamentLobby.js
+++ b/client/src/ui/screens/TournamentLobby.js
@@ -1,0 +1,650 @@
+/**
+ * Tournament Lobby Screen
+ *
+ * Lobby for tournament players to gather, chat, ready up, and view scoreboard.
+ * Supports unbounded player count (unlike the 4-player GameLobby).
+ */
+
+import { generateDistinctColor, getUsernameColor } from '../../utils/colors.js';
+import { createTournamentScoreboard } from '../components/TournamentScoreboard.js';
+
+/**
+ * Module state
+ */
+let tournamentUserColors = {};
+let currentTournamentId = null;
+let isPlayerReady = false;
+
+/**
+ * Show the tournament lobby screen.
+ *
+ * @param {Object} data - Tournament state from server
+ * @param {Object} socket - Socket instance
+ * @param {string} username - Current player's username
+ */
+export function showTournamentLobby(data, socket, username) {
+  console.log('Showing tournament lobby...', data);
+  currentTournamentId = data.tournamentId;
+  isPlayerReady = false;
+
+  // Remove any existing tournament lobby
+  removeTournamentLobby();
+
+  const isSpectator = data.isSpectator || false;
+  const isCreator = data.creatorUsername === username;
+
+  // Create container
+  const container = document.createElement('div');
+  container.id = 'tournamentLobbyContainer';
+  container.style.cssText = `
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(26, 26, 46, 0.95);
+    color: #fff;
+    padding: 25px;
+    border-radius: 12px;
+    border: 2px solid #fbbf24;
+    font-size: 16px;
+    width: 800px;
+    max-width: 95vw;
+    height: 650px;
+    max-height: 90vh;
+    box-sizing: border-box;
+    font-family: Arial, sans-serif;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+  `;
+
+  // Header row
+  const headerRow = document.createElement('div');
+  headerRow.style.cssText = `
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 15px;
+    flex-shrink: 0;
+  `;
+
+  const header = document.createElement('div');
+  header.style.cssText = 'font-size: 24px; font-weight: bold; color: #fbbf24;';
+  header.textContent = data.name || 'Tournament';
+  headerRow.appendChild(header);
+
+  // Round indicator
+  const roundIndicator = document.createElement('div');
+  roundIndicator.id = 'tournamentRoundIndicator';
+  roundIndicator.style.cssText = 'font-size: 14px; color: #9ca3af;';
+  if (data.currentRound > 0) {
+    roundIndicator.textContent = `Round ${data.currentRound} of ${data.totalRounds}`;
+  } else {
+    roundIndicator.textContent = 'Waiting to start';
+  }
+  headerRow.appendChild(roundIndicator);
+
+  container.appendChild(headerRow);
+
+  // Main content area (two panels)
+  const contentArea = document.createElement('div');
+  contentArea.style.cssText = `
+    display: flex;
+    gap: 15px;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  `;
+
+  // Left panel — Players + Chat
+  const leftPanel = document.createElement('div');
+  leftPanel.style.cssText = `
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  `;
+
+  // Players list (scrollable)
+  const playersDiv = document.createElement('div');
+  playersDiv.id = 'tournamentPlayersList';
+  playersDiv.style.cssText = `
+    max-height: 180px;
+    overflow-y: auto;
+    margin-bottom: 10px;
+    text-align: left;
+    padding: 10px;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 8px;
+    flex-shrink: 0;
+  `;
+  updateTournamentPlayersList(playersDiv, data.players, username, isCreator);
+  leftPanel.appendChild(playersDiv);
+
+  // Chat area
+  const chatArea = document.createElement('div');
+  chatArea.id = 'tournamentChatArea';
+  chatArea.style.cssText = `
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 8px;
+    padding: 10px;
+    margin-bottom: 10px;
+    text-align: left;
+    font-size: 14px;
+    word-break: break-word;
+    min-height: 0;
+  `;
+
+  // Add existing messages
+  if (data.messages) {
+    data.messages.forEach(msg => {
+      if (!tournamentUserColors[msg.username]) {
+        tournamentUserColors[msg.username] = generateDistinctColor(
+          msg.username, Object.values(tournamentUserColors)
+        );
+      }
+    });
+    data.messages.forEach(msg => {
+      appendChatMessage(chatArea, msg.username, msg.message, msg.isSpectator);
+    });
+  }
+  leftPanel.appendChild(chatArea);
+
+  // Chat input
+  const chatInputRow = document.createElement('div');
+  chatInputRow.style.cssText = 'display: flex; gap: 8px; flex-shrink: 0;';
+
+  const chatInput = document.createElement('input');
+  chatInput.id = 'tournamentChatInput';
+  chatInput.type = 'text';
+  chatInput.placeholder = 'Type a message...';
+  chatInput.style.cssText = `
+    flex: 1;
+    padding: 8px;
+    border-radius: 6px;
+    border: 1px solid #4a5568;
+    background: #2d3748;
+    color: #fff;
+    font-size: 14px;
+  `;
+  chatInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && chatInput.value.trim()) {
+      socket.emit('tournamentChat', { message: chatInput.value.trim() });
+      chatInput.value = '';
+    }
+  });
+  chatInputRow.appendChild(chatInput);
+
+  const sendBtn = document.createElement('button');
+  sendBtn.textContent = 'Send';
+  sendBtn.style.cssText = `
+    padding: 8px 16px;
+    border-radius: 6px;
+    border: none;
+    background: #3b82f6;
+    color: #fff;
+    cursor: pointer;
+    font-size: 14px;
+  `;
+  sendBtn.addEventListener('click', () => {
+    if (chatInput.value.trim()) {
+      socket.emit('tournamentChat', { message: chatInput.value.trim() });
+      chatInput.value = '';
+    }
+  });
+  chatInputRow.appendChild(sendBtn);
+  leftPanel.appendChild(chatInputRow);
+
+  contentArea.appendChild(leftPanel);
+
+  // Right panel — Scoreboard + Active Games
+  const rightPanel = document.createElement('div');
+  rightPanel.style.cssText = `
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  `;
+
+  // Scoreboard section
+  const scoreboardHeader = document.createElement('div');
+  scoreboardHeader.style.cssText = 'font-size: 16px; font-weight: bold; color: #fbbf24; margin-bottom: 8px;';
+  scoreboardHeader.textContent = 'Scoreboard';
+  rightPanel.appendChild(scoreboardHeader);
+
+  const scoreboardContainer = document.createElement('div');
+  scoreboardContainer.id = 'tournamentScoreboardContainer';
+  scoreboardContainer.style.cssText = 'flex: 1; overflow-y: auto; margin-bottom: 10px; min-height: 0;';
+
+  const scoreboardEl = createTournamentScoreboard(
+    data.scoreboard || [],
+    data.currentRound,
+    data.totalRounds
+  );
+  scoreboardContainer.appendChild(scoreboardEl);
+  rightPanel.appendChild(scoreboardContainer);
+
+  // Active games section (visible during round_active)
+  const activeGamesContainer = document.createElement('div');
+  activeGamesContainer.id = 'tournamentActiveGames';
+  activeGamesContainer.style.cssText = `
+    max-height: 150px;
+    overflow-y: auto;
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 8px;
+    padding: 10px;
+    flex-shrink: 0;
+  `;
+  updateActiveGames(activeGamesContainer, data.activeGames || [], socket);
+  rightPanel.appendChild(activeGamesContainer);
+
+  contentArea.appendChild(rightPanel);
+  container.appendChild(contentArea);
+
+  // Button row
+  const buttonRow = document.createElement('div');
+  buttonRow.id = 'tournamentButtonRow';
+  buttonRow.style.cssText = `
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-top: 15px;
+    flex-shrink: 0;
+  `;
+
+  if (!isSpectator) {
+    // Ready button
+    const readyBtn = document.createElement('button');
+    readyBtn.id = 'tournamentReadyBtn';
+    readyBtn.style.cssText = `
+      padding: 12px 30px;
+      font-size: 16px;
+      font-weight: bold;
+      border-radius: 8px;
+      border: none;
+      color: #000;
+      background: #4ade80;
+      cursor: pointer;
+    `;
+    readyBtn.textContent = 'Ready';
+
+    // Sync with server state
+    const myPlayer = data.players?.find(p => p.username === username);
+    if (myPlayer?.ready) {
+      isPlayerReady = true;
+      readyBtn.textContent = 'Ready!';
+      readyBtn.style.background = '#22c55e';
+    }
+
+    // Hide ready button during active rounds
+    if (data.phase === 'round_active') {
+      readyBtn.style.display = 'none';
+    }
+
+    readyBtn.addEventListener('click', () => {
+      if (!isPlayerReady) {
+        socket.emit('tournamentReady');
+        readyBtn.textContent = 'Ready!';
+        readyBtn.style.background = '#22c55e';
+        isPlayerReady = true;
+      } else {
+        socket.emit('tournamentUnready');
+        readyBtn.textContent = 'Ready';
+        readyBtn.style.background = '#4ade80';
+        isPlayerReady = false;
+      }
+    });
+    buttonRow.appendChild(readyBtn);
+
+    // Begin Tournament / Begin Next Round (creator only)
+    if (isCreator) {
+      const beginBtn = document.createElement('button');
+      beginBtn.id = 'tournamentBeginBtn';
+      beginBtn.style.cssText = `
+        padding: 12px 30px;
+        font-size: 16px;
+        font-weight: bold;
+        border-radius: 8px;
+        border: none;
+        color: #fff;
+        background: #6b7280;
+        cursor: not-allowed;
+      `;
+
+      if (data.phase === 'lobby') {
+        beginBtn.textContent = 'Begin Tournament';
+        beginBtn.disabled = true;
+      } else if (data.phase === 'between_rounds') {
+        beginBtn.textContent = 'Begin Next Round';
+        beginBtn.disabled = true;
+      } else {
+        beginBtn.style.display = 'none';
+      }
+
+      beginBtn.addEventListener('click', () => {
+        if (beginBtn.disabled) return;
+        if (data.phase === 'lobby' || currentPhase === 'lobby') {
+          socket.emit('beginTournament');
+        } else {
+          socket.emit('beginNextRound');
+        }
+        beginBtn.disabled = true;
+        beginBtn.style.background = '#6b7280';
+        beginBtn.style.cursor = 'not-allowed';
+      });
+      buttonRow.appendChild(beginBtn);
+    }
+
+    // Leave button
+    const leaveBtn = document.createElement('button');
+    leaveBtn.textContent = 'Leave';
+    leaveBtn.style.cssText = `
+      padding: 12px 24px;
+      font-size: 16px;
+      border-radius: 8px;
+      border: none;
+      background: #dc2626;
+      color: #fff;
+      cursor: pointer;
+    `;
+    leaveBtn.addEventListener('click', () => {
+      socket.emit('leaveTournament');
+    });
+    buttonRow.appendChild(leaveBtn);
+  } else {
+    // Spectator — just a leave button
+    const leaveBtn = document.createElement('button');
+    leaveBtn.textContent = 'Leave';
+    leaveBtn.style.cssText = `
+      padding: 12px 24px;
+      font-size: 16px;
+      border-radius: 8px;
+      border: none;
+      background: #dc2626;
+      color: #fff;
+      cursor: pointer;
+    `;
+    leaveBtn.addEventListener('click', () => {
+      socket.emit('leaveTournament');
+    });
+    buttonRow.appendChild(leaveBtn);
+  }
+
+  container.appendChild(buttonRow);
+  document.body.appendChild(container);
+
+  // Store phase for begin button logic
+  container.dataset.phase = data.phase;
+}
+
+// Track current phase at module level for begin button handler
+let currentPhase = 'lobby';
+
+/**
+ * Update the players list in the tournament lobby.
+ */
+function updateTournamentPlayersList(container, players, currentUsername, isCreator) {
+  if (!container) {
+    container = document.getElementById('tournamentPlayersList');
+  }
+  if (!container) return;
+  container.innerHTML = '';
+
+  const header = document.createElement('div');
+  header.textContent = `Players (${players?.length || 0}):`;
+  header.style.cssText = 'font-weight: bold; margin-bottom: 8px; color: #9ca3af;';
+  container.appendChild(header);
+
+  if (!players || players.length === 0) return;
+
+  players.forEach(player => {
+    const row = document.createElement('div');
+    row.style.cssText = `
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 5px 0;
+      border-bottom: 1px solid #374151;
+    `;
+
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = player.username;
+    nameSpan.style.fontSize = '14px';
+    if (player.isCreator) {
+      nameSpan.style.color = '#fbbf24';
+      nameSpan.textContent += ' (host)';
+    }
+    row.appendChild(nameSpan);
+
+    const statusSpan = document.createElement('span');
+    statusSpan.style.fontSize = '13px';
+    if (player.ready) {
+      statusSpan.textContent = 'Ready';
+      statusSpan.style.color = '#4ade80';
+    } else {
+      statusSpan.textContent = 'Waiting';
+      statusSpan.style.color = '#9ca3af';
+    }
+    row.appendChild(statusSpan);
+
+    container.appendChild(row);
+  });
+}
+
+/**
+ * Update the active games panel.
+ */
+function updateActiveGames(container, activeGames, socket) {
+  if (!container) {
+    container = document.getElementById('tournamentActiveGames');
+  }
+  if (!container) return;
+  container.innerHTML = '';
+
+  if (!activeGames || activeGames.length === 0) {
+    container.style.display = 'none';
+    return;
+  }
+
+  container.style.display = 'block';
+
+  const header = document.createElement('div');
+  header.textContent = 'Active Games';
+  header.style.cssText = 'font-weight: bold; color: #60a5fa; margin-bottom: 8px; font-size: 14px;';
+  container.appendChild(header);
+
+  activeGames.forEach(game => {
+    if (game.status !== 'active') return;
+
+    const gameRow = document.createElement('div');
+    gameRow.style.cssText = `
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 6px 0;
+      border-bottom: 1px solid #374151;
+    `;
+
+    const info = document.createElement('span');
+    info.textContent = `${game.humanPlayers.join(', ')}${game.botCount > 0 ? ` +${game.botCount} bot${game.botCount > 1 ? 's' : ''}` : ''}`;
+    info.style.cssText = 'font-size: 13px; color: #e5e7eb;';
+    gameRow.appendChild(info);
+
+    const spectateBtn = document.createElement('button');
+    spectateBtn.textContent = 'Watch';
+    spectateBtn.style.cssText = `
+      padding: 4px 12px;
+      border-radius: 4px;
+      border: none;
+      background: #60a5fa;
+      color: #fff;
+      font-size: 12px;
+      cursor: pointer;
+    `;
+    spectateBtn.addEventListener('click', () => {
+      socket.emit('spectateTournamentGame', { gameId: game.gameId });
+    });
+    gameRow.appendChild(spectateBtn);
+
+    container.appendChild(gameRow);
+  });
+}
+
+/**
+ * Append a chat message to the chat area.
+ */
+function appendChatMessage(chatArea, username, message, isSpectator) {
+  if (!chatArea) {
+    chatArea = document.getElementById('tournamentChatArea');
+  }
+  if (!chatArea) return;
+
+  if (!tournamentUserColors[username]) {
+    tournamentUserColors[username] = generateDistinctColor(
+      username, Object.values(tournamentUserColors)
+    );
+  }
+
+  const msgDiv = document.createElement('div');
+  msgDiv.style.cssText = 'margin-bottom: 6px; word-wrap: break-word;';
+
+  const nameSpan = document.createElement('span');
+  nameSpan.textContent = username + ': ';
+  nameSpan.style.fontWeight = 'bold';
+  nameSpan.style.color = tournamentUserColors[username] || getUsernameColor(username);
+  if (isSpectator) {
+    nameSpan.style.opacity = '0.7';
+  }
+  msgDiv.appendChild(nameSpan);
+
+  const textSpan = document.createElement('span');
+  textSpan.textContent = message;
+  textSpan.style.color = '#e5e7eb';
+  msgDiv.appendChild(textSpan);
+
+  chatArea.appendChild(msgDiv);
+  chatArea.scrollTop = chatArea.scrollHeight;
+}
+
+/**
+ * Add a chat message to the tournament lobby.
+ */
+export function addTournamentChatMessage(username, message, isSpectator) {
+  appendChatMessage(null, username, message, isSpectator);
+}
+
+/**
+ * Update the tournament player list from external event.
+ */
+export function updateTournamentPlayers(players, currentUsername) {
+  const container = document.getElementById('tournamentPlayersList');
+  const lobbyContainer = document.getElementById('tournamentLobbyContainer');
+  const isCreator = lobbyContainer?.dataset?.isCreator === 'true';
+  updateTournamentPlayersList(container, players, currentUsername, isCreator);
+  updateBeginButton(players);
+}
+
+/**
+ * Update scoreboard from external event.
+ */
+export function updateTournamentScoreboardUI(scoreboard, currentRound, totalRounds) {
+  const container = document.getElementById('tournamentScoreboardContainer');
+  if (!container) return;
+  container.innerHTML = '';
+  const scoreboardEl = createTournamentScoreboard(scoreboard, currentRound, totalRounds);
+  container.appendChild(scoreboardEl);
+}
+
+/**
+ * Update round indicator.
+ */
+export function updateTournamentRoundIndicator(currentRound, totalRounds) {
+  const indicator = document.getElementById('tournamentRoundIndicator');
+  if (indicator) {
+    indicator.textContent = `Round ${currentRound} of ${totalRounds}`;
+  }
+}
+
+/**
+ * Update the begin button state.
+ */
+function updateBeginButton(players) {
+  const beginBtn = document.getElementById('tournamentBeginBtn');
+  if (!beginBtn) return;
+
+  const allReady = players && players.length > 0 && players.every(p => p.ready);
+
+  if (allReady) {
+    beginBtn.disabled = false;
+    beginBtn.style.background = '#fbbf24';
+    beginBtn.style.color = '#000';
+    beginBtn.style.cursor = 'pointer';
+  } else {
+    beginBtn.disabled = true;
+    beginBtn.style.background = '#6b7280';
+    beginBtn.style.color = '#fff';
+    beginBtn.style.cursor = 'not-allowed';
+  }
+}
+
+/**
+ * Update active games list from external event.
+ */
+export function updateTournamentActiveGames(activeGames, socket) {
+  updateActiveGames(null, activeGames, socket);
+}
+
+/**
+ * Set the phase state (used for begin button logic).
+ */
+export function setTournamentPhase(phase) {
+  currentPhase = phase;
+  const lobbyContainer = document.getElementById('tournamentLobbyContainer');
+  if (lobbyContainer) {
+    lobbyContainer.dataset.phase = phase;
+  }
+
+  const readyBtn = document.getElementById('tournamentReadyBtn');
+  const beginBtn = document.getElementById('tournamentBeginBtn');
+
+  if (phase === 'round_active') {
+    if (readyBtn) readyBtn.style.display = 'none';
+    if (beginBtn) beginBtn.style.display = 'none';
+  } else if (phase === 'between_rounds') {
+    if (readyBtn) {
+      readyBtn.style.display = '';
+      readyBtn.textContent = 'Ready';
+      readyBtn.style.background = '#4ade80';
+      isPlayerReady = false;
+    }
+    if (beginBtn) {
+      beginBtn.style.display = '';
+      beginBtn.textContent = 'Begin Next Round';
+      beginBtn.disabled = true;
+      beginBtn.style.background = '#6b7280';
+    }
+  }
+}
+
+/**
+ * Remove the tournament lobby screen.
+ */
+export function removeTournamentLobby() {
+  const lobby = document.getElementById('tournamentLobbyContainer');
+  if (lobby) lobby.remove();
+  currentTournamentId = null;
+  isPlayerReady = false;
+  tournamentUserColors = {};
+  currentPhase = 'lobby';
+}
+
+/**
+ * Get current tournament ID.
+ */
+export function getCurrentTournamentId() {
+  return currentTournamentId;
+}

--- a/server/game/TournamentState.js
+++ b/server/game/TournamentState.js
@@ -1,0 +1,457 @@
+/**
+ * Encapsulates all state for a single tournament instance.
+ * Manages tournament lifecycle: lobby → round_active → between_rounds → complete.
+ */
+
+const { v4: uuidv4 } = require('uuid');
+
+class TournamentState {
+    constructor(tournamentId, name, creatorSocketId, creatorUsername) {
+        this.tournamentId = tournamentId;
+        this.roomName = `tournament:${tournamentId}`;
+        this.name = name || `${creatorUsername}'s Tournament`;
+        this.createdBy = creatorSocketId;
+        this.creatorUsername = creatorUsername;
+        this.createdAt = Date.now();
+
+        // Phase: 'lobby' | 'round_active' | 'between_rounds' | 'complete'
+        this.phase = 'lobby';
+        this.currentRound = 0; // 0 = not started, 1-4 = round number
+        this.totalRounds = 4;
+
+        // Players: socketId → { username, pic, ready }
+        this.players = new Map();
+        this.readyPlayers = new Set();
+
+        // Chat messages (capped)
+        this.messages = [];
+        this.maxMessages = 100;
+
+        // Spectators: socketId → { username, pic }
+        this.spectators = new Map();
+
+        // Rounds data
+        this.rounds = [];
+
+        // Scoreboard: username → { totalScore, roundScores: [r1..r4], roundDetails: [...] }
+        this.scoreboard = {};
+
+        this._debugMode = process.env.NODE_ENV !== 'production';
+    }
+
+    // ========================================
+    // Player Management
+    // ========================================
+
+    addPlayer(socketId, username, pic) {
+        this.players.set(socketId, { username, pic, ready: false });
+        // Initialize scoreboard entry
+        if (!this.scoreboard[username]) {
+            this.scoreboard[username] = {
+                totalScore: 0,
+                roundScores: [],
+                roundDetails: []
+            };
+        }
+        this.logAction('addPlayer', { socketId, username });
+    }
+
+    removePlayer(socketId) {
+        const player = this.players.get(socketId);
+        if (!player) return null;
+
+        this.players.delete(socketId);
+        this.readyPlayers.delete(socketId);
+
+        this.logAction('removePlayer', { socketId, username: player.username });
+        return player;
+    }
+
+    getPlayerBySocketId(socketId) {
+        return this.players.get(socketId) || null;
+    }
+
+    getPlayerByUsername(username) {
+        for (const [socketId, player] of this.players.entries()) {
+            if (player.username === username) {
+                return { socketId, ...player };
+            }
+        }
+        return null;
+    }
+
+    getHumanPlayerCount() {
+        return this.players.size;
+    }
+
+    setReady(socketId) {
+        const player = this.players.get(socketId);
+        if (!player) return false;
+        player.ready = true;
+        this.readyPlayers.add(socketId);
+        return true;
+    }
+
+    unsetReady(socketId) {
+        const player = this.players.get(socketId);
+        if (!player) return false;
+        player.ready = false;
+        this.readyPlayers.delete(socketId);
+        return true;
+    }
+
+    allPlayersReady() {
+        if (this.players.size === 0) return false;
+        return this.readyPlayers.size === this.players.size;
+    }
+
+    resetAllReady() {
+        this.readyPlayers.clear();
+        for (const [, player] of this.players) {
+            player.ready = false;
+        }
+    }
+
+    /**
+     * Transfer creator role to next human player.
+     * @returns {{ socketId: string, username: string } | null} New creator, or null if no humans remain
+     */
+    transferCreator() {
+        // Find first player that isn't the current creator
+        for (const [socketId, player] of this.players.entries()) {
+            if (socketId !== this.createdBy) {
+                this.createdBy = socketId;
+                this.creatorUsername = player.username;
+                this.logAction('transferCreator', { newCreator: player.username });
+                return { socketId, username: player.username };
+            }
+        }
+        // Only one or zero players left
+        if (this.players.size === 1) {
+            const [socketId, player] = this.players.entries().next().value;
+            this.createdBy = socketId;
+            this.creatorUsername = player.username;
+            return { socketId, username: player.username };
+        }
+        return null;
+    }
+
+    // ========================================
+    // Round Management
+    // ========================================
+
+    startRound(roundNumber) {
+        this.currentRound = roundNumber;
+        this.phase = 'round_active';
+
+        const roundData = {
+            roundNumber,
+            games: new Map(), // gameId → { humanPlayers: [], botCount, status }
+            completedGames: new Set()
+        };
+        this.rounds.push(roundData);
+
+        this.logAction('startRound', { roundNumber });
+        return roundData;
+    }
+
+    getCurrentRound() {
+        if (this.rounds.length === 0) return null;
+        return this.rounds[this.rounds.length - 1];
+    }
+
+    addGameToRound(gameId, humanPlayers, botCount) {
+        const round = this.getCurrentRound();
+        if (!round) return;
+
+        round.games.set(gameId, {
+            humanPlayers,
+            botCount,
+            status: 'active'
+        });
+        this.logAction('addGameToRound', { gameId, humanCount: humanPlayers.length, botCount });
+    }
+
+    /**
+     * Record a player's score for the current round.
+     */
+    recordPlayerRoundScore(username, details) {
+        if (!this.scoreboard[username]) {
+            this.scoreboard[username] = {
+                totalScore: 0,
+                roundScores: [],
+                roundDetails: []
+            };
+        }
+
+        const entry = this.scoreboard[username];
+        const roundScore = details.teamScore;
+        entry.roundScores.push(roundScore);
+        entry.roundDetails.push(details);
+        entry.totalScore += roundScore;
+
+        this.logAction('recordPlayerRoundScore', { username, roundScore, totalScore: entry.totalScore });
+    }
+
+    markGameComplete(gameId) {
+        const round = this.getCurrentRound();
+        if (!round) return;
+
+        const gameData = round.games.get(gameId);
+        if (gameData) {
+            gameData.status = 'complete';
+        }
+        round.completedGames.add(gameId);
+
+        this.logAction('markGameComplete', {
+            gameId,
+            completedCount: round.completedGames.size,
+            totalGames: round.games.size
+        });
+    }
+
+    isRoundComplete() {
+        const round = this.getCurrentRound();
+        if (!round) return false;
+        return round.completedGames.size === round.games.size;
+    }
+
+    completeRound() {
+        if (this.currentRound >= this.totalRounds) {
+            this.phase = 'complete';
+        } else {
+            this.phase = 'between_rounds';
+            this.resetAllReady();
+        }
+        this.logAction('completeRound', { round: this.currentRound, phase: this.phase });
+    }
+
+    isTournamentComplete() {
+        return this.phase === 'complete';
+    }
+
+    /**
+     * Get scoreboard sorted by totalScore descending.
+     */
+    getScoreboard() {
+        const entries = Object.entries(this.scoreboard)
+            .map(([username, data]) => ({
+                username,
+                ...data
+            }))
+            .sort((a, b) => b.totalScore - a.totalScore);
+
+        return entries;
+    }
+
+    // ========================================
+    // Spectator Methods
+    // ========================================
+
+    addSpectator(socketId, username, pic) {
+        this.spectators.set(socketId, { username, pic });
+    }
+
+    removeSpectator(socketId) {
+        this.spectators.delete(socketId);
+    }
+
+    isSpectator(socketId) {
+        return this.spectators.has(socketId);
+    }
+
+    // ========================================
+    // Chat Methods
+    // ========================================
+
+    addMessage(username, message, isSpectator = false) {
+        const chatMessage = {
+            username,
+            message,
+            isSpectator,
+            timestamp: Date.now()
+        };
+        this.messages.push(chatMessage);
+        if (this.messages.length > this.maxMessages) {
+            this.messages.shift();
+        }
+        return chatMessage;
+    }
+
+    // ========================================
+    // Room Management
+    // ========================================
+
+    broadcast(io, event, data) {
+        io.to(this.roomName).emit(event, data);
+    }
+
+    joinToRoom(io, socketId) {
+        const socket = io.sockets.sockets.get(socketId);
+        if (socket) {
+            socket.join(this.roomName);
+        }
+    }
+
+    leaveRoom(io, socketId) {
+        const socket = io.sockets.sockets.get(socketId);
+        if (socket) {
+            socket.leave(this.roomName);
+        }
+    }
+
+    // ========================================
+    // Active Games (for spectating during rounds)
+    // ========================================
+
+    getActiveGames() {
+        const round = this.getCurrentRound();
+        if (!round) return [];
+
+        const games = [];
+        for (const [gameId, gameData] of round.games) {
+            games.push({
+                gameId,
+                humanPlayers: gameData.humanPlayers,
+                botCount: gameData.botCount,
+                status: gameData.status
+            });
+        }
+        return games;
+    }
+
+    // ========================================
+    // Client State (for reconnection/joining)
+    // ========================================
+
+    getClientState() {
+        const players = [];
+        for (const [socketId, player] of this.players.entries()) {
+            players.push({
+                socketId,
+                username: player.username,
+                pic: player.pic,
+                ready: player.ready,
+                isCreator: socketId === this.createdBy
+            });
+        }
+
+        return {
+            tournamentId: this.tournamentId,
+            name: this.name,
+            phase: this.phase,
+            currentRound: this.currentRound,
+            totalRounds: this.totalRounds,
+            players,
+            messages: this.messages,
+            scoreboard: this.getScoreboard(),
+            activeGames: this.getActiveGames(),
+            creatorUsername: this.creatorUsername,
+            creatorSocketId: this.createdBy
+        };
+    }
+
+    // ========================================
+    // Player Distribution Algorithm
+    // ========================================
+
+    /**
+     * Distribute players into games of 4, filling gaps with bots.
+     * @param {string[]} shuffledUsernames - Shuffled array of usernames
+     * @returns {Array<{ humans: string[], botCount: number }>}
+     */
+    static distributePlayersIntoGames(shuffledUsernames) {
+        const n = shuffledUsernames.length;
+
+        if (n === 0) return [];
+
+        if (n < 4) {
+            // 1-3 players: one game with bots filling
+            return [{ humans: [...shuffledUsernames], botCount: 4 - n }];
+        }
+
+        const remainder = n % 4;
+        const results = [];
+
+        if (remainder === 0) {
+            // Perfect division
+            for (let i = 0; i < n; i += 4) {
+                results.push({
+                    humans: shuffledUsernames.slice(i, i + 4),
+                    botCount: 0
+                });
+            }
+        } else if (remainder === 1) {
+            // Take 5 players → make 2 games (3+1bot, 2+2bots). Rest fill full games.
+            const fullGameCount = Math.floor(n / 4) - 1;
+            let idx = 0;
+
+            for (let i = 0; i < fullGameCount; i++) {
+                results.push({
+                    humans: shuffledUsernames.slice(idx, idx + 4),
+                    botCount: 0
+                });
+                idx += 4;
+            }
+
+            // Split remaining 5 into (3 + 1 bot) and (2 + 2 bots)
+            results.push({
+                humans: shuffledUsernames.slice(idx, idx + 3),
+                botCount: 1
+            });
+            idx += 3;
+            results.push({
+                humans: shuffledUsernames.slice(idx, idx + 2),
+                botCount: 2
+            });
+        } else if (remainder === 2) {
+            // floor(n/4) full games + 1 game (2 humans + 2 bots)
+            const fullGameCount = Math.floor(n / 4);
+            let idx = 0;
+
+            for (let i = 0; i < fullGameCount; i++) {
+                results.push({
+                    humans: shuffledUsernames.slice(idx, idx + 4),
+                    botCount: 0
+                });
+                idx += 4;
+            }
+
+            results.push({
+                humans: shuffledUsernames.slice(idx, idx + 2),
+                botCount: 2
+            });
+        } else if (remainder === 3) {
+            // floor(n/4) full games + 1 game (3 humans + 1 bot)
+            const fullGameCount = Math.floor(n / 4);
+            let idx = 0;
+
+            for (let i = 0; i < fullGameCount; i++) {
+                results.push({
+                    humans: shuffledUsernames.slice(idx, idx + 4),
+                    botCount: 0
+                });
+                idx += 4;
+            }
+
+            results.push({
+                humans: shuffledUsernames.slice(idx, idx + 3),
+                botCount: 1
+            });
+        }
+
+        return results;
+    }
+
+    // ========================================
+    // Debug Logging
+    // ========================================
+
+    logAction(action, details = {}) {
+        if (this._debugMode) {
+            console.log(`[Tournament ${this.tournamentId.slice(0, 8)}] ${action}`, details);
+        }
+    }
+}
+
+module.exports = TournamentState;

--- a/server/socket/authHandlers.js
+++ b/server/socket/authHandlers.js
@@ -75,8 +75,26 @@ async function signIn(socket, io, data) {
             if (activeGameId) {
                 await gameManager.clearActiveGame(username);
             }
-            socket.emit('signInResponse', { success: true, username, sessionToken });
-            authLogger.info('User signed in', { username, socketId: socket.id });
+
+            // Check for active tournament
+            const activeTournamentId = user.activeTournamentId;
+            const activeTournament = activeTournamentId ? gameManager.getTournamentById(activeTournamentId) : null;
+
+            if (activeTournament) {
+                socket.emit('signInResponse', {
+                    success: true,
+                    username,
+                    sessionToken,
+                    activeTournamentId
+                });
+                authLogger.info('User signed in with active tournament', { username, socketId: socket.id, tournamentId: activeTournamentId });
+            } else {
+                if (activeTournamentId) {
+                    await gameManager.clearActiveTournament(username);
+                }
+                socket.emit('signInResponse', { success: true, username, sessionToken });
+                authLogger.info('User signed in', { username, socketId: socket.id });
+            }
         }
 
     } catch (error) {
@@ -205,8 +223,25 @@ async function restoreSession(socket, io, data) {
             if (activeGameId) {
                 await gameManager.clearActiveGame(username);
             }
-            socket.emit('restoreSessionResponse', { success: true, username });
-            authLogger.info('Session restored', { username, socketId: socket.id });
+
+            // Check for active tournament
+            const activeTournamentId = user.activeTournamentId;
+            const activeTournament = activeTournamentId ? gameManager.getTournamentById(activeTournamentId) : null;
+
+            if (activeTournament) {
+                socket.emit('restoreSessionResponse', {
+                    success: true,
+                    username,
+                    activeTournamentId
+                });
+                authLogger.info('Session restored with active tournament', { username, socketId: socket.id, tournamentId: activeTournamentId });
+            } else {
+                if (activeTournamentId) {
+                    await gameManager.clearActiveTournament(username);
+                }
+                socket.emit('restoreSessionResponse', { success: true, username });
+                authLogger.info('Session restored', { username, socketId: socket.id });
+            }
         }
 
     } catch (error) {

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -11,6 +11,7 @@ const gameHandlers = require('./gameHandlers');
 const chatHandlers = require('./chatHandlers');
 const reconnectHandlers = require('./reconnectHandlers');
 const profileHandlers = require('./profileHandlers');
+const tournamentHandlers = require('./tournamentHandlers');
 const { asyncHandler, syncHandler, safeHandler, rateLimiter } = require('./errorHandler');
 const { socketLogger } = require('../utils/logger');
 
@@ -113,6 +114,41 @@ function setupSocketHandlers(io) {
         );
         socket.on('getLeaderboard', () =>
             safeHandler(profileHandlers.getLeaderboard)(socket, io, {})
+        );
+
+        // Tournament events
+        socket.on('createTournament', () =>
+            safeHandler(tournamentHandlers.createTournament)(socket, io, {})
+        );
+        socket.on('joinTournament', (data) =>
+            asyncHandler('joinTournament', tournamentHandlers.joinTournament)(socket, io, data)
+        );
+        socket.on('leaveTournament', () =>
+            safeHandler(tournamentHandlers.leaveTournament)(socket, io, {})
+        );
+        socket.on('tournamentReady', () =>
+            safeHandler(tournamentHandlers.tournamentReady)(socket, io, {})
+        );
+        socket.on('tournamentUnready', () =>
+            safeHandler(tournamentHandlers.tournamentUnready)(socket, io, {})
+        );
+        socket.on('beginTournament', () =>
+            safeHandler(tournamentHandlers.beginTournament)(socket, io, {})
+        );
+        socket.on('beginNextRound', () =>
+            safeHandler(tournamentHandlers.beginNextRound)(socket, io, {})
+        );
+        socket.on('tournamentChat', (data) =>
+            syncHandler('chatMessage', tournamentHandlers.tournamentChat)(socket, io, data)
+        );
+        socket.on('spectateTournament', (data) =>
+            asyncHandler('spectateTournament', tournamentHandlers.spectateTournament)(socket, io, data)
+        );
+        socket.on('spectateTournamentGame', (data) =>
+            asyncHandler('spectateTournamentGame', tournamentHandlers.spectateTournamentGame)(socket, io, data)
+        );
+        socket.on('returnToTournament', () =>
+            safeHandler(tournamentHandlers.returnToTournament)(socket, io, {})
         );
 
         // Disconnect - cleanup rate limiter and handle game state

--- a/server/socket/lobbyHandlers.js
+++ b/server/socket/lobbyHandlers.js
@@ -199,13 +199,15 @@ function leaveLobby(socket, io) {
         messages: mainRoomResult.messages,
         lobbies: mainRoomResult.lobbies,
         onlineCount: mainRoomResult.onlineCount,
-        inProgressGames: gameManager.getInProgressGames()
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
     });
 
     // Notify main room of updated lobby list
     io.to('mainRoom').emit('lobbiesUpdated', {
         lobbies: gameManager.getAllLobbies(),
-        inProgressGames: gameManager.getInProgressGames()
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
     });
 
     // If lobby was deleted (no players left), nothing more to do
@@ -279,7 +281,8 @@ function addBot(socket, io) {
     // Also update main room lobby list
     io.to('mainRoom').emit('lobbiesUpdated', {
         lobbies: gameManager.getAllLobbies(),
-        inProgressGames: gameManager.getInProgressGames()
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
     });
 }
 
@@ -322,7 +325,8 @@ function removeBot(socket, io, data) {
     // Also update main room lobby list
     io.to('mainRoom').emit('lobbiesUpdated', {
         lobbies: gameManager.getAllLobbies(),
-        inProgressGames: gameManager.getInProgressGames()
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
     });
 }
 

--- a/server/socket/mainRoomHandlers.js
+++ b/server/socket/mainRoomHandlers.js
@@ -25,7 +25,8 @@ function joinMainRoom(socket, io) {
         messages: result.messages,
         lobbies: result.lobbies,
         onlineCount: result.onlineCount,
-        inProgressGames: gameManager.getInProgressGames()
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
     });
 
     // Notify others of new player
@@ -102,7 +103,8 @@ function createLobby(socket, io, data) {
     // Notify main room of new lobby
     io.to('mainRoom').emit('lobbiesUpdated', {
         lobbies: gameManager.getAllLobbies(),
-        inProgressGames: gameManager.getInProgressGames()
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
     });
 
     socketLogger.info('Player created lobby', {
@@ -157,7 +159,8 @@ function joinLobby(socket, io, data) {
     // Notify main room of updated lobbies
     io.to('mainRoom').emit('lobbiesUpdated', {
         lobbies: gameManager.getAllLobbies(),
-        inProgressGames: gameManager.getInProgressGames()
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
     });
 
     socketLogger.info('Player joined lobby', {
@@ -173,7 +176,7 @@ function joinLobby(socket, io, data) {
 function getLobbies(socket, io) {
     const lobbies = gameManager.getAllLobbies();
     const inProgressGames = gameManager.getInProgressGames();
-    socket.emit('lobbiesUpdated', { lobbies, inProgressGames });
+    socket.emit('lobbiesUpdated', { lobbies, inProgressGames, tournaments: gameManager.getAllTournaments() });
 }
 
 /**

--- a/server/socket/tournamentHandlers.js
+++ b/server/socket/tournamentHandlers.js
@@ -1,0 +1,589 @@
+/**
+ * Tournament socket event handlers.
+ * Manages tournament lifecycle: create, join, ready, rounds, chat, spectating.
+ */
+
+const gameManager = require('../game/GameManager');
+const TournamentState = require('../game/TournamentState');
+const Deck = require('../game/Deck');
+const { socketLogger } = require('../utils/logger');
+const { delay } = require('../utils/timing');
+const { botController, BotPlayer, personalities } = require('../game/bot');
+const { PERSONALITY_LIST, getDisplayName } = personalities;
+
+/**
+ * Create a new tournament from main room
+ */
+function createTournament(socket, io) {
+    const user = gameManager.getUserBySocketId(socket.id);
+    if (!user) {
+        socket.emit('error', { message: 'User not found' });
+        return;
+    }
+
+    const result = gameManager.createTournament(socket.id, `${user.username}'s Tournament`);
+    if (!result.success) {
+        socket.emit('error', { message: result.error });
+        return;
+    }
+
+    const tournament = result.tournament;
+
+    // Leave main room Socket.IO room
+    socket.leave('mainRoom');
+
+    // Join tournament room
+    tournament.joinToRoom(io, socket.id);
+
+    // Send tournament state to creator
+    socket.emit('tournamentCreated', tournament.getClientState());
+
+    // Notify main room
+    io.to('mainRoom').emit('lobbiesUpdated', {
+        lobbies: gameManager.getAllLobbies(),
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
+    });
+
+    socketLogger.info('Tournament created', {
+        socketId: socket.id,
+        username: user.username,
+        tournamentId: tournament.tournamentId
+    });
+}
+
+/**
+ * Join an existing tournament
+ */
+function joinTournament(socket, io, data) {
+    const { tournamentId } = data;
+    if (!tournamentId) {
+        socket.emit('error', { message: 'Tournament ID required' });
+        return;
+    }
+
+    const result = gameManager.joinTournament(socket.id, tournamentId);
+    if (!result.success) {
+        socket.emit('error', { message: result.error });
+        return;
+    }
+
+    const tournament = result.tournament;
+    const user = gameManager.getUserBySocketId(socket.id);
+
+    // Leave main room
+    socket.leave('mainRoom');
+
+    // Join tournament room
+    tournament.joinToRoom(io, socket.id);
+
+    // Send full state to joining player
+    socket.emit('tournamentJoined', tournament.getClientState());
+
+    // Notify existing tournament players
+    tournament.broadcast(io, 'tournamentPlayerJoined', {
+        username: user.username,
+        players: tournament.getClientState().players
+    });
+
+    // Notify main room
+    io.to('mainRoom').emit('lobbiesUpdated', {
+        lobbies: gameManager.getAllLobbies(),
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
+    });
+
+    socketLogger.info('Player joined tournament', {
+        socketId: socket.id,
+        username: user.username,
+        tournamentId
+    });
+}
+
+/**
+ * Leave a tournament
+ */
+function leaveTournament(socket, io) {
+    const tournament = gameManager.getPlayerTournament(socket.id);
+    if (!tournament) {
+        socket.emit('error', { message: 'Not in a tournament' });
+        return;
+    }
+
+    const user = gameManager.getUserBySocketId(socket.id);
+    const tournamentId = tournament.tournamentId;
+
+    // Leave tournament room
+    tournament.leaveRoom(io, socket.id);
+
+    const result = gameManager.leaveTournament(socket.id);
+    if (!result.success) {
+        socket.emit('error', { message: result.error });
+        return;
+    }
+
+    // Notify leaving player
+    socket.emit('tournamentLeft', {});
+
+    // Auto-rejoin main room
+    const mainRoomResult = gameManager.joinMainRoom(socket.id);
+    socket.join('mainRoom');
+    socket.emit('mainRoomJoined', {
+        messages: mainRoomResult.messages,
+        lobbies: mainRoomResult.lobbies,
+        onlineCount: mainRoomResult.onlineCount,
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
+    });
+
+    if (result.deleted) {
+        // Tournament was deleted — notify main room
+        io.to('mainRoom').emit('lobbiesUpdated', {
+            lobbies: gameManager.getAllLobbies(),
+            inProgressGames: gameManager.getInProgressGames(),
+            tournaments: gameManager.getAllTournaments()
+        });
+        socketLogger.info('Player left tournament (deleted)', {
+            socketId: socket.id,
+            username: user?.username,
+            tournamentId
+        });
+        return;
+    }
+
+    // Notify remaining players
+    tournament.broadcast(io, 'tournamentPlayerLeft', {
+        username: user?.username,
+        players: tournament.getClientState().players,
+        newCreator: result.newCreator ? result.newCreator.username : null
+    });
+
+    // Notify main room
+    io.to('mainRoom').emit('lobbiesUpdated', {
+        lobbies: gameManager.getAllLobbies(),
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
+    });
+
+    socketLogger.info('Player left tournament', {
+        socketId: socket.id,
+        username: user?.username,
+        tournamentId
+    });
+}
+
+/**
+ * Toggle ready in tournament lobby
+ */
+function tournamentReady(socket, io) {
+    const tournament = gameManager.getPlayerTournament(socket.id);
+    if (!tournament) {
+        socket.emit('error', { message: 'Not in a tournament' });
+        return;
+    }
+
+    tournament.setReady(socket.id);
+
+    tournament.broadcast(io, 'tournamentReadyUpdate', {
+        players: tournament.getClientState().players,
+        allReady: tournament.allPlayersReady()
+    });
+}
+
+function tournamentUnready(socket, io) {
+    const tournament = gameManager.getPlayerTournament(socket.id);
+    if (!tournament) {
+        socket.emit('error', { message: 'Not in a tournament' });
+        return;
+    }
+
+    tournament.unsetReady(socket.id);
+
+    tournament.broadcast(io, 'tournamentReadyUpdate', {
+        players: tournament.getClientState().players,
+        allReady: tournament.allPlayersReady()
+    });
+}
+
+/**
+ * Begin tournament (round 1) — creator only
+ */
+async function beginTournament(socket, io) {
+    const tournament = gameManager.getPlayerTournament(socket.id);
+    if (!tournament) {
+        socket.emit('error', { message: 'Not in a tournament' });
+        return;
+    }
+
+    if (tournament.createdBy !== socket.id) {
+        socket.emit('error', { message: 'Only the creator can start the tournament' });
+        return;
+    }
+
+    if (tournament.phase !== 'lobby') {
+        socket.emit('error', { message: 'Tournament already started' });
+        return;
+    }
+
+    if (!tournament.allPlayersReady()) {
+        socket.emit('error', { message: 'Not all players are ready' });
+        return;
+    }
+
+    // Set active tournament in DB for all players
+    for (const [, player] of tournament.players) {
+        await gameManager.setActiveTournament(player.username, tournament.tournamentId);
+    }
+
+    await startTournamentRound(io, tournament, 1);
+}
+
+/**
+ * Begin next round (rounds 2-4) — creator only
+ */
+async function beginNextRound(socket, io) {
+    const tournament = gameManager.getPlayerTournament(socket.id);
+    if (!tournament) {
+        socket.emit('error', { message: 'Not in a tournament' });
+        return;
+    }
+
+    if (tournament.createdBy !== socket.id) {
+        socket.emit('error', { message: 'Only the creator can start the next round' });
+        return;
+    }
+
+    if (tournament.phase !== 'between_rounds') {
+        socket.emit('error', { message: 'Not between rounds' });
+        return;
+    }
+
+    if (!tournament.allPlayersReady()) {
+        socket.emit('error', { message: 'Not all players are ready' });
+        return;
+    }
+
+    const nextRound = tournament.currentRound + 1;
+    if (nextRound > tournament.totalRounds) {
+        socket.emit('error', { message: 'Tournament is complete' });
+        return;
+    }
+
+    await startTournamentRound(io, tournament, nextRound);
+}
+
+/**
+ * Start a tournament round — creates games, assigns players, starts draw phase
+ */
+async function startTournamentRound(io, tournament, roundNumber) {
+    // Shuffle player usernames
+    const usernames = [];
+    for (const [, player] of tournament.players) {
+        usernames.push(player.username);
+    }
+    // Fisher-Yates shuffle
+    for (let i = usernames.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [usernames[i], usernames[j]] = [usernames[j], usernames[i]];
+    }
+
+    const assignments = TournamentState.distributePlayersIntoGames(usernames);
+    const roundData = tournament.startRound(roundNumber);
+
+    // Broadcast round start
+    tournament.broadcast(io, 'tournamentRoundStart', {
+        roundNumber,
+        totalRounds: tournament.totalRounds,
+        assignments: assignments.map(a => ({ humanCount: a.humans.length, botCount: a.botCount }))
+    });
+
+    await delay(1500);
+
+    // Create each game
+    for (const assignment of assignments) {
+        // Collect human socket IDs
+        const humanSocketIds = [];
+        for (const username of assignment.humans) {
+            const playerInfo = tournament.getPlayerByUsername(username);
+            if (playerInfo) {
+                humanSocketIds.push(playerInfo.socketId);
+            }
+        }
+
+        // Create bot socket IDs
+        const botSocketIds = [];
+        const usedPersonalities = [];
+        for (let i = 0; i < assignment.botCount; i++) {
+            const available = PERSONALITY_LIST.filter(p => !usedPersonalities.includes(p));
+            const personality = available[Math.floor(Math.random() * available.length)];
+            usedPersonalities.push(personality);
+
+            const realName = `🤖 ${getDisplayName(personality)}`;
+            const bot = botController.createBot(realName, personality);
+            botSocketIds.push({ socketId: bot.socketId, personality, bot });
+        }
+
+        const allSocketIds = [...humanSocketIds, ...botSocketIds.map(b => b.socketId)];
+
+        // Create game via GameManager
+        const game = gameManager.createGame(allSocketIds);
+
+        // Map game to tournament
+        gameManager.tournamentGames.set(game.gameId, tournament.tournamentId);
+
+        // Register bots
+        for (const botInfo of botSocketIds) {
+            botInfo.bot.socketId = botInfo.socketId;
+            botController.registerBot(game.gameId, botInfo.bot);
+        }
+
+        // Add game to tournament round
+        tournament.addGameToRound(game.gameId, assignment.humans, assignment.botCount);
+
+        // Set active game in DB for humans
+        for (const username of assignment.humans) {
+            await gameManager.setActiveGame(username, game.gameId);
+        }
+
+        // Join human players to game room
+        for (const socketId of humanSocketIds) {
+            const playerSocket = io.sockets.sockets.get(socketId);
+            if (playerSocket) {
+                playerSocket.join(game.roomName);
+            }
+        }
+
+        // Emit game assignment to humans
+        for (const socketId of humanSocketIds) {
+            io.to(socketId).emit('tournamentGameAssignment', {
+                gameId: game.gameId,
+                tournamentId: tournament.tournamentId,
+                roundNumber
+            });
+        }
+
+        // Emit allPlayersReady to humans (triggers transition to draw)
+        for (const socketId of humanSocketIds) {
+            io.to(socketId).emit('allPlayersReady', {
+                gameId: game.gameId
+            });
+        }
+
+        // Start draw phase after delay
+        await delay(2000);
+
+        game.deck = new Deck();
+        game.deck.shuffle();
+        game.phase = 'drawing';
+        game.broadcast(io, 'startDraw', { start: true });
+
+        // Schedule bot draws
+        let botDrawOrder = 0;
+        for (const botInfo of botSocketIds) {
+            botDrawOrder++;
+            botController.scheduleBotDraw(io, game, botInfo.socketId, botDrawOrder);
+        }
+    }
+
+    // Update main room
+    io.to('mainRoom').emit('lobbiesUpdated', {
+        lobbies: gameManager.getAllLobbies(),
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
+    });
+
+    socketLogger.info('Tournament round started', {
+        tournamentId: tournament.tournamentId,
+        roundNumber,
+        gameCount: assignments.length
+    });
+}
+
+/**
+ * Tournament chat
+ */
+function tournamentChat(socket, io, data) {
+    const { message } = data;
+    if (!message || message.trim().length === 0) return;
+
+    const tournament = gameManager.getPlayerTournament(socket.id);
+    // Also check if they're a spectator
+    let isSpectator = false;
+    let foundTournament = tournament;
+
+    if (!foundTournament) {
+        // Check spectators
+        for (const [, t] of gameManager.tournaments) {
+            if (t.isSpectator(socket.id)) {
+                foundTournament = t;
+                isSpectator = true;
+                break;
+            }
+        }
+    }
+
+    if (!foundTournament) {
+        socket.emit('error', { message: 'Not in a tournament' });
+        return;
+    }
+
+    const user = gameManager.getUserBySocketId(socket.id);
+    const chatMessage = foundTournament.addMessage(
+        user?.username || 'Unknown',
+        message.trim(),
+        isSpectator
+    );
+
+    foundTournament.broadcast(io, 'tournamentMessage', {
+        username: chatMessage.username,
+        message: chatMessage.message,
+        isSpectator: chatMessage.isSpectator,
+        timestamp: chatMessage.timestamp
+    });
+}
+
+/**
+ * Spectate a tournament (join tournament room to see games list)
+ */
+function spectateTournament(socket, io, data) {
+    const { tournamentId } = data;
+    const tournament = gameManager.getTournamentById(tournamentId);
+    if (!tournament) {
+        socket.emit('error', { message: 'Tournament not found' });
+        return;
+    }
+
+    const user = gameManager.getUserBySocketId(socket.id);
+    if (!user) {
+        socket.emit('error', { message: 'User not found' });
+        return;
+    }
+
+    // Leave main room
+    socket.leave('mainRoom');
+    gameManager.leaveMainRoom(socket.id);
+
+    // Add as spectator
+    tournament.addSpectator(socket.id, user.username, null);
+    tournament.joinToRoom(io, socket.id);
+
+    // Send tournament state
+    socket.emit('tournamentJoined', {
+        ...tournament.getClientState(),
+        isSpectator: true
+    });
+
+    tournament.broadcast(io, 'tournamentMessage', {
+        username: 'System',
+        message: `${user.username} is now spectating`,
+        isSpectator: false,
+        timestamp: Date.now()
+    });
+
+    socketLogger.info('Player spectating tournament', {
+        socketId: socket.id,
+        username: user.username,
+        tournamentId
+    });
+}
+
+/**
+ * Spectate a specific game within a tournament
+ */
+function spectateTournamentGame(socket, io, data) {
+    const { gameId } = data;
+
+    const game = gameManager.getGameById(gameId);
+    if (!game) {
+        socket.emit('error', { message: 'Game not found' });
+        return;
+    }
+
+    const user = gameManager.getUserBySocketId(socket.id);
+    if (!user) {
+        socket.emit('error', { message: 'User not found' });
+        return;
+    }
+
+    // Add as spectator to the game
+    game.addSpectator(socket.id, user.username, null);
+    game.joinToRoom(io, socket.id);
+
+    // Build player info
+    const playerInfo = [];
+    for (let pos = 1; pos <= 4; pos++) {
+        const player = game.getPlayerByPosition(pos);
+        if (player) {
+            playerInfo.push({
+                position: pos,
+                username: player.username,
+                pic: player.pic,
+                socketId: player.socketId
+            });
+        }
+    }
+
+    // Send spectator join success with game state
+    socket.emit('spectatorJoined', {
+        gameId: game.gameId,
+        players: playerInfo,
+        trump: game.trump,
+        currentHand: game.currentHand,
+        dealer: game.dealer,
+        phase: game.phase,
+        bidding: game.bidding,
+        currentTurn: game.currentTurn,
+        bids: game.bids,
+        playerBids: game.playerBids,
+        tricks: game.tricks,
+        score: game.score,
+        playedCards: game.playedCards,
+        isTrumpBroken: game.isTrumpBroken,
+        gameLog: game.getGameLog(),
+        spectatorCount: game.getSpectators().length
+    });
+
+    game.broadcast(io, 'spectatorJoined', {
+        username: user.username,
+        spectatorCount: game.getSpectators().length
+    });
+}
+
+/**
+ * Return to tournament lobby from game/spectating
+ */
+function returnToTournament(socket, io) {
+    const tournament = gameManager.getPlayerTournament(socket.id);
+    if (!tournament) {
+        socket.emit('error', { message: 'Not in a tournament' });
+        return;
+    }
+
+    // Remove from any game spectator lists
+    for (const [, game] of gameManager.games) {
+        if (game.isSpectator(socket.id)) {
+            game.removeSpectator(socket.id);
+            game.leaveRoom(io, socket.id);
+        }
+    }
+
+    // Make sure they're in tournament room
+    tournament.joinToRoom(io, socket.id);
+
+    // Send current tournament state
+    socket.emit('tournamentJoined', tournament.getClientState());
+}
+
+module.exports = {
+    createTournament,
+    joinTournament,
+    leaveTournament,
+    tournamentReady,
+    tournamentUnready,
+    beginTournament,
+    beginNextRound,
+    tournamentChat,
+    spectateTournament,
+    spectateTournamentGame,
+    returnToTournament
+};

--- a/server/socket/validators.js
+++ b/server/socket/validators.js
@@ -82,6 +82,19 @@ const schemas = {
 
     uploadProfilePic: Joi.object({
         imageData: Joi.string().required()
+    }),
+
+    // Tournament
+    joinTournament: Joi.object({
+        tournamentId: Joi.string().uuid().required()
+    }),
+
+    spectateTournament: Joi.object({
+        tournamentId: Joi.string().uuid().required()
+    }),
+
+    spectateTournamentGame: Joi.object({
+        gameId: Joi.string().uuid().required()
     })
 };
 


### PR DESCRIPTION
## Summary

- Add a tournament system where players compete across 4 rounds of randomly-assigned games
- "Create Tournament" button in main room opens a tournament lobby with unbounded players
- Players ready up, creator begins the tournament, players are divided into games of 4 (bots fill gaps), and after each round scores are tallied per individual
- After 4 rounds, the player with the highest cumulative score wins

## New Files (5)

| File | Description |
|------|-------------|
| `server/game/TournamentState.js` | Core tournament state class — lifecycle management, player distribution algorithm, scoring, round management |
| `server/socket/tournamentHandlers.js` | 11 socket event handlers for the full tournament lifecycle (create, join, leave, ready, begin, chat, spectate, return) |
| `client/src/handlers/tournamentHandlers.js` | Client-side handler registration for 13 tournament events |
| `client/src/ui/screens/TournamentLobby.js` | Tournament lobby screen with player list, chat, ready buttons, scoreboard, active games panel |
| `client/src/ui/components/TournamentScoreboard.js` | Reusable scoreboard table and final results overlay components |

## Modified Files (15)

| File | Changes |
|------|---------|
| `server/game/GameManager.js` | Tournament maps (`tournaments`, `playerTournaments`, `tournamentGames`), CRUD methods, disconnect handling |
| `server/socket/index.js` | Register 11 tournament socket events |
| `server/socket/validators.js` | Joi schemas for tournament events |
| `server/socket/gameHandlers.js` | Tournament-aware game end flow in `handleHandComplete` — records scores, detects round/tournament completion |
| `server/socket/queueHandlers.js` | Tournament disconnect handling |
| `server/socket/mainRoomHandlers.js` | Include `tournaments` in `lobbiesUpdated` emissions |
| `server/socket/lobbyHandlers.js` | Include `tournaments` in `lobbiesUpdated` emissions |
| `server/socket/authHandlers.js` | Check `activeTournamentId` on sign-in/restore for reconnection |
| `client/src/constants/events.js` | 24 new tournament event constants (11 client, 13 server) |
| `client/src/handlers/index.js` | Wire tournament handler registration and callbacks |
| `client/src/ui/UIManager.js` | `TOURNAMENT_LOBBY` screen management |
| `client/src/ui/screens/MainRoom.js` | "Create Tournament" button and tournament listings in lobby browser |
| `client/src/ui/components/ScoreModal.js` | Configurable `buttonText` parameter for tournament context |
| `client/src/state/GameState.js` | `tournamentId` field for tournament context during games |
| `client/src/main.js` | 13 tournament callbacks, modified game end for tournament context, session restore support |

## Key Design Decisions

- **Player distribution algorithm**: Remainder-aware grouping that minimizes bot usage. When `n % 4 == 1`, splits 5 players into two games (3+1bot, 2+2bots) instead of one game with 1 human + 3 bots.
- **Socket room strategy**: Players stay in `tournament:{id}` room even during games (dual room membership with `game:{id}`). Tournament chat and events persist across rounds.
- **Creator transfer**: When creator leaves/disconnects, role transfers to next human player. Tournament only ends if no humans remain.
- **Scoring**: Each player's round score = their team's final score. Tournament winner = highest cumulative individual score across 4 rounds.
- **Reconnection**: `activeTournamentId` stored in MongoDB user doc. On sign-in, checks for active tournament and rejoins.

## Round Flow

1. Creator clicks "Begin Tournament" → server shuffles players, runs distribution algorithm
2. Games created via existing GameManager, bots added as needed, draw phases start
3. Games play out using existing game logic (no changes to bidding/playing/tricks)
4. On game end, scores recorded to tournament, "Return to Tournament" button shown
5. When all games complete, round ends → scoreboard shown, ready flow for next round
6. After round 4, final results overlay with winner announcement

## Test plan

- [ ] Create tournament from main room, verify it appears in lobby browser
- [ ] Join with multiple browser tabs, ready up, begin tournament
- [ ] Play through a full game in a tournament round
- [ ] Verify "Return to Tournament" flow after game ends
- [ ] Verify scoreboard updates between rounds
- [ ] Test with various player counts (1, 2, 3, 4, 5, 8+) to verify bot distribution
- [ ] Test creator leaving — verify role transfers to next player
- [ ] Test player disconnect/reconnect during tournament game
- [ ] Test spectating tournament games from tournament lobby
- [ ] Complete full 4-round tournament and verify final results

🤖 Generated with [Claude Code](https://claude.com/claude-code)