### PR TITLE
Fix iOS bid UI: bore availability and bid bubble display

### DIFF
--- a/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
+++ b/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
@@ -162,13 +162,11 @@ class GameSKScene: SKScene {
             .store(in: &cancellables)
 
         // Bid received
-        gameState.$bids
+        gameState.bidReceivedSubject
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] bids in
+            .sink { [weak self] (position, bid) in
                 guard let self, let myPos = self.gameState.position else { return }
-                for (pos, bid) in bids {
-                    self.bidManager?.showBid(position: pos, bid: bid, myPosition: myPos)
-                }
+                self.bidManager?.showBid(position: position, bid: bid, myPosition: myPos)
             }
             .store(in: &cancellables)
 

--- a/iOSClient/BABOnline/State/GameState.swift
+++ b/iOSClient/BABOnline/State/GameState.swift
@@ -127,6 +127,7 @@ final class GameState: ObservableObject {
     let destroyHandsSubject = PassthroughSubject<Void, Never>()
     let rainbowSubject = PassthroughSubject<Int, Never>()          // position
     let chatBubbleSubject = PassthroughSubject<(message: String, position: Int), Never>()
+    let bidReceivedSubject = PassthroughSubject<(position: Int, bid: String), Never>()
 
     // MARK: - Optimistic Update State
 
@@ -299,6 +300,7 @@ final class GameState: ObservableObject {
         bids[pos] = bid
         tempBids.append(bid.uppercased())
         updateTeamBids()
+        bidReceivedSubject.send((position: pos, bid: bid))
     }
 
     private func updateTeamBids() {

--- a/iOSClient/BABOnline/Views/Game/BidOverlayView.swift
+++ b/iOSClient/BABOnline/Views/Game/BidOverlayView.swift
@@ -10,30 +10,16 @@ struct BidOverlayView: View {
         gameState.myCards.count
     }
 
-    /// Check if a bore bid is available based on bid history
-    private var canBore: Bool {
-        // Bore requires all previous bids to be 0
-        guard maxBid > 0 else { return false }
-        let previousBids = gameState.tempBids
-        return !previousBids.isEmpty && previousBids.allSatisfy { $0 == "0" }
-    }
-
-    /// Current bore level
-    private var currentBoreLevel: String? {
-        let bores = gameState.tempBids.filter { $0.contains("B") }
-        if bores.isEmpty { return nil }
-        return bores.last
-    }
-
-    /// Available bore levels
+    /// Available bore levels based on what's already been bid
     private var availableBoreLevels: [String] {
-        guard canBore || currentBoreLevel != nil else { return [] }
-        let levels = ["B", "2B", "3B", "4B"]
-        if let current = currentBoreLevel, let idx = levels.firstIndex(of: current) {
-            // Can only escalate
-            return Array(levels.suffix(from: idx + 1))
-        }
-        return ["B"]
+        guard maxBid > 0 else { return [] }
+        let bids = gameState.tempBids
+        var levels: [String] = []
+        if !bids.contains("B")                          { levels.append("B") }
+        if bids.contains("B") && !bids.contains("2B")   { levels.append("2B") }
+        if bids.contains("2B") && !bids.contains("3B")  { levels.append("3B") }
+        if bids.contains("3B") && !bids.contains("4B")  { levels.append("4B") }
+        return levels
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary

- **Bore button availability**: Fixed incorrect logic that prevented bore (B) from appearing for the first bidder and blocked it when any non-zero bid existed. Now matches the web client — B is always available unless already bid, and 2B/3B/4B follow the escalation chain.
- **Bid bubble display**: Fixed bore bids (B, 2B, 3B, 4B) showing as "0" in floating bid bubbles. Root cause was `@Published` dictionary + Combine `willSet` timing delivering stale values. Switched to a `PassthroughSubject` (matching existing `cardPlayedSubject`/`trickCompleteSubject` pattern) so each bid event delivers the exact value.
- **Bonus**: Bid bubbles no longer re-create for all positions on every single bid change — only the newly received bid gets a bubble.

## Test plan

- [ ] Build the iOS client in Xcode
- [ ] Start a game and enter bidding phase
- [ ] Verify bore button (B) is visible for the first bidder
- [ ] Verify B remains available for subsequent bidders until someone bids B
- [ ] Bid B — verify 2B appears for the next bidder (not B again)
- [ ] Have a bot bid bore — verify the bid bubble shows "B"/"2B" (not "0")
- [ ] Verify game log matches bid bubbles
- [ ] Verify regular numeric bids still work and show correct bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)