### PR TITLE
Commit iOS project config from polish PR

### DIFF
--- a/iOSClient/BABOnline.xcodeproj/project.pbxproj
+++ b/iOSClient/BABOnline.xcodeproj/project.pbxproj
@@ -3,13 +3,14 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 63;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		0AFE71725CB8CD0D40446684 /* GameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006A718437AB193FE3F34B14 /* GameState.swift */; };
 		0D1479057F4F8E28A2C0C482 /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 409C82291F02FA6A105021BE /* ChatMessage.swift */; };
 		0D25FCF69FC9AF34A7A5C0A3 /* SKTrickManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E2E4B3B3896E524EF05AB1 /* SKTrickManager.swift */; };
+		1A2B3C4D5E6F7A8B9C0D1E2F /* DrawPhaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E8F9A0B1C2 /* DrawPhaseView.swift */; };
 		1A52C4D663DFAE60116D9CB0 /* TrickHistoryNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9851CDF9CB5E3CFFBD929C8F /* TrickHistoryNode.swift */; };
 		2C879BC1C33494BB4AC7468C /* ScoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD47677D06A3496EC34B3AC /* ScoreData.swift */; };
 		2DC3F6E51394ABFC98D3F746 /* GameEndView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7D19DF413AEB22E4D8F0CB7 /* GameEndView.swift */; };
@@ -48,6 +49,7 @@
 		902F44A26653DE8831F20CDE /* SKCardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82EEBA726E4095626D47FD1C /* SKCardManager.swift */; };
 		928367895A6772000691F618 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6417A37D0B5BC7A02FB2BBB2 /* HapticManager.swift */; };
 		94E6B3762DD45EE9BA15062F /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DFDBCEB31996914FD461DC /* SignInView.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1A2C3D4E5F6A7B8C9D0E1F /* SplashView.swift */; };
 		B0C0F2FA27394738C0CD3E36 /* OpponentHandNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CDC046A6CD61F2193F4516 /* OpponentHandNode.swift */; };
 		B348925DF11C006AF98146DA /* LobbySocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FD14869A6FDEFEF8A26EB44 /* LobbySocketHandler.swift */; };
 		BFAE12C47A3D5E9B01234567 /* CardTextureGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFAE12C47A3D5E9B76543210 /* CardTextureGenerator.swift */; };
@@ -71,8 +73,6 @@
 		F74A788A36EF3556E7FD78E0 /* AuthSocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28474CFED18B3E46768C988 /* AuthSocketHandler.swift */; };
 		FA7C18BDCC1C31AC365877F9 /* CardUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62295A09DC541B3ED5023CE7 /* CardUtils.swift */; };
 		FDB5445E7BEE26B8943D8770 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8790511FF395019A12A1F429 /* Assets.xcassets */; };
-		A1B2C3D4E5F6A7B8C9D0E1F2 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1A2C3D4E5F6A7B8C9D0E1F /* SplashView.swift */; };
-		1A2B3C4D5E6F7A8B9C0D1E2F /* DrawPhaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C6D7E8F9A0B1C2 /* DrawPhaseView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -92,6 +92,7 @@
 		4C753D08CF7E5D35B8C398DD /* DisconnectBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectBannerView.swift; sourceTree = "<group>"; };
 		58321163C76BBDE1CED7AA3F /* SKDrawManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKDrawManager.swift; sourceTree = "<group>"; };
 		590A4C6D80BFFB5B7643CFB6 /* View+Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Haptics.swift"; sourceTree = "<group>"; };
+		5B1A2C3D4E5F6A7B8C9D0E1F /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		5BA11DB6AFE269661E829F5A /* Lobby.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lobby.swift; sourceTree = "<group>"; };
 		5DA7DA1840AFEF31F921700C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		60E60EBA3E35912039DA9C3E /* SocketEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketEvents.swift; sourceTree = "<group>"; };
@@ -99,7 +100,7 @@
 		6417A37D0B5BC7A02FB2BBB2 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		7187D649710ECFC3C9A68D59 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		7AA293C5CC063A9C3A5D35F2 /* GameSocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameSocketHandler.swift; sourceTree = "<group>"; };
-		7F8955A183A4B54328782B3C /* BABOnline.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = BABOnline.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7F8955A183A4B54328782B3C /* BAB Online.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BAB Online.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7FD14869A6FDEFEF8A26EB44 /* LobbySocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LobbySocketHandler.swift; sourceTree = "<group>"; };
 		812F272D69A23E90F74E663E /* Positions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Positions.swift; sourceTree = "<group>"; };
 		82EEBA726E4095626D47FD1C /* SKCardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKCardManager.swift; sourceTree = "<group>"; };
@@ -108,7 +109,6 @@
 		8B639F96D4A1C11BA1CDD076 /* LobbyChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LobbyChatView.swift; sourceTree = "<group>"; };
 		91311C67E1ED8D1C5421D58E /* BidBubbleNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BidBubbleNode.swift; sourceTree = "<group>"; };
 		92E3162E733BE7280BECE498 /* CardSpriteNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardSpriteNode.swift; sourceTree = "<group>"; };
-		BFAE12C47A3D5E9B76543210 /* CardTextureGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardTextureGenerator.swift; sourceTree = "<group>"; };
 		933108D8AFD4FC2B2D6CEF38 /* HandNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandNode.swift; sourceTree = "<group>"; };
 		97217006DFD0797BEBAF6836 /* GameEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEmitter.swift; sourceTree = "<group>"; };
 		9851CDF9CB5E3CFFBD929C8F /* TrickHistoryNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrickHistoryNode.swift; sourceTree = "<group>"; };
@@ -119,12 +119,14 @@
 		B0E2E4B3B3896E524EF05AB1 /* SKTrickManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKTrickManager.swift; sourceTree = "<group>"; };
 		B7CDC046A6CD61F2193F4516 /* OpponentHandNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpponentHandNode.swift; sourceTree = "<group>"; };
 		B7D19DF413AEB22E4D8F0CB7 /* GameEndView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameEndView.swift; sourceTree = "<group>"; };
+		BFAE12C47A3D5E9B76543210 /* CardTextureGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardTextureGenerator.swift; sourceTree = "<group>"; };
 		C388CF7DA4B1B394B2FB89C7 /* TrickAreaNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrickAreaNode.swift; sourceTree = "<group>"; };
 		C53AAE255FBF334AD3AEC34F /* LobbyListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LobbyListView.swift; sourceTree = "<group>"; };
 		CA579DC4E6B636DA5E52C8AE /* GameContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameContainerView.swift; sourceTree = "<group>"; };
 		CBBC8430F514042641E150DF /* MainRoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainRoomView.swift; sourceTree = "<group>"; };
 		CD3FDF5B050165FBA337E6D1 /* SocketEventRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketEventRouter.swift; sourceTree = "<group>"; };
 		CF9F36992678FBDC040366E9 /* LobbyPlayerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LobbyPlayerRow.swift; sourceTree = "<group>"; };
+		D1E2F3A4B5C6D7E8F9A0B1C2 /* DrawPhaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawPhaseView.swift; sourceTree = "<group>"; };
 		D74F821D951B0C701D3EEC7F /* AuthEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthEmitter.swift; sourceTree = "<group>"; };
 		D8844D76D26441BDFA1AA6B4 /* SocketService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketService.swift; sourceTree = "<group>"; };
 		D8BFDA96358A6BEB484A42FB /* MainRoomState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainRoomState.swift; sourceTree = "<group>"; };
@@ -140,8 +142,6 @@
 		F28474CFED18B3E46768C988 /* AuthSocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSocketHandler.swift; sourceTree = "<group>"; };
 		FA8B8AB7C156EE02DB4AA5EC /* SKOpponentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKOpponentManager.swift; sourceTree = "<group>"; };
 		FD7736BF05FE6B17925F5B58 /* AvatarNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarNode.swift; sourceTree = "<group>"; };
-		5B1A2C3D4E5F6A7B8C9D0E1F /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
-		D1E2F3A4B5C6D7E8F9A0B1C2 /* DrawPhaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawPhaseView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -352,7 +352,7 @@
 		E80216038A0F001B2BEA7D32 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				7F8955A183A4B54328782B3C /* BABOnline.app */,
+				7F8955A183A4B54328782B3C /* BAB Online.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -416,7 +416,7 @@
 				369628F9131811122EB62EAD /* SocketIO */,
 			);
 			productName = BABOnline;
-			productReference = 7F8955A183A4B54328782B3C /* BABOnline.app */;
+			productReference = 7F8955A183A4B54328782B3C /* BAB Online.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -445,9 +445,8 @@
 			mainGroup = 426F53F5D8BE43B74A85A9D1;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket.io-client-swift" */,
+				68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket" */,
 			);
-			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -602,11 +601,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 9SYNY7K2HE;
 				INFOPLIST_FILE = BABOnline/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.card-games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -692,11 +693,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 9SYNY7K2HE;
 				INFOPLIST_FILE = BABOnline/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.card-games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -739,7 +742,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket.io-client-swift" */ = {
+		68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/socketio/socket.io-client-swift";
 			requirement = {
@@ -752,7 +755,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		369628F9131811122EB62EAD /* SocketIO */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket.io-client-swift" */;
+			package = 68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket" */;
 			productName = SocketIO;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/iOSClient/BABOnline.xcodeproj/project.pbxproj
+++ b/iOSClient/BABOnline.xcodeproj/project.pbxproj
@@ -426,7 +426,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 2620;
 				TargetAttributes = {
 					2AC5F2EA7EC758EF4B1916F8 = {
 						DevelopmentTeam = "";
@@ -576,8 +576,10 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 9SYNY7K2HE;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -591,6 +593,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.9;
@@ -605,7 +608,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9SYNY7K2HE;
 				INFOPLIST_FILE = BABOnline/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.card-games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -661,8 +663,10 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 9SYNY7K2HE;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -683,6 +687,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.9;
@@ -697,7 +702,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 9SYNY7K2HE;
 				INFOPLIST_FILE = BABOnline/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.card-games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/iOSClient/BABOnline/Info.plist
+++ b/iOSClient/BABOnline/Info.plist
@@ -38,5 +38,16 @@
 		<key>UIColorName</key>
 		<string>LaunchBackground</string>
 	</dict>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Xcode project and Info.plist changes from the iOS polish work (#117) that were left uncommitted
- Adds `SplashView.swift` and `DrawPhaseView.swift` file references to the project
- Renames app product to "BAB Online"
- Sets development team and app category (card games)
- Locks iPhone to portrait only, allows all orientations on iPad
- Downgrades `objectVersion` to 63 for broader Xcode compatibility

## Test plan

- [ ] Open project in Xcode and verify it builds
- [ ] Verify SplashView and DrawPhaseView are included in the target
- [ ] Verify orientation lock works on iPhone (portrait only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)