### PR TITLE
Fix trick state race condition, keyboard dismiss, and rejoin visuals

### DIFF
--- a/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
@@ -187,8 +187,11 @@ final class GameSocketHandler {
                 let winnerName = self.gameState.getPlayerName(position: winner)
                 self.gameState.addSystemLog("\(winnerName) won the trick (\(self.gameState.teamTricks)-\(self.gameState.oppTricks))")
 
-                // Clear trick state after delay (let animation play)
+                // Clear trick state after delay (let animation play).
+                // Guard: if a new trick's card has already been played
+                // (playedCardIndex > 0), skip to avoid wiping new trick state.
                 DispatchQueue.main.asyncAfter(deadline: .now() + LayoutConstants.collectTrickDuration + 0.3) {
+                    guard self.gameState.playedCardIndex == 0 else { return }
                     self.gameState.clearTrick()
                 }
             }

--- a/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
+++ b/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
@@ -187,7 +187,7 @@ class GameSKScene: SKScene {
         case .bidding:
             setupGameUI()
         case .playing:
-            cardManager?.updateHand()
+            setupGameUI()
         case .ended:
             // Handled by SwiftUI overlay
             break

--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomChatView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomChatView.swift
@@ -30,6 +30,7 @@ struct MainRoomChatView: View {
                     .padding(.horizontal)
                     .padding(.vertical, 8)
                 }
+                .scrollDismissesKeyboard(.interactively)
                 .onChange(of: mainRoomState.messages.count) {
                     if let last = mainRoomState.messages.last {
                         withAnimation(.easeOut(duration: 0.2)) {

--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
@@ -29,6 +29,9 @@ struct MainRoomView: View {
                 }
             }
         }
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
         .onAppear {
             LobbyEmitter.joinMainRoom()
         }


### PR DESCRIPTION
## Summary

- **Trick state race condition**: The delayed `clearTrick()` (0.7s after trick ends) could fire after a new trick's first card was already played, resetting `playedCardIndex` to 0. This corrupted subsequent trick counting — the 4th card only reached index 3 (never triggering the `>=4` reset), leaving stale `leadCard` across tricks and forcing "must follow suit" on what should be a free lead. Added a guard to skip `clearTrick()` if `playedCardIndex > 0` (new trick already started).
- **Main room keyboard dismiss**: Added `.scrollDismissesKeyboard(.interactively)` to `MainRoomChatView` ScrollView and `.onTapGesture` keyboard dismiss to `MainRoomView` (matching the game lobby pattern).
- **Rejoin game visuals missing**: Changed `.playing` phase handler in `GameSKScene` to call `setupGameUI()` instead of just `cardManager?.updateHand()`. On rejoin, the phase goes directly to `.playing` (skipping `.bidding`), so managers never received `setup(gameState:)` and couldn't render cards, opponents, or trick area.

## Test plan

- [ ] Lead HI joker in a trick with bots → verify next lead is unrestricted and trick area clears properly
- [ ] Open main room chat → type a message → swipe down on chat or tap outside → verify keyboard dismisses
- [ ] Mid-game, kill the app → reopen → verify game visuals (cards, opponents, trick area) render after rejoin

🤖 Generated with [Claude Code](https://claude.com/claude-code)