### PR TITLE
Fix iOS client reconnection after backgrounding

### DIFF
--- a/iOSClient/BABOnline/BABOnlineApp.swift
+++ b/iOSClient/BABOnline/BABOnlineApp.swift
@@ -49,11 +49,13 @@ struct BABOnlineApp: App {
     private func handleScenePhase(_ phase: ScenePhase) {
         switch phase {
         case .active:
-            // Reconnect socket when app comes to foreground
-            if !socketService.isConnected {
-                print("[App] Foregrounded — reconnecting socket")
-                socketService.connect()
-            }
+            // Always force reconnect when foregrounding. iOS can silently kill the
+            // WebSocket without firing a disconnect event, so `isConnected` is unreliable.
+            // forceReconnect() tears down and re-establishes the connection, which triggers
+            // the .reconnect handler's restoreSession flow (handles both main room and
+            // in-game rejoin).
+            print("[App] Foregrounded — force reconnecting socket")
+            socketService.forceReconnect()
         case .background:
             print("[App] Backgrounded")
         default:

--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MainRoomView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var mainRoomState: MainRoomState
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         ZStack {
@@ -34,6 +35,13 @@ struct MainRoomView: View {
         }
         .onAppear {
             LobbyEmitter.joinMainRoom()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                // Re-join main room after foregrounding to re-establish the server-side
+                // room subscription. Safe to call redundantly — server just re-adds to the room.
+                LobbyEmitter.joinMainRoom()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- iOS can silently kill the WebSocket when backgrounded without firing a disconnect event, leaving `isConnected` stale — so reconnection logic never fires
- Added `forceReconnect()` to `SocketService` that tears down and re-establishes the socket, forcing Socket.IO through its full connect cycle and triggering the `restoreSession` flow
- `BABOnlineApp` now always calls `forceReconnect()` on foreground (instead of gating on `isConnected`)
- `MainRoomView` re-joins the main room on foreground as belt-and-suspenders for lobby subscription

## Test plan
- [ ] Sign in, reach main room, background app for 10+ seconds, return — "Create" lobby should work and lobby list should refresh
- [ ] Start a game with 2 human players + bots, Player B backgrounds, Player A sees disconnect banner, Player B returns — disconnect banner should disappear and game should continue normally
- [ ] Verify rapid background/foreground cycles don't cause duplicate reconnection attempts (re-entrancy guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)