### PR TITLE
Fix stale in-progress games in lobby after game abort/end

### DIFF
--- a/iOSClient/BABOnline/Resources/Cards.xcassets/10_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/10_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "10_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/10_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/10_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "10_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/10_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/10_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "10_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/10_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/10_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "10_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/2_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/2_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "2_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/2_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/2_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "2_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/2_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/2_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "2_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/2_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/2_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "2_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/3_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/3_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "3_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/3_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/3_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "3_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/3_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/3_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "3_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/3_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/3_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "3_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/4_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/4_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "4_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/4_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/4_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "4_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/4_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/4_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "4_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/4_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/4_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "4_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/5_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/5_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "5_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/5_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/5_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "5_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/5_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/5_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "5_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/5_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/5_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "5_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/6_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/6_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "6_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/6_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/6_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "6_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/6_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/6_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "6_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/6_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/6_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "6_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/7_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/7_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "7_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/7_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/7_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "7_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/7_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/7_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "7_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/7_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/7_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "7_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/8_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/8_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "8_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/8_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/8_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "8_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/8_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/8_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "8_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/8_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/8_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "8_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/9_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/9_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "9_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/9_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/9_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "9_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/9_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/9_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "9_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/9_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/9_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "9_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/ace_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/ace_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "ace_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/ace_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/ace_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "ace_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/ace_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/ace_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "ace_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/ace_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/ace_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "ace_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/card_back.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/card_back.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "card_back.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/hi_joker.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/hi_joker.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "hi_joker.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/jack_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/jack_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "jack_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/jack_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/jack_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "jack_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/jack_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/jack_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "jack_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/jack_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/jack_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "jack_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/king_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/king_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "king_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/king_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/king_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "king_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/king_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/king_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "king_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/king_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/king_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "king_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/lo_joker.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/lo_joker.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "lo_joker.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/queen_clubs.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/queen_clubs.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "queen_clubs.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/queen_diamonds.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/queen_diamonds.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "queen_diamonds.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/queen_hearts.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/queen_hearts.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "queen_hearts.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Cards.xcassets/queen_spades.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Cards.xcassets/queen_spades.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "queen_spades.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Misc.xcassets/2b.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Misc.xcassets/2b.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "2b.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Misc.xcassets/3b.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Misc.xcassets/3b.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "3b.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Misc.xcassets/4b.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Misc.xcassets/4b.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "4b.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Misc.xcassets/b.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Misc.xcassets/b.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "b.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Misc.xcassets/background.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Misc.xcassets/background.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "background.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Misc.xcassets/logo.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Misc.xcassets/logo.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "logo.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Misc.xcassets/ot.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Misc.xcassets/ot.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "ot.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/iOSClient/BABOnline/Resources/Misc.xcassets/rainbow1.imageset/Contents.json
+++ b/iOSClient/BABOnline/Resources/Misc.xcassets/rainbow1.imageset/Contents.json
@@ -4,6 +4,14 @@
       "filename" : "rainbow1.png",
       "idiom" : "universal",
       "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
     }
   ],
   "info" : {

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -821,6 +821,13 @@ async function handleHandComplete(game, io) {
         // Clear playerGames Map entries so players can create new lobbies/return to tournament
         gameManager.endGame(game.gameId);
         game.resetForNewGame();
+
+        // Notify main room that an in-progress game has ended
+        io.to('mainRoom').emit('lobbiesUpdated', {
+            lobbies: gameManager.getAllLobbies(),
+            inProgressGames: gameManager.getInProgressGames(),
+            tournaments: gameManager.getAllTournaments()
+        });
     } else {
         gameLogger.debug('Starting next hand', { dealer: nextDealer, handSize: nextHandSize, gameId: game.gameId });
         await cleanupNextHand(game, io, nextDealer, nextHandSize);

--- a/server/socket/queueHandlers.js
+++ b/server/socket/queueHandlers.js
@@ -135,6 +135,11 @@ async function handleDisconnect(socket, io) {
                 await gameManager.clearActiveGameForAll(result.gameId);
                 result.game.leaveAllFromRoom(io);
                 gameManager.abortGame(result.gameId);
+                io.to('mainRoom').emit('lobbiesUpdated', {
+                    lobbies: gameManager.getAllLobbies(),
+                    inProgressGames: gameManager.getInProgressGames(),
+                    tournaments: gameManager.getAllTournaments()
+                });
             }
             return;
         }
@@ -176,6 +181,11 @@ async function handleDisconnect(socket, io) {
                     await gameManager.clearActiveGameForAll(result.gameId);
                     checkResult.game.leaveAllFromRoom(io);
                     gameManager.abortGame(result.gameId);
+                    io.to('mainRoom').emit('lobbiesUpdated', {
+                        lobbies: gameManager.getAllLobbies(),
+                        inProgressGames: gameManager.getInProgressGames(),
+                        tournaments: gameManager.getAllTournaments()
+                    });
                 } else {
                     // Broadcast resignationAvailable to remaining connected players
                     for (const pos of disconnectedPositions) {


### PR DESCRIPTION
## Summary

- When a game aborts (all humans disconnected, only bots remain) or ends normally, the server now broadcasts `lobbiesUpdated` to the main room so the in-progress games list is immediately cleaned up
- Previously, stale entries persisted until the next unrelated lobby event (e.g. someone creating a new lobby)
- Adds the broadcast to both abort paths in `queueHandlers.js` (lazy-mode disconnect and 60s grace-period expiry) and after normal game end in `gameHandlers.js`

## Test plan

- [ ] Start a game with 3 bots → `/leave` → verify game appears in "In Progress" list
- [ ] Wait 60s for game to abort → in-progress entry should disappear automatically without refreshing
- [ ] Start a game with 3 bots → play to completion → game should disappear from in-progress list
- [ ] Verify other lobby operations (create/join/leave lobby) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)