### PR TITLE
Add tournament mode to iOS client

### DIFF
--- a/iOSClient/BABOnline.xcodeproj/project.pbxproj
+++ b/iOSClient/BABOnline.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 63;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -76,6 +76,16 @@
 		F74A788A36EF3556E7FD78E0 /* AuthSocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28474CFED18B3E46768C988 /* AuthSocketHandler.swift */; };
 		FA7C18BDCC1C31AC365877F9 /* CardUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62295A09DC541B3ED5023CE7 /* CardUtils.swift */; };
 		FDB5445E7BEE26B8943D8770 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8790511FF395019A12A1F429 /* Assets.xcassets */; };
+		BB1234567890ABCDEF000001 /* Tournament.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000001 /* Tournament.swift */; };
+		BB1234567890ABCDEF000002 /* TournamentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000002 /* TournamentState.swift */; };
+		BB1234567890ABCDEF000003 /* TournamentEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000003 /* TournamentEmitter.swift */; };
+		BB1234567890ABCDEF000004 /* TournamentSocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000004 /* TournamentSocketHandler.swift */; };
+		BB1234567890ABCDEF000005 /* TournamentLobbyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000005 /* TournamentLobbyView.swift */; };
+		BB1234567890ABCDEF000006 /* TournamentPlayerListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000006 /* TournamentPlayerListView.swift */; };
+		BB1234567890ABCDEF000007 /* TournamentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000007 /* TournamentChatView.swift */; };
+		BB1234567890ABCDEF000008 /* TournamentScoreboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000008 /* TournamentScoreboardView.swift */; };
+		BB1234567890ABCDEF000009 /* TournamentActiveGamesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000009 /* TournamentActiveGamesView.swift */; };
+		BB1234567890ABCDEF00000A /* TournamentResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000A /* TournamentResultsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -106,7 +116,7 @@
 		7187D649710ECFC3C9A68D59 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		75D2E270D4D2316436C2B415 /* UsernameColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameColor.swift; sourceTree = "<group>"; };
 		7AA293C5CC063A9C3A5D35F2 /* GameSocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameSocketHandler.swift; sourceTree = "<group>"; };
-		7F8955A183A4B54328782B3C /* BABOnline.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = BABOnline.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7F8955A183A4B54328782B3C /* BAB Online.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BAB Online.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7FD14869A6FDEFEF8A26EB44 /* LobbySocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LobbySocketHandler.swift; sourceTree = "<group>"; };
 		812F272D69A23E90F74E663E /* Positions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Positions.swift; sourceTree = "<group>"; };
 		82EEBA726E4095626D47FD1C /* SKCardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKCardManager.swift; sourceTree = "<group>"; };
@@ -148,6 +158,16 @@
 		F5181763FA4333160B98FDC2 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		FA8B8AB7C156EE02DB4AA5EC /* SKOpponentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKOpponentManager.swift; sourceTree = "<group>"; };
 		FD7736BF05FE6B17925F5B58 /* AvatarNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarNode.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF000001 /* Tournament.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tournament.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF000002 /* TournamentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentState.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF000003 /* TournamentEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentEmitter.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF000004 /* TournamentSocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentSocketHandler.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF000005 /* TournamentLobbyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentLobbyView.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF000006 /* TournamentPlayerListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentPlayerListView.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF000007 /* TournamentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentChatView.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF000008 /* TournamentScoreboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentScoreboardView.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF000009 /* TournamentActiveGamesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentActiveGamesView.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF00000A /* TournamentResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentResultsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -180,6 +200,7 @@
 				281B7D8A956EA7591D9F54C8 /* ChatEmitter.swift */,
 				97217006DFD0797BEBAF6836 /* GameEmitter.swift */,
 				ABFB49C1B9B998424D06A9B7 /* LobbyEmitter.swift */,
+				AA1234567890ABCDEF000003 /* TournamentEmitter.swift */,
 			);
 			path = Emitters;
 			sourceTree = "<group>";
@@ -199,6 +220,7 @@
 				1CC5887542913E6A913FA11E /* ChatSocketHandler.swift */,
 				7AA293C5CC063A9C3A5D35F2 /* GameSocketHandler.swift */,
 				7FD14869A6FDEFEF8A26EB44 /* LobbySocketHandler.swift */,
+				AA1234567890ABCDEF000004 /* TournamentSocketHandler.swift */,
 			);
 			path = Handlers;
 			sourceTree = "<group>";
@@ -224,8 +246,22 @@
 				9CB8AFDF8AACB2CDF741C5B0 /* Game */,
 				C12D81E2062D1556C063393C /* GameLobby */,
 				D5AAEA07E9E0D4E83C6DED04 /* MainRoom */,
+				CC1234567890ABCDEF000001 /* Tournament */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		CC1234567890ABCDEF000001 /* Tournament */ = {
+			isa = PBXGroup;
+			children = (
+				AA1234567890ABCDEF000005 /* TournamentLobbyView.swift */,
+				AA1234567890ABCDEF000006 /* TournamentPlayerListView.swift */,
+				AA1234567890ABCDEF000007 /* TournamentChatView.swift */,
+				AA1234567890ABCDEF000008 /* TournamentScoreboardView.swift */,
+				AA1234567890ABCDEF000009 /* TournamentActiveGamesView.swift */,
+				AA1234567890ABCDEF00000A /* TournamentResultsView.swift */,
+			);
+			path = Tournament;
 			sourceTree = "<group>";
 		};
 		72042726A6D40442AA539569 /* Constants */ = {
@@ -361,7 +397,7 @@
 		E80216038A0F001B2BEA7D32 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				7F8955A183A4B54328782B3C /* BABOnline.app */,
+				7F8955A183A4B54328782B3C /* BAB Online.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -373,6 +409,7 @@
 				006A718437AB193FE3F34B14 /* GameState.swift */,
 				E9B310B890DA152FC2DC27BB /* LobbyState.swift */,
 				D8BFDA96358A6BEB484A42FB /* MainRoomState.swift */,
+				AA1234567890ABCDEF000002 /* TournamentState.swift */,
 			);
 			path = State;
 			sourceTree = "<group>";
@@ -393,6 +430,7 @@
 				5BA11DB6AFE269661E829F5A /* Lobby.swift */,
 				7187D649710ECFC3C9A68D59 /* Player.swift */,
 				ABD47677D06A3496EC34B3AC /* ScoreData.swift */,
+				AA1234567890ABCDEF000001 /* Tournament.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -425,7 +463,7 @@
 				369628F9131811122EB62EAD /* SocketIO */,
 			);
 			productName = BABOnline;
-			productReference = 7F8955A183A4B54328782B3C /* BABOnline.app */;
+			productReference = 7F8955A183A4B54328782B3C /* BAB Online.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -438,7 +476,6 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					2AC5F2EA7EC758EF4B1916F8 = {
-						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -454,9 +491,8 @@
 			mainGroup = 426F53F5D8BE43B74A85A9D1;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket.io-client-swift" */,
+				68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket" */,
 			);
-			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -546,6 +582,16 @@
 				935CFA3A9A5E985D296ADBB6 /* SplashView.swift in Sources */,
 				762849D3514C9326C39FFF29 /* TrickAreaNode.swift in Sources */,
 				1A52C4D663DFAE60116D9CB0 /* TrickHistoryNode.swift in Sources */,
+				BB1234567890ABCDEF000001 /* Tournament.swift in Sources */,
+				BB1234567890ABCDEF000002 /* TournamentState.swift in Sources */,
+				BB1234567890ABCDEF000003 /* TournamentEmitter.swift in Sources */,
+				BB1234567890ABCDEF000004 /* TournamentSocketHandler.swift in Sources */,
+				BB1234567890ABCDEF000005 /* TournamentLobbyView.swift in Sources */,
+				BB1234567890ABCDEF000006 /* TournamentPlayerListView.swift in Sources */,
+				BB1234567890ABCDEF000007 /* TournamentChatView.swift in Sources */,
+				BB1234567890ABCDEF000008 /* TournamentScoreboardView.swift in Sources */,
+				BB1234567890ABCDEF000009 /* TournamentActiveGamesView.swift in Sources */,
+				BB1234567890ABCDEF00000A /* TournamentResultsView.swift in Sources */,
 				01BE20189A36B2369389142A /* UsernameColor.swift in Sources */,
 				39B5487AEDCCC050AFED060C /* View+Haptics.swift in Sources */,
 			);
@@ -617,8 +663,9 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 9SYNY7K2HE;
 				INFOPLIST_FILE = BABOnline/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.card-games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -707,8 +754,9 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 9SYNY7K2HE;
 				INFOPLIST_FILE = BABOnline/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.card-games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -751,7 +799,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket.io-client-swift" */ = {
+		68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/socketio/socket.io-client-swift";
 			requirement = {
@@ -764,7 +812,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		369628F9131811122EB62EAD /* SocketIO */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket.io-client-swift" */;
+			package = 68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket" */;
 			productName = SocketIO;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/iOSClient/BABOnline/AppState.swift
+++ b/iOSClient/BABOnline/AppState.swift
@@ -7,6 +7,7 @@ final class AppState: ObservableObject {
         case register
         case mainRoom
         case gameLobby
+        case tournamentLobby
         case game
     }
 

--- a/iOSClient/BABOnline/BABOnlineApp.swift
+++ b/iOSClient/BABOnline/BABOnlineApp.swift
@@ -7,6 +7,7 @@ struct BABOnlineApp: App {
     @StateObject private var mainRoomState = MainRoomState()
     @StateObject private var lobbyState = LobbyState()
     @StateObject private var gameState = GameState()
+    @StateObject private var tournamentState = TournamentState()
     @Environment(\.scenePhase) private var scenePhase
 
     private let socketService = SocketService.shared
@@ -19,6 +20,7 @@ struct BABOnlineApp: App {
                 .environmentObject(mainRoomState)
                 .environmentObject(lobbyState)
                 .environmentObject(gameState)
+                .environmentObject(tournamentState)
                 .environmentObject(socketService)
                 .onAppear {
                     setupSocket()
@@ -40,7 +42,8 @@ struct BABOnlineApp: App {
             mainRoomState: mainRoomState,
             lobbyState: lobbyState,
             gameState: gameState,
-            appState: appState
+            appState: appState,
+            tournamentState: tournamentState
         )
         router.registerAll()
         socketService.eventRouter = router

--- a/iOSClient/BABOnline/Constants/SocketEvents.swift
+++ b/iOSClient/BABOnline/Constants/SocketEvents.swift
@@ -38,6 +38,19 @@ enum SocketEvents {
         // Bots
         static let addBot = "addBot"
         static let removeBot = "removeBot"
+
+        // Tournament
+        static let createTournament = "createTournament"
+        static let joinTournament = "joinTournament"
+        static let leaveTournament = "leaveTournament"
+        static let tournamentReady = "tournamentReady"
+        static let tournamentUnready = "tournamentUnready"
+        static let beginTournament = "beginTournament"
+        static let beginNextRound = "beginNextRound"
+        static let tournamentChat = "tournamentChat"
+        static let spectateTournament = "spectateTournament"
+        static let spectateTournamentGame = "spectateTournamentGame"
+        static let returnToTournament = "returnToTournament"
     }
 
     // MARK: - Server → Client
@@ -107,6 +120,21 @@ enum SocketEvents {
         static let leftGame = "leftGame"
         static let restorePlayerState = "restorePlayerState"
         static let spectatorJoined = "spectatorJoined"
+
+        // Tournament
+        static let tournamentCreated = "tournamentCreated"
+        static let tournamentJoined = "tournamentJoined"
+        static let tournamentPlayerJoined = "tournamentPlayerJoined"
+        static let tournamentPlayerLeft = "tournamentPlayerLeft"
+        static let tournamentReadyUpdate = "tournamentReadyUpdate"
+        static let tournamentMessage = "tournamentMessage"
+        static let tournamentRoundStart = "tournamentRoundStart"
+        static let tournamentGameAssignment = "tournamentGameAssignment"
+        static let tournamentGameComplete = "tournamentGameComplete"
+        static let tournamentRoundComplete = "tournamentRoundComplete"
+        static let tournamentComplete = "tournamentComplete"
+        static let tournamentLeft = "tournamentLeft"
+        static let activeTournamentFound = "activeTournamentFound"
 
         // Connection
         static let connect = "connect"

--- a/iOSClient/BABOnline/ContentView.swift
+++ b/iOSClient/BABOnline/ContentView.swift
@@ -23,6 +23,8 @@ struct ContentView: View {
                         MainRoomView()
                     case .gameLobby:
                         GameLobbyView()
+                    case .tournamentLobby:
+                        TournamentLobbyView()
                     case .game:
                         GameContainerView()
                     }

--- a/iOSClient/BABOnline/Models/ChatMessage.swift
+++ b/iOSClient/BABOnline/Models/ChatMessage.swift
@@ -27,7 +27,11 @@ struct ChatMessage: Identifiable, Equatable {
         let username = dict["username"] as? String ?? "System"
         let message = dict["message"] as? String ?? ""
         let typeStr = dict["type"] as? String ?? "player"
-        let type = MessageType(rawValue: typeStr) ?? .player
+        var type = MessageType(rawValue: typeStr) ?? .player
+        // Tournament messages use isSpectator boolean instead of type string
+        if dict["isSpectator"] as? Bool == true {
+            type = .spectator
+        }
         let position = dict["position"] as? Int
         return ChatMessage(username: username, message: message, type: type, position: position)
     }

--- a/iOSClient/BABOnline/Models/Tournament.swift
+++ b/iOSClient/BABOnline/Models/Tournament.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+struct TournamentPlayer: Identifiable, Equatable {
+    let id: String          // socket ID
+    let username: String
+    var pic: String?
+    var isReady: Bool
+    var isCreator: Bool
+
+    static func from(_ dict: [String: Any]) -> TournamentPlayer? {
+        guard let username = dict["username"] as? String else { return nil }
+        let id = dict["socketId"] as? String ?? dict["id"] as? String ?? UUID().uuidString
+        let pic: String?
+        if let s = dict["pic"] as? String { pic = s }
+        else if let n = dict["pic"] as? Int { pic = String(n) }
+        else { pic = nil }
+        let isReady = dict["ready"] as? Bool ?? dict["isReady"] as? Bool ?? false
+        let isCreator = dict["isCreator"] as? Bool ?? false
+        return TournamentPlayer(id: id, username: username, pic: pic, isReady: isReady, isCreator: isCreator)
+    }
+}
+
+struct TournamentScoreEntry: Identifiable, Equatable {
+    let id: String
+    let username: String
+    let totalScore: Int
+    let roundScores: [Int]
+
+    static func from(_ dict: [String: Any]) -> TournamentScoreEntry? {
+        guard let username = dict["username"] as? String else { return nil }
+        let totalScore = dict["totalScore"] as? Int ?? 0
+        let roundScores = dict["roundScores"] as? [Int] ?? []
+        return TournamentScoreEntry(id: username, username: username, totalScore: totalScore, roundScores: roundScores)
+    }
+}
+
+struct TournamentActiveGame: Identifiable, Equatable {
+    let id: String          // game ID
+    let humanPlayers: [String]
+    let botCount: Int
+    let status: String
+
+    static func from(_ dict: [String: Any]) -> TournamentActiveGame? {
+        guard let id = dict["gameId"] as? String else { return nil }
+        let humanPlayers = dict["humanPlayers"] as? [String] ?? []
+        let botCount = dict["botCount"] as? Int ?? 0
+        let status = dict["status"] as? String ?? "active"
+        return TournamentActiveGame(id: id, humanPlayers: humanPlayers, botCount: botCount, status: status)
+    }
+}
+
+struct TournamentSummary: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let playerCount: Int
+    let phase: String
+    let currentRound: Int
+    let totalRounds: Int
+    let creatorUsername: String
+
+    static func from(_ dict: [String: Any]) -> TournamentSummary? {
+        guard let id = dict["id"] as? String else { return nil }
+        let name = dict["name"] as? String ?? "Tournament"
+        let playerCount = dict["playerCount"] as? Int ?? 0
+        let phase = dict["phase"] as? String ?? "lobby"
+        let currentRound = dict["currentRound"] as? Int ?? 0
+        let totalRounds = dict["totalRounds"] as? Int ?? 4
+        let creatorUsername = dict["creatorUsername"] as? String ?? ""
+        return TournamentSummary(id: id, name: name, playerCount: playerCount, phase: phase, currentRound: currentRound, totalRounds: totalRounds, creatorUsername: creatorUsername)
+    }
+}

--- a/iOSClient/BABOnline/Networking/Emitters/TournamentEmitter.swift
+++ b/iOSClient/BABOnline/Networking/Emitters/TournamentEmitter.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum TournamentEmitter {
+    private static var socket: SocketService { .shared }
+
+    static func createTournament() {
+        socket.emit(SocketEvents.Client.createTournament, [:])
+    }
+
+    static func joinTournament(tournamentId: String) {
+        socket.emit(SocketEvents.Client.joinTournament, ["tournamentId": tournamentId])
+    }
+
+    static func leaveTournament() {
+        socket.emit(SocketEvents.Client.leaveTournament)
+    }
+
+    static func tournamentReady() {
+        socket.emit(SocketEvents.Client.tournamentReady)
+    }
+
+    static func tournamentUnready() {
+        socket.emit(SocketEvents.Client.tournamentUnready)
+    }
+
+    static func beginTournament() {
+        socket.emit(SocketEvents.Client.beginTournament)
+    }
+
+    static func beginNextRound() {
+        socket.emit(SocketEvents.Client.beginNextRound)
+    }
+
+    static func tournamentChat(message: String) {
+        socket.emit(SocketEvents.Client.tournamentChat, ["message": message])
+    }
+
+    static func spectateTournament(tournamentId: String) {
+        socket.emit(SocketEvents.Client.spectateTournament, ["tournamentId": tournamentId])
+    }
+
+    static func spectateTournamentGame(gameId: String) {
+        socket.emit(SocketEvents.Client.spectateTournamentGame, ["gameId": gameId])
+    }
+
+    static func returnToTournament() {
+        socket.emit(SocketEvents.Client.returnToTournament)
+    }
+}

--- a/iOSClient/BABOnline/Networking/Handlers/AuthSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/AuthSocketHandler.swift
@@ -62,6 +62,9 @@ final class AuthSocketHandler {
                 if let gameId = data["activeGameId"] as? String, !gameId.isEmpty {
                     print("[Auth] Signed in with active game: \(gameId)")
                     AuthEmitter.rejoinGame(gameId: gameId, username: username)
+                } else if let tournamentId = data["activeTournamentId"] as? String, !tournamentId.isEmpty {
+                    print("[Auth] Signed in with active tournament: \(tournamentId)")
+                    TournamentEmitter.joinTournament(tournamentId: tournamentId)
                 } else {
                     self.appState.screen = .mainRoom
                     LobbyEmitter.joinMainRoom()
@@ -127,6 +130,9 @@ final class AuthSocketHandler {
                 if let gameId = data["activeGameId"] as? String, !gameId.isEmpty {
                     print("[Auth] Session restored with active game: \(gameId)")
                     AuthEmitter.rejoinGame(gameId: gameId, username: username)
+                } else if let tournamentId = data["activeTournamentId"] as? String, !tournamentId.isEmpty {
+                    print("[Auth] Session restored with active tournament: \(tournamentId)")
+                    TournamentEmitter.joinTournament(tournamentId: tournamentId)
                 } else {
                     print("[Auth] Session restored for: \(username)")
                     self.appState.screen = .mainRoom

--- a/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
@@ -247,8 +247,13 @@ final class GameSocketHandler {
         socket.on(SocketEvents.Server.abortGame) { [weak self] _, _ in
             guard let self else { return }
             DispatchQueue.main.async {
+                let savedTournamentId = self.gameState.tournamentId
                 self.gameState.reset()
-                self.appState.screen = .mainRoom
+                if savedTournamentId != nil {
+                    TournamentEmitter.returnToTournament()
+                } else {
+                    self.appState.screen = .mainRoom
+                }
             }
         }
 
@@ -397,9 +402,14 @@ final class GameSocketHandler {
         socket.on(SocketEvents.Server.leftGame) { [weak self] _, _ in
             guard let self else { return }
             DispatchQueue.main.async {
+                let savedTournamentId = self.gameState.tournamentId
                 self.gameState.reset()
-                self.appState.screen = .mainRoom
-                LobbyEmitter.joinMainRoom()
+                if savedTournamentId != nil {
+                    TournamentEmitter.returnToTournament()
+                } else {
+                    self.appState.screen = .mainRoom
+                    LobbyEmitter.joinMainRoom()
+                }
             }
         }
 

--- a/iOSClient/BABOnline/Networking/Handlers/LobbySocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/LobbySocketHandler.swift
@@ -32,6 +32,9 @@ final class LobbySocketHandler {
                 if let inProgress = dict["inProgressGames"] as? [[String: Any]] {
                     self.mainRoomState.inProgressGames = inProgress.compactMap { Lobby.from($0) }
                 }
+                if let tournamentsArr = dict["tournaments"] as? [[String: Any]] {
+                    self.mainRoomState.tournaments = tournamentsArr.compactMap { TournamentSummary.from($0) }
+                }
                 print("[Lobby] Joined main room")
             }
         }
@@ -61,6 +64,9 @@ final class LobbySocketHandler {
                 }
                 if let inProgress = dict["inProgressGames"] as? [[String: Any]] {
                     self?.mainRoomState.inProgressGames = inProgress.compactMap { Lobby.from($0) }
+                }
+                if let tournamentsArr = dict["tournaments"] as? [[String: Any]] {
+                    self?.mainRoomState.tournaments = tournamentsArr.compactMap { TournamentSummary.from($0) }
                 }
             }
         }

--- a/iOSClient/BABOnline/Networking/Handlers/TournamentSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/TournamentSocketHandler.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// Handles tournament-related socket events.
+final class TournamentSocketHandler {
+    private let socket: SocketService
+    private let tournamentState: TournamentState
+    private let gameState: GameState
+    private let appState: AppState
+
+    init(socket: SocketService, tournamentState: TournamentState, gameState: GameState, appState: AppState) {
+        self.socket = socket
+        self.tournamentState = tournamentState
+        self.gameState = gameState
+        self.appState = appState
+    }
+
+    func register() {
+        // MARK: - Tournament Created / Joined
+
+        socket.on(SocketEvents.Server.tournamentCreated) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                self.tournamentState.loadFromServerState(dict)
+                self.appState.screen = .tournamentLobby
+                print("[Tournament] Created tournament: \(self.tournamentState.tournamentId)")
+            }
+        }
+
+        socket.on(SocketEvents.Server.tournamentJoined) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                self.tournamentState.loadFromServerState(dict)
+                self.appState.screen = .tournamentLobby
+                print("[Tournament] Joined tournament: \(self.tournamentState.tournamentId)")
+            }
+        }
+
+        // MARK: - Player Updates
+
+        socket.on(SocketEvents.Server.tournamentPlayerJoined) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                if let playersArr = dict["players"] as? [[String: Any]] {
+                    self.tournamentState.players = playersArr.compactMap { TournamentPlayer.from($0) }
+                }
+            }
+        }
+
+        socket.on(SocketEvents.Server.tournamentPlayerLeft) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                if let playersArr = dict["players"] as? [[String: Any]] {
+                    self.tournamentState.players = playersArr.compactMap { TournamentPlayer.from($0) }
+                }
+                // Handle creator transfer
+                if let newCreator = dict["newCreator"] as? String {
+                    self.tournamentState.creatorUsername = newCreator
+                }
+            }
+        }
+
+        socket.on(SocketEvents.Server.tournamentReadyUpdate) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                if let playersArr = dict["players"] as? [[String: Any]] {
+                    self.tournamentState.players = playersArr.compactMap { TournamentPlayer.from($0) }
+                }
+            }
+        }
+
+        // MARK: - Chat
+
+        socket.on(SocketEvents.Server.tournamentMessage) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                if let msg = ChatMessage.from(dict) {
+                    self.tournamentState.messages.append(msg)
+                }
+            }
+        }
+
+        // MARK: - Round Flow
+
+        socket.on(SocketEvents.Server.tournamentRoundStart) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                self.tournamentState.phase = "round_active"
+                if let round = dict["roundNumber"] as? Int {
+                    self.tournamentState.currentRound = round
+                }
+                if let total = dict["totalRounds"] as? Int {
+                    self.tournamentState.totalRounds = total
+                }
+                print("[Tournament] Round \(self.tournamentState.currentRound) started")
+            }
+        }
+
+        socket.on(SocketEvents.Server.tournamentGameAssignment) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                // Store tournament context on game state so game-end knows to return here
+                if let tournamentId = dict["tournamentId"] as? String {
+                    self.gameState.tournamentId = tournamentId
+                }
+                print("[Tournament] Game assigned: \(dict["gameId"] as? String ?? "")")
+            }
+        }
+
+        socket.on(SocketEvents.Server.tournamentGameComplete) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                if let gamesArr = dict["activeGames"] as? [[String: Any]] {
+                    self.tournamentState.activeGames = gamesArr.compactMap { TournamentActiveGame.from($0) }
+                }
+                if let scoreboardArr = dict["scoreboard"] as? [[String: Any]] {
+                    self.tournamentState.scoreboard = scoreboardArr.compactMap { TournamentScoreEntry.from($0) }
+                }
+                if let round = dict["currentRound"] as? Int {
+                    self.tournamentState.currentRound = round
+                }
+            }
+        }
+
+        socket.on(SocketEvents.Server.tournamentRoundComplete) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                self.tournamentState.phase = "between_rounds"
+                self.tournamentState.isReady = false
+                if let scoreboardArr = dict["scoreboard"] as? [[String: Any]] {
+                    self.tournamentState.scoreboard = scoreboardArr.compactMap { TournamentScoreEntry.from($0) }
+                }
+                if let round = dict["currentRound"] as? Int {
+                    self.tournamentState.currentRound = round
+                }
+                // Reset player ready states
+                for i in self.tournamentState.players.indices {
+                    self.tournamentState.players[i].isReady = false
+                }
+                print("[Tournament] Round \(self.tournamentState.currentRound) complete")
+            }
+        }
+
+        socket.on(SocketEvents.Server.tournamentComplete) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                self.tournamentState.phase = "complete"
+                if let scoreboardArr = dict["scoreboard"] as? [[String: Any]] {
+                    self.tournamentState.scoreboard = scoreboardArr.compactMap { TournamentScoreEntry.from($0) }
+                }
+                print("[Tournament] Tournament complete")
+            }
+        }
+
+        // MARK: - Leave / Reconnect
+
+        socket.on(SocketEvents.Server.tournamentLeft) { [weak self] _, _ in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                self.tournamentState.reset()
+                self.appState.screen = .mainRoom
+                LobbyEmitter.joinMainRoom()
+                print("[Tournament] Left tournament")
+            }
+        }
+
+        socket.on(SocketEvents.Server.activeTournamentFound) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                if let tournamentId = dict["tournamentId"] as? String {
+                    TournamentEmitter.joinTournament(tournamentId: tournamentId)
+                    print("[Tournament] Active tournament found, rejoining: \(tournamentId)")
+                }
+            }
+        }
+    }
+}

--- a/iOSClient/BABOnline/Networking/SocketEventRouter.swift
+++ b/iOSClient/BABOnline/Networking/SocketEventRouter.swift
@@ -8,6 +8,7 @@ final class SocketEventRouter {
     private let lobbyHandler: LobbySocketHandler
     private let gameHandler: GameSocketHandler
     private let chatHandler: ChatSocketHandler
+    private let tournamentHandler: TournamentSocketHandler
 
     init(
         socket: SocketService,
@@ -15,13 +16,15 @@ final class SocketEventRouter {
         mainRoomState: MainRoomState,
         lobbyState: LobbyState,
         gameState: GameState,
-        appState: AppState
+        appState: AppState,
+        tournamentState: TournamentState
     ) {
         self.socket = socket
         self.authHandler = AuthSocketHandler(socket: socket, authState: authState, appState: appState, gameState: gameState)
         self.lobbyHandler = LobbySocketHandler(socket: socket, mainRoomState: mainRoomState, lobbyState: lobbyState, appState: appState, gameState: gameState)
         self.gameHandler = GameSocketHandler(socket: socket, gameState: gameState, appState: appState)
         self.chatHandler = ChatSocketHandler(socket: socket, gameState: gameState)
+        self.tournamentHandler = TournamentSocketHandler(socket: socket, tournamentState: tournamentState, gameState: gameState, appState: appState)
     }
 
     func registerAll() {
@@ -29,5 +32,6 @@ final class SocketEventRouter {
         lobbyHandler.register()
         gameHandler.register()
         chatHandler.register()
+        tournamentHandler.register()
     }
 }

--- a/iOSClient/BABOnline/State/GameState.swift
+++ b/iOSClient/BABOnline/State/GameState.swift
@@ -27,6 +27,7 @@ final class GameState: ObservableObject {
     // MARK: - Game Info
 
     @Published var gameId: String?
+    @Published var tournamentId: String?
     @Published var phase: GamePhase = .none
     @Published var currentHand: Int = 0
     @Published var dealer: Int?
@@ -155,6 +156,7 @@ final class GameState: ObservableObject {
         pic = nil
 
         gameId = nil
+        tournamentId = nil
         phase = .none
         currentHand = 0
         dealer = nil

--- a/iOSClient/BABOnline/State/MainRoomState.swift
+++ b/iOSClient/BABOnline/State/MainRoomState.swift
@@ -6,11 +6,13 @@ final class MainRoomState: ObservableObject {
     @Published var inProgressGames: [Lobby] = []
     @Published var messages: [ChatMessage] = []
     @Published var onlineCount: Int = 0
+    @Published var tournaments: [TournamentSummary] = []
 
     func reset() {
         lobbies = []
         inProgressGames = []
         messages = []
         onlineCount = 0
+        tournaments = []
     }
 }

--- a/iOSClient/BABOnline/State/TournamentState.swift
+++ b/iOSClient/BABOnline/State/TournamentState.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// State for the tournament lobby screen.
+final class TournamentState: ObservableObject {
+    @Published var tournamentId: String = ""
+    @Published var name: String = ""
+    @Published var phase: String = "lobby"      // lobby, round_active, between_rounds, complete
+    @Published var currentRound: Int = 0
+    @Published var totalRounds: Int = 4
+    @Published var players: [TournamentPlayer] = []
+    @Published var messages: [ChatMessage] = []
+    @Published var scoreboard: [TournamentScoreEntry] = []
+    @Published var activeGames: [TournamentActiveGame] = []
+    @Published var creatorUsername: String = ""
+    @Published var isSpectator: Bool = false
+    @Published var isReady: Bool = false
+
+    func reset() {
+        tournamentId = ""
+        name = ""
+        phase = "lobby"
+        currentRound = 0
+        totalRounds = 4
+        players = []
+        messages = []
+        scoreboard = []
+        activeGames = []
+        creatorUsername = ""
+        isSpectator = false
+        isReady = false
+    }
+
+    func loadFromServerState(_ dict: [String: Any]) {
+        tournamentId = dict["tournamentId"] as? String ?? ""
+        name = dict["name"] as? String ?? ""
+        phase = dict["phase"] as? String ?? "lobby"
+        currentRound = dict["currentRound"] as? Int ?? 0
+        totalRounds = dict["totalRounds"] as? Int ?? 4
+        creatorUsername = dict["creatorUsername"] as? String ?? ""
+        isSpectator = dict["isSpectator"] as? Bool ?? false
+
+        if let playersArr = dict["players"] as? [[String: Any]] {
+            players = playersArr.compactMap { TournamentPlayer.from($0) }
+        }
+
+        if let messagesArr = dict["messages"] as? [[String: Any]] {
+            messages = messagesArr.compactMap { ChatMessage.from($0) }
+        }
+
+        if let scoreboardArr = dict["scoreboard"] as? [[String: Any]] {
+            scoreboard = scoreboardArr.compactMap { TournamentScoreEntry.from($0) }
+        }
+
+        if let gamesArr = dict["activeGames"] as? [[String: Any]] {
+            activeGames = gamesArr.compactMap { TournamentActiveGame.from($0) }
+        }
+    }
+}

--- a/iOSClient/BABOnline/Views/Game/GameEndView.swift
+++ b/iOSClient/BABOnline/Views/Game/GameEndView.swift
@@ -52,12 +52,12 @@ struct GameEndView: View {
                     }
                 }
 
-                Button(action: returnToMainRoom) {
-                    Text("Return to Lobby")
+                Button(action: returnAction) {
+                    Text(gameState.tournamentId != nil ? "Return to Tournament" : "Return to Lobby")
                         .font(.body.bold())
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 14)
-                        .background(Color.Theme.buttonBackground)
+                        .background(gameState.tournamentId != nil ? Color.Theme.warning : Color.Theme.buttonBackground)
                         .foregroundColor(.white)
                         .cornerRadius(10)
                 }
@@ -72,9 +72,14 @@ struct GameEndView: View {
         }
     }
 
-    private func returnToMainRoom() {
+    private func returnAction() {
+        let savedTournamentId = gameState.tournamentId
         gameState.reset()
-        appState.screen = .mainRoom
-        LobbyEmitter.joinMainRoom()
+        if savedTournamentId != nil {
+            TournamentEmitter.returnToTournament()
+        } else {
+            appState.screen = .mainRoom
+            LobbyEmitter.joinMainRoom()
+        }
     }
 }

--- a/iOSClient/BABOnline/Views/MainRoom/LobbyListView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/LobbyListView.swift
@@ -6,7 +6,7 @@ struct LobbyListView: View {
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 1) {
-                if mainRoomState.lobbies.isEmpty && mainRoomState.inProgressGames.isEmpty {
+                if mainRoomState.lobbies.isEmpty && mainRoomState.inProgressGames.isEmpty && mainRoomState.tournaments.isEmpty {
                     VStack(spacing: 12) {
                         Image(systemName: "gamecontroller")
                             .font(.system(size: 40))
@@ -36,6 +36,20 @@ struct LobbyListView: View {
 
                         ForEach(mainRoomState.inProgressGames) { game in
                             LobbyRowView(lobby: game, isInProgress: true)
+                        }
+                    }
+
+                    // Tournaments
+                    if !mainRoomState.tournaments.isEmpty {
+                        Text("Tournaments")
+                            .font(.caption.bold())
+                            .foregroundColor(Color.Theme.warning)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal)
+                            .padding(.top, 12)
+
+                        ForEach(mainRoomState.tournaments) { tournament in
+                            TournamentRowView(tournament: tournament)
                         }
                     }
                 }
@@ -84,6 +98,78 @@ struct LobbyRowView: View {
                         .padding(.horizontal, 20)
                         .padding(.vertical, 8)
                         .background(Color.Theme.buttonBackground)
+                        .cornerRadius(8)
+                }
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+        .background(Color.Theme.surface)
+    }
+}
+
+struct TournamentRowView: View {
+    let tournament: TournamentSummary
+
+    private var phaseDescription: String {
+        switch tournament.phase {
+        case "lobby": return "Waiting to start"
+        case "round_active": return "Round \(tournament.currentRound) of \(tournament.totalRounds)"
+        case "between_rounds": return "Between rounds (\(tournament.currentRound)/\(tournament.totalRounds))"
+        case "complete": return "Complete"
+        default: return tournament.phase
+        }
+    }
+
+    private var canJoin: Bool {
+        tournament.phase == "lobby" || tournament.phase == "between_rounds"
+    }
+
+    private var canSpectate: Bool {
+        tournament.phase == "round_active"
+    }
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Image(systemName: "trophy.fill")
+                        .font(.caption)
+                        .foregroundColor(Color.Theme.warning)
+                    Text(tournament.name)
+                        .font(.body.bold())
+                        .foregroundColor(Color.Theme.warning)
+                }
+
+                Text("\(tournament.playerCount) players \u{2022} \(phaseDescription)")
+                    .font(.caption)
+                    .foregroundColor(Color.Theme.textSecondary)
+            }
+
+            Spacer()
+
+            if canJoin {
+                Button(action: {
+                    TournamentEmitter.joinTournament(tournamentId: tournament.id)
+                }) {
+                    Text("Join")
+                        .font(.callout.bold())
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 8)
+                        .background(Color.Theme.buttonBackground)
+                        .cornerRadius(8)
+                }
+            } else if canSpectate {
+                Button(action: {
+                    TournamentEmitter.spectateTournament(tournamentId: tournament.id)
+                }) {
+                    Text("Spectate")
+                        .font(.callout.bold())
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(Color(red: 0.376, green: 0.647, blue: 0.98))
                         .cornerRadius(8)
                 }
             }

--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
@@ -61,6 +61,12 @@ struct MainRoomView: View {
                     .font(.caption)
                     .foregroundColor(Color.Theme.textSecondary)
 
+                Button(action: { TournamentEmitter.createTournament() }) {
+                    Label("Tournament", systemImage: "trophy.fill")
+                        .font(.callout.bold())
+                        .foregroundColor(Color.Theme.warning)
+                }
+
                 Button(action: { LobbyEmitter.createLobby() }) {
                     Label("Create", systemImage: "plus.circle.fill")
                         .font(.callout.bold())

--- a/iOSClient/BABOnline/Views/Tournament/TournamentActiveGamesView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentActiveGamesView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct TournamentActiveGamesView: View {
+    @EnvironmentObject var tournamentState: TournamentState
+
+    var body: some View {
+        let activeGames = tournamentState.activeGames.filter { $0.status == "active" }
+
+        if tournamentState.phase == "round_active" && !activeGames.isEmpty {
+            VStack(spacing: 0) {
+                HStack {
+                    Text("Active Games")
+                        .font(.caption.bold())
+                        .foregroundColor(Color.Theme.textSecondary)
+                    Spacer()
+                }
+                .padding(.horizontal)
+                .padding(.top, 12)
+                .padding(.bottom, 4)
+
+                ForEach(activeGames) { game in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(game.humanPlayers.joined(separator: ", "))
+                                .font(.caption)
+                                .foregroundColor(Color.Theme.textPrimary)
+                                .lineLimit(1)
+
+                            if game.botCount > 0 {
+                                Text("+ \(game.botCount) bot\(game.botCount == 1 ? "" : "s")")
+                                    .font(.caption2)
+                                    .foregroundColor(Color.Theme.textDim)
+                            }
+                        }
+
+                        Spacer()
+
+                        Button(action: {
+                            TournamentEmitter.spectateTournamentGame(gameId: game.id)
+                        }) {
+                            Text("Watch")
+                                .font(.caption.bold())
+                                .foregroundColor(.white)
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 6)
+                                .background(Color(red: 0.376, green: 0.647, blue: 0.98))
+                                .cornerRadius(6)
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 8)
+                }
+            }
+            .background(Color.Theme.surface)
+            .cornerRadius(10)
+            .padding(.horizontal)
+        }
+    }
+}

--- a/iOSClient/BABOnline/Views/Tournament/TournamentChatView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentChatView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct TournamentChatView: View {
+    @EnvironmentObject var tournamentState: TournamentState
+    @State private var message = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider().background(Color.Theme.inputBorder)
+
+            // Messages
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 4) {
+                        ForEach(tournamentState.messages) { msg in
+                            ChatBubbleView(message: msg)
+                                .id(msg.id)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                }
+                .scrollDismissesKeyboard(.interactively)
+                .onChange(of: tournamentState.messages.count) {
+                    if let last = tournamentState.messages.last {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            proxy.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+
+            Divider().background(Color.Theme.inputBorder)
+
+            // Input
+            HStack(spacing: 8) {
+                TextField("Chat...", text: $message)
+                    .textFieldStyle(BABTextFieldStyle())
+                    .onSubmit(sendMessage)
+
+                Button(action: sendMessage) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                        .foregroundColor(message.isEmpty ? Color.Theme.textDim : Color.Theme.primary)
+                }
+                .disabled(message.isEmpty)
+            }
+            .padding(8)
+        }
+    }
+
+    private func sendMessage() {
+        let text = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        TournamentEmitter.tournamentChat(message: text)
+        message = ""
+    }
+}

--- a/iOSClient/BABOnline/Views/Tournament/TournamentLobbyView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentLobbyView.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+
+struct TournamentLobbyView: View {
+    @EnvironmentObject var appState: AppState
+    @EnvironmentObject var authState: AuthState
+    @EnvironmentObject var tournamentState: TournamentState
+
+    var body: some View {
+        ZStack {
+            Color.Theme.background.ignoresSafeArea()
+
+            GeometryReader { geo in
+                if geo.size.width > LayoutConstants.compactWidthThreshold {
+                    // iPad: side-by-side
+                    HStack(spacing: 0) {
+                        leftPanel
+                            .frame(width: geo.size.width * 0.55)
+                        Divider().background(Color.Theme.inputBorder)
+                        rightPanel
+                            .frame(maxWidth: .infinity)
+                    }
+                } else {
+                    // iPhone: stacked
+                    VStack(spacing: 0) {
+                        headerBar
+                        ScrollView {
+                            VStack(spacing: 16) {
+                                TournamentPlayerListView()
+                                TournamentScoreboardView()
+                                TournamentActiveGamesView()
+                                TournamentChatView()
+                                    .frame(minHeight: 200)
+                            }
+                            .padding(.bottom, 8)
+                        }
+                        bottomButtons
+                    }
+                }
+            }
+
+            // Results overlay
+            if tournamentState.phase == "complete" {
+                TournamentResultsView()
+            }
+        }
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+    }
+
+    // MARK: - iPad Layout
+
+    private var leftPanel: some View {
+        VStack(spacing: 0) {
+            headerBar
+            TournamentPlayerListView()
+            TournamentChatView()
+            bottomButtons
+        }
+    }
+
+    private var rightPanel: some View {
+        VStack(spacing: 0) {
+            TournamentScoreboardView()
+            TournamentActiveGamesView()
+            Spacer()
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerBar: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button(action: leaveTournament) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text("Leave")
+                    }
+                    .foregroundColor(Color.Theme.textSecondary)
+                }
+
+                Spacer()
+
+                VStack(spacing: 2) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "trophy.fill")
+                            .foregroundColor(Color.Theme.warning)
+                        Text(tournamentState.name.isEmpty ? "Tournament" : tournamentState.name)
+                            .font(.headline)
+                            .foregroundColor(Color.Theme.warning)
+                    }
+                    Text(roundIndicator)
+                        .font(.caption)
+                        .foregroundColor(Color.Theme.textSecondary)
+                }
+
+                Spacer()
+
+                Text("\(tournamentState.players.count) players")
+                    .font(.caption)
+                    .foregroundColor(Color.Theme.textSecondary)
+            }
+            .padding()
+
+            Divider().background(Color.Theme.inputBorder)
+        }
+    }
+
+    private var roundIndicator: String {
+        switch tournamentState.phase {
+        case "lobby": return "Waiting to start"
+        case "round_active": return "Round \(tournamentState.currentRound) of \(tournamentState.totalRounds)"
+        case "between_rounds": return "Round \(tournamentState.currentRound) complete"
+        case "complete": return "Tournament complete"
+        default: return ""
+        }
+    }
+
+    // MARK: - Bottom Buttons
+
+    private var isCreator: Bool {
+        authState.username == tournamentState.creatorUsername
+    }
+
+    private var allReady: Bool {
+        !tournamentState.players.isEmpty && tournamentState.players.allSatisfy { $0.isReady }
+    }
+
+    private var bottomButtons: some View {
+        VStack(spacing: 8) {
+            if tournamentState.phase == "lobby" || tournamentState.phase == "between_rounds" {
+                // Ready / Unready
+                Button(action: toggleReady) {
+                    Text(tournamentState.isReady ? "Unready" : "Ready")
+                        .font(.title3.bold())
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(tournamentState.isReady ? Color.Theme.oppColor : Color.Theme.buttonBackground)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+
+                // Begin button (creator only)
+                if isCreator {
+                    let label = tournamentState.phase == "lobby" ? "Begin Tournament" : "Begin Next Round"
+                    Button(action: beginRound) {
+                        Text(label)
+                            .font(.title3.bold())
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(allReady ? Color.Theme.warning : Color.Theme.buttonDisabled)
+                            .foregroundColor(.white)
+                            .cornerRadius(10)
+                    }
+                    .disabled(!allReady)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Actions
+
+    private func toggleReady() {
+        tournamentState.isReady.toggle()
+        if tournamentState.isReady {
+            TournamentEmitter.tournamentReady()
+        } else {
+            TournamentEmitter.tournamentUnready()
+        }
+        HapticManager.mediumImpact()
+    }
+
+    private func beginRound() {
+        if tournamentState.phase == "lobby" {
+            TournamentEmitter.beginTournament()
+        } else {
+            TournamentEmitter.beginNextRound()
+        }
+    }
+
+    private func leaveTournament() {
+        TournamentEmitter.leaveTournament()
+    }
+}

--- a/iOSClient/BABOnline/Views/Tournament/TournamentPlayerListView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentPlayerListView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct TournamentPlayerListView: View {
+    @EnvironmentObject var authState: AuthState
+    @EnvironmentObject var tournamentState: TournamentState
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Players")
+                    .font(.caption.bold())
+                    .foregroundColor(Color.Theme.textSecondary)
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.top, 12)
+            .padding(.bottom, 4)
+
+            VStack(spacing: 8) {
+                ForEach(tournamentState.players) { player in
+                    playerRow(player)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+        }
+    }
+
+    private func playerRow(_ player: TournamentPlayer) -> some View {
+        let isCurrentUser = player.username == authState.username
+
+        return HStack(spacing: 12) {
+            // Avatar
+            Circle()
+                .fill(isCurrentUser ? Color.Theme.primary.opacity(0.3) : Color.Theme.surfaceLight)
+                .frame(width: 40, height: 40)
+                .overlay(
+                    Image(systemName: "person.fill")
+                        .foregroundColor(isCurrentUser ? Color.Theme.primary : Color.Theme.textSecondary)
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(player.username)
+                        .font(.body.bold())
+                        .foregroundColor(isCurrentUser ? Color.Theme.primary : Color.Theme.textPrimary)
+
+                    if isCurrentUser {
+                        Text("(you)")
+                            .font(.caption)
+                            .foregroundColor(Color.Theme.textDim)
+                    }
+
+                    if player.isCreator {
+                        Text("HOST")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundColor(Color.Theme.warning)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.Theme.warning.opacity(0.15))
+                            .cornerRadius(4)
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Ready indicator
+            if player.isReady {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(Color.Theme.success)
+                    .font(.title3)
+            } else {
+                Image(systemName: "circle")
+                    .foregroundColor(Color.Theme.textDim)
+                    .font(.title3)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+        .background(Color.Theme.surface)
+        .cornerRadius(10)
+    }
+}

--- a/iOSClient/BABOnline/Views/Tournament/TournamentResultsView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentResultsView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct TournamentResultsView: View {
+    @EnvironmentObject var tournamentState: TournamentState
+    @EnvironmentObject var appState: AppState
+
+    private var winner: TournamentScoreEntry? {
+        tournamentState.scoreboard.first
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.7).ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                // Trophy icon
+                Image(systemName: "trophy.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(Color.Theme.warning)
+
+                Text("Tournament Complete!")
+                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                    .foregroundColor(Color.Theme.warning)
+
+                if let winner = winner {
+                    Text("\(winner.username) wins!")
+                        .font(.title2.bold())
+                        .foregroundColor(Color.Theme.textPrimary)
+                }
+
+                // Final standings
+                VStack(spacing: 4) {
+                    ForEach(Array(tournamentState.scoreboard.enumerated()), id: \.element.id) { index, entry in
+                        HStack {
+                            Text("\(index + 1).")
+                                .font(.body.bold())
+                                .frame(width: 24, alignment: .trailing)
+                                .foregroundColor(rankColor(index))
+
+                            Text(entry.username)
+                                .font(.body)
+                                .foregroundColor(Color.Theme.textPrimary)
+
+                            Spacer()
+
+                            Text("\(entry.totalScore)")
+                                .font(.body.bold())
+                                .foregroundColor(rankColor(index))
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 6)
+                    }
+                }
+                .padding(.vertical, 8)
+
+                Button(action: returnToMainRoom) {
+                    Text("Return to Main Room")
+                        .font(.body.bold())
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(Color.Theme.buttonBackground)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+                .padding(.horizontal, 40)
+            }
+            .padding(32)
+            .background(
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color.Theme.surface)
+            )
+            .padding(.horizontal, 24)
+        }
+    }
+
+    private func rankColor(_ index: Int) -> Color {
+        switch index {
+        case 0: return Color(red: 1.0, green: 0.84, blue: 0.0)   // gold
+        case 1: return Color(white: 0.75)                          // silver
+        case 2: return Color(red: 0.8, green: 0.5, blue: 0.2)    // bronze
+        default: return Color.Theme.textSecondary
+        }
+    }
+
+    private func returnToMainRoom() {
+        tournamentState.reset()
+        appState.screen = .mainRoom
+        LobbyEmitter.joinMainRoom()
+    }
+}

--- a/iOSClient/BABOnline/Views/Tournament/TournamentScoreboardView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentScoreboardView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct TournamentScoreboardView: View {
+    @EnvironmentObject var authState: AuthState
+    @EnvironmentObject var tournamentState: TournamentState
+
+    var body: some View {
+        if tournamentState.scoreboard.isEmpty {
+            EmptyView()
+        } else {
+            VStack(spacing: 0) {
+                HStack {
+                    Text("Scoreboard")
+                        .font(.caption.bold())
+                        .foregroundColor(Color.Theme.textSecondary)
+                    Spacer()
+                }
+                .padding(.horizontal)
+                .padding(.top, 12)
+                .padding(.bottom, 4)
+
+                // Header row
+                HStack(spacing: 0) {
+                    Text("Player")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    ForEach(1...tournamentState.totalRounds, id: \.self) { round in
+                        Text("R\(round)")
+                            .frame(width: 40)
+                    }
+                    Text("Total")
+                        .frame(width: 50)
+                        .bold()
+                }
+                .font(.caption)
+                .foregroundColor(Color.Theme.textDim)
+                .padding(.horizontal)
+                .padding(.vertical, 4)
+
+                // Score rows
+                ForEach(Array(tournamentState.scoreboard.enumerated()), id: \.element.id) { index, entry in
+                    let isCurrentUser = entry.username == authState.username
+                    HStack(spacing: 0) {
+                        HStack(spacing: 6) {
+                            if tournamentState.phase == "complete" {
+                                rankBadge(index: index)
+                            }
+                            Text(entry.username)
+                                .lineLimit(1)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        ForEach(0..<tournamentState.totalRounds, id: \.self) { round in
+                            if round < entry.roundScores.count {
+                                Text("\(entry.roundScores[round])")
+                                    .frame(width: 40)
+                            } else {
+                                Text("-")
+                                    .frame(width: 40)
+                                    .foregroundColor(Color.Theme.textDim)
+                            }
+                        }
+
+                        Text("\(entry.totalScore)")
+                            .frame(width: 50)
+                            .bold()
+                    }
+                    .font(.caption)
+                    .foregroundColor(isCurrentUser ? Color.Theme.primary : Color.Theme.textPrimary)
+                    .padding(.horizontal)
+                    .padding(.vertical, 6)
+                    .background(isCurrentUser ? Color.Theme.primary.opacity(0.1) : Color.clear)
+                }
+            }
+            .background(Color.Theme.surface)
+            .cornerRadius(10)
+            .padding(.horizontal)
+        }
+    }
+
+    @ViewBuilder
+    private func rankBadge(index: Int) -> some View {
+        switch index {
+        case 0:
+            Image(systemName: "medal.fill")
+                .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.0))  // gold
+                .font(.caption2)
+        case 1:
+            Image(systemName: "medal.fill")
+                .foregroundColor(Color(white: 0.75))  // silver
+                .font(.caption2)
+        case 2:
+            Image(systemName: "medal.fill")
+                .foregroundColor(Color(red: 0.8, green: 0.5, blue: 0.2))  // bronze
+                .font(.caption2)
+        default:
+            EmptyView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds complete tournament support to the iOS client, matching the existing server and web client functionality
- iOS users can create, join, play in, spectate, and reconnect to multi-round tournaments (4 rounds, players shuffled into games of 4 with bots filling gaps)
- 10 new files (models, state, emitter, socket handler, 6 views) and 14 modified files for integration

## New Files
| File | Purpose |
|------|---------|
| `Models/Tournament.swift` | `TournamentPlayer`, `TournamentScoreEntry`, `TournamentActiveGame`, `TournamentSummary` |
| `State/TournamentState.swift` | `ObservableObject` with all tournament state |
| `Networking/Emitters/TournamentEmitter.swift` | 11 client→server event methods |
| `Networking/Handlers/TournamentSocketHandler.swift` | 13 server→client event handlers |
| `Views/Tournament/TournamentLobbyView.swift` | Main tournament screen (adaptive iPad/iPhone layout) |
| `Views/Tournament/TournamentPlayerListView.swift` | Player list with host badge, ready indicators |
| `Views/Tournament/TournamentChatView.swift` | Chat component (reuses ChatBubbleView) |
| `Views/Tournament/TournamentScoreboardView.swift` | Round-by-round scores with medal icons |
| `Views/Tournament/TournamentActiveGamesView.swift` | Active games with "Watch" buttons |
| `Views/Tournament/TournamentResultsView.swift` | Full-screen results overlay with rankings |

## Key Integration Points
- **Tournament → Game**: `tournamentGameAssignment` stores `tournamentId` on `gameState`, then existing `allPlayersReady` handler transitions to game
- **Game → Tournament**: Game end shows "Return to Tournament" → emits `returnToTournament` → server responds with `tournamentJoined`
- **Auth reconnection**: Checks `activeTournamentId` after `activeGameId` in both sign-in and session restore
- **Main room**: "Tournament" create button + tournament list section in lobby browser

## Test plan
- [ ] Create tournament from main room → tournament lobby appears with yourself as host
- [ ] Second user joins from lobby list → both see updated player list
- [ ] Ready up + Begin → game starts with draw phase
- [ ] Complete game → "Return to Tournament" → back in tournament lobby with scores
- [ ] Subsequent rounds: ready up → "Begin Next Round" → new game
- [ ] After round 4: final results overlay with rankings
- [ ] Spectating: "Spectate" from main room → "Watch" on active game
- [ ] Reconnection: force-kill app during tournament → reopen → auto-rejoins
- [ ] Leave: tap "Leave" at any point → returns to main room

🤖 Generated with [Claude Code](https://claude.com/claude-code)