### PR TITLE
iOS: Bore animations, button rename, reconnection toast

### DIFF
--- a/iOSClient/BABOnline.xcodeproj/project.pbxproj
+++ b/iOSClient/BABOnline.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		F74A788A36EF3556E7FD78E0 /* AuthSocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28474CFED18B3E46768C988 /* AuthSocketHandler.swift */; };
 		FA7C18BDCC1C31AC365877F9 /* CardUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62295A09DC541B3ED5023CE7 /* CardUtils.swift */; };
 		FDB5445E7BEE26B8943D8770 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8790511FF395019A12A1F429 /* Assets.xcassets */; };
+		CC0000000000000000000001 /* ConnectionStatusToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000000000000000000002 /* ConnectionStatusToast.swift */; };
 		BB1234567890ABCDEF000001 /* Tournament.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000001 /* Tournament.swift */; };
 		BB1234567890ABCDEF000002 /* TournamentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000002 /* TournamentState.swift */; };
 		BB1234567890ABCDEF000003 /* TournamentEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000003 /* TournamentEmitter.swift */; };
@@ -158,6 +159,7 @@
 		F5181763FA4333160B98FDC2 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		FA8B8AB7C156EE02DB4AA5EC /* SKOpponentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKOpponentManager.swift; sourceTree = "<group>"; };
 		FD7736BF05FE6B17925F5B58 /* AvatarNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarNode.swift; sourceTree = "<group>"; };
+		CC0000000000000000000002 /* ConnectionStatusToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatusToast.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF000001 /* Tournament.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tournament.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF000002 /* TournamentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentState.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF000003 /* TournamentEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentEmitter.swift; sourceTree = "<group>"; };
@@ -243,12 +245,21 @@
 			children = (
 				F5181763FA4333160B98FDC2 /* SplashView.swift */,
 				D86C161126AE20A6A2F082D3 /* Auth */,
+				CC0000000000000000000003 /* Components */,
 				9CB8AFDF8AACB2CDF741C5B0 /* Game */,
 				C12D81E2062D1556C063393C /* GameLobby */,
 				D5AAEA07E9E0D4E83C6DED04 /* MainRoom */,
 				CC1234567890ABCDEF000001 /* Tournament */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		CC0000000000000000000003 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				CC0000000000000000000002 /* ConnectionStatusToast.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		CC1234567890ABCDEF000001 /* Tournament */ = {
@@ -538,6 +549,7 @@
 				0D1479057F4F8E28A2C0C482 /* ChatMessage.swift in Sources */,
 				3D0A859DE21658E3D5B09BE1 /* ChatSocketHandler.swift in Sources */,
 				896418D2F4B35BC3D18218A4 /* Color+Theme.swift in Sources */,
+				CC0000000000000000000001 /* ConnectionStatusToast.swift in Sources */,
 				EA59CF07192D698567C4B4ED /* ContentView.swift in Sources */,
 				695D67B3F890889F37A7163E /* DisconnectBannerView.swift in Sources */,
 				673F325B6550AE9311E0041A /* DrawPhaseNode.swift in Sources */,

--- a/iOSClient/BABOnline/ContentView.swift
+++ b/iOSClient/BABOnline/ContentView.swift
@@ -13,20 +13,26 @@ struct ContentView: View {
                 SplashView()
                     .transition(.opacity)
             } else {
-                Group {
-                    switch appState.screen {
-                    case .signIn:
-                        SignInView()
-                    case .register:
-                        RegisterView()
-                    case .mainRoom:
-                        MainRoomView()
-                    case .gameLobby:
-                        GameLobbyView()
-                    case .tournamentLobby:
-                        TournamentLobbyView()
-                    case .game:
-                        GameContainerView()
+                ZStack {
+                    Group {
+                        switch appState.screen {
+                        case .signIn:
+                            SignInView()
+                        case .register:
+                            RegisterView()
+                        case .mainRoom:
+                            MainRoomView()
+                        case .gameLobby:
+                            GameLobbyView()
+                        case .tournamentLobby:
+                            TournamentLobbyView()
+                        case .game:
+                            GameContainerView()
+                        }
+                    }
+
+                    if authState.isAuthenticated {
+                        ConnectionStatusToast()
                     }
                 }
                 .transition(.opacity)

--- a/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
+++ b/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
@@ -167,6 +167,10 @@ class GameSKScene: SKScene {
             .sink { [weak self] (position, bid) in
                 guard let self, let myPos = self.gameState.position else { return }
                 self.bidManager?.showBid(position: position, bid: bid, myPosition: myPos)
+                // Trigger bore badge animation for bore bids
+                if bid == "B" || bid == "2B" || bid == "3B" || bid == "4B" {
+                    self.effectsManager?.showBoreBadge(bid)
+                }
             }
             .store(in: &cancellables)
 

--- a/iOSClient/BABOnline/SpriteKit/Managers/SKEffectsManager.swift
+++ b/iOSClient/BABOnline/SpriteKit/Managers/SKEffectsManager.swift
@@ -39,7 +39,7 @@ class SKEffectsManager {
     }
 
     /// Show bore badge effect
-    func showBoreBadge(_ level: String, sceneSize: CGSize) {
+    func showBoreBadge(_ level: String) {
         guard let scene = scene else { return }
 
         let textureName: String
@@ -53,7 +53,7 @@ class SKEffectsManager {
 
         let texture = SKTexture(imageNamed: textureName)
         let badge = SKSpriteNode(texture: texture, size: CGSize(width: 80, height: 80))
-        badge.position = .zero
+        badge.position = CGPoint(x: -scene.size.width / 4, y: scene.size.height / 4)
         badge.zPosition = 500
         badge.alpha = 0
         badge.setScale(0.5)

--- a/iOSClient/BABOnline/Views/Components/ConnectionStatusToast.swift
+++ b/iOSClient/BABOnline/Views/Components/ConnectionStatusToast.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Floating pill that shows reconnection status after the app foregrounds.
+struct ConnectionStatusToast: View {
+    @EnvironmentObject var socketService: SocketService
+    @State private var wasDisconnected = false
+    @State private var showToast = false
+    @State private var isReconnected = false
+
+    var body: some View {
+        VStack {
+            if showToast {
+                HStack(spacing: 8) {
+                    if isReconnected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(Color.Theme.success)
+                    } else {
+                        ProgressView()
+                            .tint(Color.Theme.warning)
+                    }
+                    Text(isReconnected ? "Connected!" : "Reconnecting...")
+                        .font(.callout.bold())
+                        .foregroundColor(Color.Theme.textPrimary)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(Color.Theme.surface)
+                .clipShape(Capsule())
+                .shadow(color: .black.opacity(0.4), radius: 8, y: 4)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .padding(.top, 8)
+            }
+            Spacer()
+        }
+        .onChange(of: socketService.isConnected) { _, connected in
+            if !connected {
+                wasDisconnected = true
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    isReconnected = false
+                    showToast = true
+                }
+            } else if wasDisconnected {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    isReconnected = true
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        showToast = false
+                    }
+                    wasDisconnected = false
+                }
+            }
+        }
+    }
+}

--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
@@ -68,7 +68,7 @@ struct MainRoomView: View {
                 }
 
                 Button(action: { LobbyEmitter.createLobby() }) {
-                    Label("Create", systemImage: "plus.circle.fill")
+                    Label("Game", systemImage: "suit.spade.fill")
                         .font(.callout.bold())
                         .foregroundColor(Color.Theme.primary)
                 }


### PR DESCRIPTION
## Summary
- **Bore animations**: `showBoreBadge()` was fully implemented but never called — now triggered on B/2B/3B/4B bids in the `bidReceivedSubject` subscription. Badge positioned at top-left of play area (same as OT badge) instead of dead center. Removed unused `sceneSize` parameter.
- **Button rename**: Changed "Create" button to "Game" with a spade icon (`suit.spade.fill`) to distinguish it from the "Tournament" trophy button.
- **Reconnection toast**: New `ConnectionStatusToast` component shows "Reconnecting..." with spinner when socket disconnects, then "Connected!" with auto-dismiss after foregrounding. Only shown when authenticated (sign-in screen has its own indicator).

## Test plan
- [ ] Start a game, have a player bid "B" — bore badge should animate at top-left of play area
- [ ] Check Game Lobbies header shows "Tournament" and "Game" buttons with distinct icons
- [ ] Background the app for a few seconds, foreground — should see "Reconnecting..." then "Connected!" toast
- [ ] Verify toast does NOT appear on initial app launch / first connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)