### PR TITLE
Fix iOS playtest bugs, add leaderboard, enable 1Password autofill

### DIFF
--- a/iOSClient/BABOnline.xcodeproj/project.pbxproj
+++ b/iOSClient/BABOnline.xcodeproj/project.pbxproj
@@ -87,6 +87,11 @@
 		BB1234567890ABCDEF000008 /* TournamentScoreboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000008 /* TournamentScoreboardView.swift */; };
 		BB1234567890ABCDEF000009 /* TournamentActiveGamesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000009 /* TournamentActiveGamesView.swift */; };
 		BB1234567890ABCDEF00000A /* TournamentResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000A /* TournamentResultsView.swift */; };
+		BB1234567890ABCDEF00000B /* LeaderboardEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000B /* LeaderboardEntry.swift */; };
+		BB1234567890ABCDEF00000C /* LeaderboardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000C /* LeaderboardState.swift */; };
+		BB1234567890ABCDEF00000D /* LeaderboardEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000D /* LeaderboardEmitter.swift */; };
+		BB1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift */; };
+		BB1234567890ABCDEF00000F /* LeaderboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000F /* LeaderboardView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -170,6 +175,11 @@
 		AA1234567890ABCDEF000008 /* TournamentScoreboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentScoreboardView.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF000009 /* TournamentActiveGamesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentActiveGamesView.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF00000A /* TournamentResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentResultsView.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF00000B /* LeaderboardEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardEntry.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF00000C /* LeaderboardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardState.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF00000D /* LeaderboardEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardEmitter.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardSocketHandler.swift; sourceTree = "<group>"; };
+		AA1234567890ABCDEF00000F /* LeaderboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,6 +211,7 @@
 				D74F821D951B0C701D3EEC7F /* AuthEmitter.swift */,
 				281B7D8A956EA7591D9F54C8 /* ChatEmitter.swift */,
 				97217006DFD0797BEBAF6836 /* GameEmitter.swift */,
+				AA1234567890ABCDEF00000D /* LeaderboardEmitter.swift */,
 				ABFB49C1B9B998424D06A9B7 /* LobbyEmitter.swift */,
 				AA1234567890ABCDEF000003 /* TournamentEmitter.swift */,
 			);
@@ -221,6 +232,7 @@
 				F28474CFED18B3E46768C988 /* AuthSocketHandler.swift */,
 				1CC5887542913E6A913FA11E /* ChatSocketHandler.swift */,
 				7AA293C5CC063A9C3A5D35F2 /* GameSocketHandler.swift */,
+				AA1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift */,
 				7FD14869A6FDEFEF8A26EB44 /* LobbySocketHandler.swift */,
 				AA1234567890ABCDEF000004 /* TournamentSocketHandler.swift */,
 			);
@@ -374,6 +386,7 @@
 		D5AAEA07E9E0D4E83C6DED04 /* MainRoom */ = {
 			isa = PBXGroup;
 			children = (
+				AA1234567890ABCDEF00000F /* LeaderboardView.swift */,
 				C53AAE255FBF334AD3AEC34F /* LobbyListView.swift */,
 				07ED0716768E28CCCDE8A731 /* MainRoomChatView.swift */,
 				CBBC8430F514042641E150DF /* MainRoomView.swift */,
@@ -418,6 +431,7 @@
 			children = (
 				31CC71A809AE3AFB89C1E0D7 /* AuthState.swift */,
 				006A718437AB193FE3F34B14 /* GameState.swift */,
+				AA1234567890ABCDEF00000C /* LeaderboardState.swift */,
 				E9B310B890DA152FC2DC27BB /* LobbyState.swift */,
 				D8BFDA96358A6BEB484A42FB /* MainRoomState.swift */,
 				AA1234567890ABCDEF000002 /* TournamentState.swift */,
@@ -438,6 +452,7 @@
 			children = (
 				D93F1941362F417B0FA5594F /* Card.swift */,
 				409C82291F02FA6A105021BE /* ChatMessage.swift */,
+				AA1234567890ABCDEF00000B /* LeaderboardEntry.swift */,
 				5BA11DB6AFE269661E829F5A /* Lobby.swift */,
 				7187D649710ECFC3C9A68D59 /* Player.swift */,
 				ABD47677D06A3496EC34B3AC /* ScoreData.swift */,
@@ -565,6 +580,11 @@
 				6C8BF96D03D45CA6E2768194 /* HandNode.swift in Sources */,
 				928367895A6772000691F618 /* HapticManager.swift in Sources */,
 				34DB3B2F9965A4193CCF4DD0 /* LayoutConstants.swift in Sources */,
+				BB1234567890ABCDEF00000D /* LeaderboardEmitter.swift in Sources */,
+				BB1234567890ABCDEF00000B /* LeaderboardEntry.swift in Sources */,
+				BB1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift in Sources */,
+				BB1234567890ABCDEF00000C /* LeaderboardState.swift in Sources */,
+				BB1234567890ABCDEF00000F /* LeaderboardView.swift in Sources */,
 				48DFFF3FEE58CD64BDDC5C99 /* Lobby.swift in Sources */,
 				47380CD80F8287DC58668AA9 /* LobbyChatView.swift in Sources */,
 				8CA174CB34AD22C90102770A /* LobbyEmitter.swift in Sources */,
@@ -672,6 +692,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = BABOnline/BABOnline.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -763,6 +784,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = BABOnline/BABOnline.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;

--- a/iOSClient/BABOnline/BABOnline.entitlements
+++ b/iOSClient/BABOnline/BABOnline.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:babonline.io</string>
+	</array>
+</dict>
+</plist>

--- a/iOSClient/BABOnline/BABOnlineApp.swift
+++ b/iOSClient/BABOnline/BABOnlineApp.swift
@@ -8,6 +8,7 @@ struct BABOnlineApp: App {
     @StateObject private var lobbyState = LobbyState()
     @StateObject private var gameState = GameState()
     @StateObject private var tournamentState = TournamentState()
+    @StateObject private var leaderboardState = LeaderboardState()
     @Environment(\.scenePhase) private var scenePhase
 
     private let socketService = SocketService.shared
@@ -21,6 +22,7 @@ struct BABOnlineApp: App {
                 .environmentObject(lobbyState)
                 .environmentObject(gameState)
                 .environmentObject(tournamentState)
+                .environmentObject(leaderboardState)
                 .environmentObject(socketService)
                 .onAppear {
                     setupSocket()
@@ -43,7 +45,8 @@ struct BABOnlineApp: App {
             lobbyState: lobbyState,
             gameState: gameState,
             appState: appState,
-            tournamentState: tournamentState
+            tournamentState: tournamentState,
+            leaderboardState: leaderboardState
         )
         router.registerAll()
         socketService.eventRouter = router

--- a/iOSClient/BABOnline/Constants/SocketEvents.swift
+++ b/iOSClient/BABOnline/Constants/SocketEvents.swift
@@ -39,6 +39,9 @@ enum SocketEvents {
         static let addBot = "addBot"
         static let removeBot = "removeBot"
 
+        // Leaderboard
+        static let getLeaderboard = "getLeaderboard"
+
         // Tournament
         static let createTournament = "createTournament"
         static let joinTournament = "joinTournament"
@@ -135,6 +138,9 @@ enum SocketEvents {
         static let tournamentComplete = "tournamentComplete"
         static let tournamentLeft = "tournamentLeft"
         static let activeTournamentFound = "activeTournamentFound"
+
+        // Leaderboard
+        static let leaderboardResponse = "leaderboardResponse"
 
         // Connection
         static let connect = "connect"

--- a/iOSClient/BABOnline/ContentView.swift
+++ b/iOSClient/BABOnline/ContentView.swift
@@ -45,16 +45,8 @@ struct ContentView: View {
                 withAnimation(.easeInOut(duration: 0.4)) {
                     showSplash = false
                 }
-                // Attempt session restore if we have stored credentials
-                attemptSessionRestore()
             }
         }
-    }
-
-    private func attemptSessionRestore() {
-        guard authState.hasStoredSession, socketService.isConnected else { return }
-        print("[ContentView] Attempting session restore for: \(authState.username)")
-        AuthEmitter.restoreSession(username: authState.username, sessionToken: authState.sessionToken)
     }
 }
 

--- a/iOSClient/BABOnline/Models/LeaderboardEntry.swift
+++ b/iOSClient/BABOnline/Models/LeaderboardEntry.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct LeaderboardEntry: Identifiable {
+    let id: String
+    let username: String
+    let profilePic: Int
+    let gamesPlayed: Int
+    let winRate: Double
+    let pointsPerGame: Double
+    let bidsPerGame: Double
+    let tricksPerBid: Double
+    let setRate: Double
+    let drag: Double
+    let faultsPerGame: Double
+    let avgHSI: Double
+
+    static func from(_ dict: [String: Any]) -> LeaderboardEntry? {
+        guard let username = dict["username"] as? String else { return nil }
+        return LeaderboardEntry(
+            id: username,
+            username: username,
+            profilePic: dict["profilePic"] as? Int ?? 1,
+            gamesPlayed: dict["gamesPlayed"] as? Int ?? 0,
+            winRate: dict["winRate"] as? Double ?? 0,
+            pointsPerGame: dict["pointsPerGame"] as? Double ?? 0,
+            bidsPerGame: dict["bidsPerGame"] as? Double ?? 0,
+            tricksPerBid: dict["tricksPerBid"] as? Double ?? 0,
+            setRate: dict["setRate"] as? Double ?? 0,
+            drag: dict["drag"] as? Double ?? 0,
+            faultsPerGame: dict["faultsPerGame"] as? Double ?? 0,
+            avgHSI: dict["avgHSI"] as? Double ?? 0
+        )
+    }
+}

--- a/iOSClient/BABOnline/Networking/Emitters/LeaderboardEmitter.swift
+++ b/iOSClient/BABOnline/Networking/Emitters/LeaderboardEmitter.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum LeaderboardEmitter {
+    private static var socket: SocketService { .shared }
+
+    static func getLeaderboard() {
+        socket.emit(SocketEvents.Client.getLeaderboard)
+    }
+}

--- a/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
@@ -339,7 +339,12 @@ final class GameSocketHandler {
             DispatchQueue.main.async {
                 let reason = dict?["reason"] as? String ?? "Rejoin failed"
                 print("[Game] Rejoin failed: \(reason)")
-                self.appState.screen = .mainRoom
+                // Don't navigate away if we're already in a game
+                // (handles duplicate rejoin where first succeeded)
+                if self.appState.screen != .game {
+                    self.appState.screen = .mainRoom
+                    LobbyEmitter.joinMainRoom()
+                }
             }
         }
     }
@@ -495,6 +500,8 @@ final class GameSocketHandler {
 
         // Track lead
         if gameState.playedCardIndex == 0 {
+            // Safety net: clear stale trick data if the delayed clearTrick() was skipped
+            gameState.clearTrick()
             gameState.leadCard = card
             gameState.leadPosition = position
         }

--- a/iOSClient/BABOnline/Networking/Handlers/LeaderboardSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/LeaderboardSocketHandler.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+final class LeaderboardSocketHandler {
+    private let socket: SocketService
+    private let leaderboardState: LeaderboardState
+
+    init(socket: SocketService, leaderboardState: LeaderboardState) {
+        self.socket = socket
+        self.leaderboardState = leaderboardState
+    }
+
+    func register() {
+        socket.on(SocketEvents.Server.leaderboardResponse) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                self.leaderboardState.isLoading = false
+
+                guard let success = dict["success"] as? Bool, success,
+                      let entries = dict["leaderboard"] as? [[String: Any]] else {
+                    self.leaderboardState.error = dict["message"] as? String ?? "Failed to load leaderboard"
+                    return
+                }
+
+                self.leaderboardState.entries = entries.compactMap { LeaderboardEntry.from($0) }
+                self.leaderboardState.error = nil
+            }
+        }
+    }
+}

--- a/iOSClient/BABOnline/Networking/SocketEventRouter.swift
+++ b/iOSClient/BABOnline/Networking/SocketEventRouter.swift
@@ -9,6 +9,7 @@ final class SocketEventRouter {
     private let gameHandler: GameSocketHandler
     private let chatHandler: ChatSocketHandler
     private let tournamentHandler: TournamentSocketHandler
+    private let leaderboardHandler: LeaderboardSocketHandler
 
     init(
         socket: SocketService,
@@ -17,7 +18,8 @@ final class SocketEventRouter {
         lobbyState: LobbyState,
         gameState: GameState,
         appState: AppState,
-        tournamentState: TournamentState
+        tournamentState: TournamentState,
+        leaderboardState: LeaderboardState
     ) {
         self.socket = socket
         self.authHandler = AuthSocketHandler(socket: socket, authState: authState, appState: appState, gameState: gameState)
@@ -25,6 +27,7 @@ final class SocketEventRouter {
         self.gameHandler = GameSocketHandler(socket: socket, gameState: gameState, appState: appState)
         self.chatHandler = ChatSocketHandler(socket: socket, gameState: gameState)
         self.tournamentHandler = TournamentSocketHandler(socket: socket, tournamentState: tournamentState, gameState: gameState, appState: appState)
+        self.leaderboardHandler = LeaderboardSocketHandler(socket: socket, leaderboardState: leaderboardState)
     }
 
     func registerAll() {
@@ -33,5 +36,6 @@ final class SocketEventRouter {
         gameHandler.register()
         chatHandler.register()
         tournamentHandler.register()
+        leaderboardHandler.register()
     }
 }

--- a/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
+++ b/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
@@ -231,6 +231,12 @@ class GameSKScene: SKScene {
     private func handleCardPlayed(_ played: PlayedCard) {
         guard let myPos = gameState.position else { return }
 
+        // If first card of a new trick, ensure trick area is visually clear
+        // (safety net for trickComplete's delayed clear being skipped)
+        if gameState.playedCards.count <= 1 {
+            trickManager?.clearTrickArea()
+        }
+
         let trickPos = trickManager?.trickPosition(for: played.position) ?? .zero
 
         if played.position == myPos && !gameState.isSpectator {

--- a/iOSClient/BABOnline/State/LeaderboardState.swift
+++ b/iOSClient/BABOnline/State/LeaderboardState.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+final class LeaderboardState: ObservableObject {
+    @Published var entries: [LeaderboardEntry] = []
+    @Published var isLoading = false
+    @Published var error: String?
+
+    func reset() {
+        entries = []
+        isLoading = false
+        error = nil
+    }
+}

--- a/iOSClient/BABOnline/Views/MainRoom/LeaderboardView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/LeaderboardView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+struct LeaderboardView: View {
+    @EnvironmentObject var leaderboardState: LeaderboardState
+
+    enum SortField: String, CaseIterable {
+        case winRate = "Win %"
+        case pointsPerGame = "Pts/G"
+        case bidsPerGame = "Bids/G"
+        case tricksPerBid = "T/Bid"
+        case setRate = "Set %"
+        case drag = "Drag"
+        case avgHSI = "HSI"
+        case gamesPlayed = "Games"
+    }
+
+    @State private var selectedSort: SortField = .winRate
+
+    private var sortedEntries: [LeaderboardEntry] {
+        leaderboardState.entries.sorted { a, b in
+            switch selectedSort {
+            case .winRate:       return a.winRate > b.winRate
+            case .pointsPerGame: return a.pointsPerGame > b.pointsPerGame
+            case .bidsPerGame:   return a.bidsPerGame > b.bidsPerGame
+            case .tricksPerBid:  return a.tricksPerBid > b.tricksPerBid
+            case .setRate:       return a.setRate > b.setRate
+            case .drag:          return a.drag > b.drag
+            case .avgHSI:        return a.avgHSI > b.avgHSI
+            case .gamesPlayed:   return a.gamesPlayed > b.gamesPlayed
+            }
+        }
+    }
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color.Theme.background.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    // Sort buttons
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(SortField.allCases, id: \.self) { field in
+                                Button(action: { selectedSort = field }) {
+                                    Text(field.rawValue)
+                                        .font(.caption.bold())
+                                        .padding(.horizontal, 12)
+                                        .padding(.vertical, 6)
+                                        .background(selectedSort == field ? Color.Theme.primary : Color.Theme.surface)
+                                        .foregroundColor(selectedSort == field ? .white : Color.Theme.textSecondary)
+                                        .cornerRadius(16)
+                                }
+                            }
+                        }
+                        .padding(.horizontal)
+                        .padding(.vertical, 8)
+                    }
+
+                    Divider().background(Color.Theme.inputBorder)
+
+                    if leaderboardState.isLoading {
+                        Spacer()
+                        ProgressView()
+                            .tint(Color.Theme.textSecondary)
+                        Spacer()
+                    } else if let error = leaderboardState.error {
+                        Spacer()
+                        Text(error)
+                            .foregroundColor(Color.Theme.error)
+                            .font(.callout)
+                        Spacer()
+                    } else if sortedEntries.isEmpty {
+                        Spacer()
+                        Text("No players yet")
+                            .foregroundColor(Color.Theme.textSecondary)
+                            .font(.callout)
+                        Spacer()
+                    } else {
+                        List {
+                            ForEach(Array(sortedEntries.enumerated()), id: \.element.id) { index, entry in
+                                leaderboardRow(rank: index + 1, entry: entry)
+                                    .listRowBackground(Color.Theme.background)
+                            }
+                        }
+                        .listStyle(.plain)
+                    }
+                }
+            }
+            .navigationTitle("Leaderboard")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .onAppear {
+            leaderboardState.isLoading = true
+            LeaderboardEmitter.getLeaderboard()
+        }
+    }
+
+    private func leaderboardRow(rank: Int, entry: LeaderboardEntry) -> some View {
+        HStack(spacing: 12) {
+            // Rank
+            Text("#\(rank)")
+                .font(.callout.bold())
+                .foregroundColor(rankColor(rank))
+                .frame(width: 36, alignment: .leading)
+
+            // Username
+            Text(entry.username)
+                .font(.callout.bold())
+                .foregroundColor(Color.Theme.textPrimary)
+                .lineLimit(1)
+
+            Spacer()
+
+            // Primary stat
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(formattedStat(entry))
+                    .font(.callout.bold())
+                    .foregroundColor(Color.Theme.primary)
+                Text("\(entry.gamesPlayed) games")
+                    .font(.caption2)
+                    .foregroundColor(Color.Theme.textSecondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func formattedStat(_ entry: LeaderboardEntry) -> String {
+        switch selectedSort {
+        case .winRate:       return String(format: "%.1f%%", entry.winRate)
+        case .pointsPerGame: return String(format: "%.1f", entry.pointsPerGame)
+        case .bidsPerGame:   return String(format: "%.1f", entry.bidsPerGame)
+        case .tricksPerBid:  return String(format: "%.2f", entry.tricksPerBid)
+        case .setRate:       return String(format: "%.1f%%", entry.setRate)
+        case .drag:          return String(format: "%.1f", entry.drag)
+        case .avgHSI:        return String(format: "%.1f", entry.avgHSI)
+        case .gamesPlayed:   return "\(entry.gamesPlayed)"
+        }
+    }
+
+    private func rankColor(_ rank: Int) -> Color {
+        switch rank {
+        case 1: return Color.Theme.warning
+        case 2: return Color.Theme.textSecondary
+        case 3: return Color(red: 0.8, green: 0.5, blue: 0.2)
+        default: return Color.Theme.textSecondary
+        }
+    }
+}

--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
@@ -4,6 +4,7 @@ struct MainRoomView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var mainRoomState: MainRoomState
     @Environment(\.scenePhase) private var scenePhase
+    @State private var showLeaderboard = false
 
     var body: some View {
         ZStack {
@@ -43,6 +44,9 @@ struct MainRoomView: View {
                 LobbyEmitter.joinMainRoom()
             }
         }
+        .sheet(isPresented: $showLeaderboard) {
+            LeaderboardView()
+        }
     }
 
     // MARK: - Lobby Browser
@@ -60,6 +64,12 @@ struct MainRoomView: View {
                 Text("\(mainRoomState.onlineCount) online")
                     .font(.caption)
                     .foregroundColor(Color.Theme.textSecondary)
+
+                Button(action: { showLeaderboard = true }) {
+                    Label("Stats", systemImage: "chart.bar.fill")
+                        .font(.callout.bold())
+                        .foregroundColor(Color.Theme.textSecondary)
+                }
 
                 Button(action: { TournamentEmitter.createTournament() }) {
                     Label("Tournament", systemImage: "trophy.fill")

--- a/server/game/GameManager.js
+++ b/server/game/GameManager.js
@@ -1027,6 +1027,24 @@ class GameManager {
     }
 
     /**
+     * Delete a completed tournament and clean up all references
+     */
+    deleteTournament(tournamentId) {
+        const tournament = this.tournaments.get(tournamentId);
+        if (!tournament) return;
+
+        for (const [socketId] of tournament.players) {
+            this.playerTournaments.delete(socketId);
+        }
+        for (const [gameId, tId] of this.tournamentGames) {
+            if (tId === tournamentId) {
+                this.tournamentGames.delete(gameId);
+            }
+        }
+        this.tournaments.delete(tournamentId);
+    }
+
+    /**
      * Get the tournament a player is in
      */
     getPlayerTournament(socketId) {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -60,6 +60,16 @@ router.get('/privacy', (req, res) => {
 </html>`);
 });
 
+// Apple App Site Association — links iOS app with this domain for password autofill
+router.get('/.well-known/apple-app-site-association', (req, res) => {
+    res.set('Content-Type', 'application/json');
+    res.json({
+        webcredentials: {
+            apps: ['9SYNY7K2HE.com.bab-online.BABOnline']
+        }
+    });
+});
+
 // Health check endpoint - is the server running?
 router.get('/health', (req, res) => {
     res.json({

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -803,6 +803,8 @@ async function handleHandComplete(game, io) {
                             scoreboard: tournament.getScoreboard()
                         });
                         await gameManager.clearActiveTournamentForAll(tournament.tournamentId);
+                        // Clean up tournament from memory and update lobby
+                        gameManager.deleteTournament(tournament.tournamentId);
                     } else {
                         // Round complete, waiting for next round
                         tournament.broadcast(io, 'tournamentRoundComplete', {


### PR DESCRIPTION
## Summary

- **Stuck card on table**: Fix race condition where cards get stuck on the trick table. When the first card of a new trick arrives before the delayed `clearTrick()` fires, the guard fails and old sprites are never cleared. Now force-clears stale trick state and sprites as a safety net when the first card of a new trick arrives.
- **Force-quit reconnection**: Fix reconnection failure after force-quitting mid-game. `restoreSession` was emitted twice on cold start (once from `SocketService.connect`, once from `ContentView.onAppear`), causing a duplicate `rejoinGame` where the second fails and overrides the game screen with main room. Removed the duplicate call and made `rejoinFailed` defensive.
- **Tournament cleanup**: Completed tournaments were never deleted from the `GameManager.tournaments` Map, staying in the lobby list forever. Now deleted after completion.
- **iOS Leaderboard**: Full implementation — model, state, emitter, socket handler, and sortable SwiftUI view presented as a sheet from main room. Supports sorting by Win %, Pts/G, Bids/G, T/Bid, Set %, Drag, HSI, and Games.
- **1Password autofill**: Added Associated Domains entitlement (`webcredentials:babonline.io`) and AASA route on the server so 1Password and iOS autofill recognize stored credentials for babonline.io.

## Test plan

- [ ] Play a fast game with bots — watch for lingering card sprites between tricks
- [ ] Force quit while in a game, reopen — should go directly to game screen, not main room
- [ ] Complete a tournament — should no longer appear in lobby list after completion
- [ ] Tap "Stats" button in main room — leaderboard sheet shows with sortable player stats
- [ ] After deploying, verify `https://babonline.io/.well-known/apple-app-site-association` returns valid JSON
- [ ] On sign-in screen, 1Password should offer stored babonline.io credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)