### PR TITLE
Reorder and tighten main room header buttons

### DIFF
--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
@@ -55,20 +55,10 @@ struct MainRoomView: View {
         VStack(spacing: 0) {
             // Header
             HStack {
-                Text("Game Lobbies")
-                    .font(.title2.bold())
-                    .foregroundColor(Color.Theme.textPrimary)
-
-                Spacer()
-
-                Text("\(mainRoomState.onlineCount) online")
-                    .font(.caption)
-                    .foregroundColor(Color.Theme.textSecondary)
-
-                Button(action: { showLeaderboard = true }) {
-                    Label("Stats", systemImage: "chart.bar.fill")
+                Button(action: { LobbyEmitter.createLobby() }) {
+                    Label("New Game", systemImage: "suit.spade.fill")
                         .font(.callout.bold())
-                        .foregroundColor(Color.Theme.textSecondary)
+                        .foregroundColor(Color.Theme.primary)
                 }
 
                 Button(action: { TournamentEmitter.createTournament() }) {
@@ -77,11 +67,17 @@ struct MainRoomView: View {
                         .foregroundColor(Color.Theme.warning)
                 }
 
-                Button(action: { LobbyEmitter.createLobby() }) {
-                    Label("Game", systemImage: "suit.spade.fill")
+                Button(action: { showLeaderboard = true }) {
+                    Label("Stats", systemImage: "chart.bar.fill")
                         .font(.callout.bold())
-                        .foregroundColor(Color.Theme.primary)
+                        .foregroundColor(Color.Theme.textSecondary)
                 }
+
+                Spacer()
+
+                Text("\(mainRoomState.onlineCount) online")
+                    .font(.caption)
+                    .foregroundColor(Color.Theme.textSecondary)
             }
             .padding()
 


### PR DESCRIPTION
## Summary

- Remove "Game Lobbies" title to free horizontal space
- Reorder buttons: New Game, Tournament, Stats (left-aligned), online count (right-aligned)
- Prevents header from wrapping on smaller iPhone screens

## Test plan

- [ ] Main room header fits on a single line on iPhone SE / smaller screens
- [ ] All buttons (New Game, Tournament, Stats) still functional
- [ ] Online count displays correctly on the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)