### PR TITLE
Fix playtest bugs: spectator UI, scoring, lobby, and web client improvements

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -2102,6 +2102,7 @@ function initializeApp() {
               // Set up managers
               if (scene.trickManager) {
                 scene.trickManager.setPlayerPosition(1);
+                scene.trickManager.setSpectatorMode(true);
                 scene.trickManager.updatePlayPositions();
               }
               if (scene.opponentManager) {
@@ -2123,6 +2124,18 @@ function initializeApp() {
                 scene.trickManager._teamTrickCount = gameState.teamTricks || 0;
                 scene.trickManager._oppTrickCount = gameState.oppTricks || 0;
                 scene.trickManager.createTrickBackgrounds(false);
+
+                // Create card-back placeholder stacks for already-won tricks
+                // (server only sends counts, not actual cards)
+                if (gameState.teamTricks > 0 || gameState.oppTricks > 0) {
+                  // Reset counts first — restoreTrickPlaceholders increments them
+                  scene.trickManager._teamTrickCount = 0;
+                  scene.trickManager._oppTrickCount = 0;
+                  scene.trickManager.restoreTrickPlaceholders(
+                    gameState.teamTricks || 0,
+                    gameState.oppTricks || 0
+                  );
+                }
               }
 
               // Display trump card
@@ -2911,10 +2924,11 @@ function initializeApp() {
       const senderName = data.username || getPlayerName(data.position, state.playerData);
 
       // Add to game feed with player position for color coding
+      const chatPosition = data.isSpectator ? 'spectator' : data.position;
       if (scene && scene.handleAddToGameFeed) {
-        scene.handleAddToGameFeed(`${senderName}: ${data.message}`, data.position);
+        scene.handleAddToGameFeed(`${senderName}: ${data.message}`, chatPosition);
       } else if (window.addToGameFeedFromLegacy) {
-        window.addToGameFeedFromLegacy(`${senderName}: ${data.message}`, data.position);
+        window.addToGameFeedFromLegacy(`${senderName}: ${data.message}`, chatPosition);
       }
 
       // Show chat bubble at appropriate position

--- a/client/src/ui/components/GameLog.js
+++ b/client/src/ui/components/GameLog.js
@@ -368,11 +368,15 @@ export function createGameLog({ onChatSubmit } = {}) {
       `;
       msgDiv.appendChild(timeSpan);
 
-      // Message text with team coloring
+      // Message text with team/spectator coloring
       const textSpan = document.createElement('span');
       textSpan.textContent = message;
-      // Team 1 (positions 1, 3) = blue, Team 2 (positions 2, 4) = red
-      textSpan.style.color = (playerPosition === 1 || playerPosition === 3) ? '#63b3ed' : '#fc8181';
+      if (playerPosition === 'spectator') {
+        textSpan.style.color = '#4ade80'; // Green for spectators
+      } else {
+        // Team 1 (positions 1, 3) = blue, Team 2 (positions 2, 4) = red
+        textSpan.style.color = (playerPosition === 1 || playerPosition === 3) ? '#63b3ed' : '#fc8181';
+      }
       msgDiv.appendChild(textSpan);
 
       messageArea.appendChild(msgDiv);

--- a/iOSClient/BABOnline/Models/Lobby.swift
+++ b/iOSClient/BABOnline/Models/Lobby.swift
@@ -25,7 +25,7 @@ struct Lobby: Identifiable, Equatable {
             name = "Game \(id.prefix(4))"
         }
 
-        let playerCount = dict["playerCount"] as? Int ?? 0
+        let playerCount = dict["playerCount"] as? Int ?? (dict["players"] as? [[String: Any]])?.count ?? 0
         let isInProgress = dict["inProgress"] as? Bool ?? false
 
         var players: [LobbyPlayer] = []

--- a/iOSClient/BABOnline/Networking/Handlers/LobbySocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/LobbySocketHandler.swift
@@ -23,6 +23,9 @@ final class LobbySocketHandler {
             guard let self, let dict = data.first as? [String: Any] else { return }
             DispatchQueue.main.async {
                 self.mainRoomState.onlineCount = dict["onlineCount"] as? Int ?? 0
+                if let users = dict["onlineUsers"] as? [String] {
+                    self.mainRoomState.onlineUsers = users
+                }
                 if let messages = dict["recentMessages"] as? [[String: Any]] {
                     self.mainRoomState.messages = messages.compactMap { ChatMessage.from($0) }
                 }
@@ -52,6 +55,9 @@ final class LobbySocketHandler {
             DispatchQueue.main.async {
                 if let count = dict["onlineCount"] as? Int {
                     self?.mainRoomState.onlineCount = count
+                }
+                if let users = dict["onlineUsers"] as? [String] {
+                    self?.mainRoomState.onlineUsers = users
                 }
             }
         }
@@ -112,11 +118,10 @@ final class LobbySocketHandler {
         }
 
         socket.on(SocketEvents.Server.lobbyPlayerJoined) { [weak self] data, _ in
-            guard let self, let dict = data.first as? [String: Any],
-                  let player = LobbyPlayer.from(dict) else { return }
+            guard let self, let dict = data.first as? [String: Any] else { return }
             DispatchQueue.main.async {
-                if !self.lobbyState.players.contains(where: { $0.username == player.username }) {
-                    self.lobbyState.players.append(player)
+                if let players = dict["players"] as? [[String: Any]] {
+                    self.lobbyState.players = players.compactMap { LobbyPlayer.from($0) }
                 }
             }
         }

--- a/iOSClient/BABOnline/SpriteKit/Managers/SKOpponentManager.swift
+++ b/iOSClient/BABOnline/SpriteKit/Managers/SKOpponentManager.swift
@@ -68,7 +68,7 @@ class SKOpponentManager {
 
             switch relPos {
             case .bottom:
-                node.position = CGPoint(x: 0, y: -scene.size.height / 2 + 80)
+                node.position = CGPoint(x: 0, y: -scene.size.height / 2 + 140)
             case .top:
                 node.position = CGPoint(x: 0, y: scene.size.height / 2 - 220)
             case .left:

--- a/iOSClient/BABOnline/State/GameState.swift
+++ b/iOSClient/BABOnline/State/GameState.swift
@@ -136,6 +136,7 @@ final class GameState: ObservableObject {
     let rainbowSubject = PassthroughSubject<Int, Never>()          // position
     let chatBubbleSubject = PassthroughSubject<(message: String, position: Int), Never>()
     let bidReceivedSubject = PassthroughSubject<(position: Int, bid: String), Never>()
+    let overTrumpSubject = PassthroughSubject<Void, Never>()
 
     // MARK: - Optimistic Update State
 

--- a/iOSClient/BABOnline/State/MainRoomState.swift
+++ b/iOSClient/BABOnline/State/MainRoomState.swift
@@ -6,6 +6,7 @@ final class MainRoomState: ObservableObject {
     @Published var inProgressGames: [Lobby] = []
     @Published var messages: [ChatMessage] = []
     @Published var onlineCount: Int = 0
+    @Published var onlineUsers: [String] = []
     @Published var tournaments: [TournamentSummary] = []
 
     func reset() {
@@ -13,6 +14,7 @@ final class MainRoomState: ObservableObject {
         inProgressGames = []
         messages = []
         onlineCount = 0
+        onlineUsers = []
         tournaments = []
     }
 }

--- a/iOSClient/BABOnline/Views/Game/BidOverlayView.swift
+++ b/iOSClient/BABOnline/Views/Game/BidOverlayView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct BidOverlayView: View {
     @EnvironmentObject var gameState: GameState
 
-    @State private var selectedBid: Int?
+    @State private var selectedBid: String?
 
     private var maxBid: Int {
         gameState.myCards.count
@@ -29,12 +29,13 @@ struct BidOverlayView: View {
 
             LazyVGrid(columns: columns, spacing: 4) {
                 ForEach(0...maxBid, id: \.self) { bid in
-                    Button(action: { selectedBid = bid }) {
+                    let bidStr = String(bid)
+                    Button(action: { selectedBid = bidStr }) {
                         Text("\(bid)")
                             .font(.callout.bold())
                             .frame(minWidth: 36, minHeight: 36)
-                            .background(selectedBid == bid ? Color.Theme.primary : Color.Theme.surfaceLight)
-                            .foregroundColor(selectedBid == bid ? .black : Color.Theme.textPrimary)
+                            .background(selectedBid == bidStr ? Color.Theme.primary : Color.Theme.surfaceLight)
+                            .foregroundColor(selectedBid == bidStr ? .black : Color.Theme.textPrimary)
                             .cornerRadius(6)
                     }
                 }
@@ -45,13 +46,13 @@ struct BidOverlayView: View {
                 // Bore buttons inline with submit
                 if !availableBoreLevels.isEmpty {
                     ForEach(availableBoreLevels, id: \.self) { level in
-                        Button(action: { submitBore(level) }) {
+                        Button(action: { selectedBid = level }) {
                             Text(level)
                                 .font(.caption.bold())
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 6)
-                                .background(Color.Theme.oppColor)
-                                .foregroundColor(.white)
+                                .background(selectedBid == level ? Color.Theme.oppColor : Color.Theme.surfaceLight)
+                                .foregroundColor(selectedBid == level ? .white : Color.Theme.textPrimary)
                                 .cornerRadius(6)
                         }
                     }
@@ -86,15 +87,16 @@ struct BidOverlayView: View {
     private func submitBid() {
         guard let bid = selectedBid, let pos = gameState.position else { return }
         HapticManager.mediumImpact()
-        gameState.optimisticBid(String(bid))
-        GameEmitter.playerBid(bid: bid, position: pos)
-        selectedBid = nil
-    }
 
-    private func submitBore(_ level: String) {
-        guard let pos = gameState.position else { return }
-        HapticManager.mediumImpact()
-        gameState.optimisticBid(level)
-        GameEmitter.playerBidBore(bid: level, position: pos)
+        let boreLevels = ["B", "2B", "3B", "4B"]
+        if boreLevels.contains(bid) {
+            gameState.optimisticBid(bid)
+            GameEmitter.playerBidBore(bid: bid, position: pos)
+        } else if let numericBid = Int(bid) {
+            gameState.optimisticBid(bid)
+            GameEmitter.playerBid(bid: numericBid, position: pos)
+        }
+
+        selectedBid = nil
     }
 }

--- a/iOSClient/BABOnline/Views/Game/ScoreBarView.swift
+++ b/iOSClient/BABOnline/Views/Game/ScoreBarView.swift
@@ -6,9 +6,9 @@ struct ScoreBarView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            // Team side
+            // Team side (positions 1 & 3)
             VStack(spacing: 2) {
-                Text("Your Team")
+                Text(team1Label)
                     .font(.system(size: 10))
                     .foregroundColor(Color.Theme.textDim)
                 Text("\(gameState.teamScore)")
@@ -52,9 +52,9 @@ struct ScoreBarView: View {
             }
             .frame(width: 100)
 
-            // Opponent side
+            // Opponent side (positions 2 & 4)
             VStack(spacing: 2) {
-                Text("Opponents")
+                Text(team2Label)
                     .font(.system(size: 10))
                     .foregroundColor(Color.Theme.textDim)
                 Text("\(gameState.oppScore)")
@@ -77,6 +77,24 @@ struct ScoreBarView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .background(Color.Theme.surface.opacity(0.9))
+    }
+
+    private var team1Label: String {
+        if gameState.isSpectator {
+            let p1 = gameState.players[1]?.username.prefix(1) ?? "?"
+            let p3 = gameState.players[3]?.username.prefix(1) ?? "?"
+            return "\(p1) & \(p3)"
+        }
+        return "Your Team"
+    }
+
+    private var team2Label: String {
+        if gameState.isSpectator {
+            let p2 = gameState.players[2]?.username.prefix(1) ?? "?"
+            let p4 = gameState.players[4]?.username.prefix(1) ?? "?"
+            return "\(p2) & \(p4)"
+        }
+        return "Opponents"
     }
 
     private var handNumber: String {

--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
@@ -5,6 +5,7 @@ struct MainRoomView: View {
     @EnvironmentObject var mainRoomState: MainRoomState
     @Environment(\.scenePhase) private var scenePhase
     @State private var showLeaderboard = false
+    @State private var showOnlineUsers = false
 
     var body: some View {
         ZStack {
@@ -47,6 +48,9 @@ struct MainRoomView: View {
         .sheet(isPresented: $showLeaderboard) {
             LeaderboardView()
         }
+        .sheet(isPresented: $showOnlineUsers) {
+            OnlineUsersSheet(users: mainRoomState.onlineUsers)
+        }
     }
 
     // MARK: - Lobby Browser
@@ -75,9 +79,11 @@ struct MainRoomView: View {
 
                 Spacer()
 
-                Text("\(mainRoomState.onlineCount) online")
-                    .font(.caption)
-                    .foregroundColor(Color.Theme.textSecondary)
+                Button(action: { showOnlineUsers = true }) {
+                    Text("\(mainRoomState.onlineCount) online")
+                        .font(.caption)
+                        .foregroundColor(Color.Theme.textSecondary)
+                }
             }
             .padding()
 
@@ -88,4 +94,30 @@ struct MainRoomView: View {
         }
     }
 
+}
+
+// MARK: - Online Users Sheet
+
+private struct OnlineUsersSheet: View {
+    let users: [String]
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            List(users, id: \.self) { username in
+                Text(username)
+                    .foregroundColor(Color.Theme.textPrimary)
+            }
+            .listStyle(.plain)
+            .background(Color.Theme.background)
+            .scrollContentBackground(.hidden)
+            .navigationTitle("Online Players")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
 }

--- a/server/game/GameManager.js
+++ b/server/game/GameManager.js
@@ -178,6 +178,13 @@ class GameManager {
     }
 
     /**
+     * Get usernames of all online users (registered in currentUsers)
+     */
+    getOnlineUsernames() {
+        return this.currentUsers.map(u => u.username);
+    }
+
+    /**
      * Check if player is in main room
      */
     isInMainRoom(socketId) {
@@ -841,6 +848,7 @@ class GameManager {
         const games = [];
         for (const [gameId, game] of this.games) {
             if (game.phase === 'waiting' || game.phase === 'drawing') continue;
+            if (this.tournamentGames.has(gameId)) continue;
 
             const players = [];
             for (let pos = 1; pos <= 4; pos++) {

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -474,6 +474,20 @@ async function startHand(game, io) {
         });
     }
 
+    // Send spectator-safe gameStart (no hand data) so spectators see updated trump/score/hand
+    for (const spec of game.getSpectators()) {
+        io.to(spec.socketId).emit('gameStart', {
+            gameId: game.gameId,
+            trump: game.trump,
+            score1: game.score.team1,
+            score2: game.score.team2,
+            dealer: game.dealer,
+            currentHand: game.currentHand,
+            hand: [],
+            playerInfo
+        });
+    }
+
     gameLogger.info('Game started', { gameId: game.gameId, handSize: game.currentHand, dealer: game.dealer });
     game.bidding = true;
     game.currentTurn = game.bidder;
@@ -598,8 +612,8 @@ async function handleHandComplete(game, io) {
             (game.tricks.team1 - game.bids.team1) +
             game.rainbows.team1 * 10;
     } else {
-        game.score.team1 -= game.bids.team1 * 10 * game.team1Mult -
-            game.rainbows.team1 * 10;
+        game.score.team1 -= game.bids.team1 * 10 * game.team1Mult;
+        game.score.team1 += game.rainbows.team1 * 10;
     }
 
     // Calculate team 2 score
@@ -608,8 +622,8 @@ async function handleHandComplete(game, io) {
             (game.tricks.team2 - game.bids.team2) +
             game.rainbows.team2 * 10;
     } else {
-        game.score.team2 -= game.bids.team2 * 10 * game.team2Mult -
-            game.rainbows.team2 * 10;
+        game.score.team2 -= game.bids.team2 * 10 * game.team2Mult;
+        game.score.team2 += game.rainbows.team2 * 10;
     }
 
     // Track hand stats for player profiles
@@ -892,6 +906,20 @@ async function cleanupNextHand(game, io, dealer, handSize) {
             currentHand: game.currentHand,  // Hand index for hand indicator
             hsiValues,  // HSI for all players to display under avatars
             playerInfo  // Current player info for avatar updates
+        });
+    }
+
+    // Send spectator-safe gameStart (no hand data) so spectators see updated trump/score/hand
+    for (const spec of game.getSpectators()) {
+        io.to(spec.socketId).emit('gameStart', {
+            gameId: game.gameId,
+            trump: game.trump,
+            score1: game.score.team1,
+            score2: game.score.team2,
+            dealer: game.dealer,
+            currentHand: game.currentHand,
+            hand: [],
+            playerInfo
         });
     }
 

--- a/server/socket/mainRoomHandlers.js
+++ b/server/socket/mainRoomHandlers.js
@@ -25,6 +25,7 @@ function joinMainRoom(socket, io) {
         messages: result.messages,
         lobbies: result.lobbies,
         onlineCount: result.onlineCount,
+        onlineUsers: gameManager.getOnlineUsernames(),
         inProgressGames: gameManager.getInProgressGames(),
         tournaments: gameManager.getAllTournaments()
     });
@@ -32,7 +33,8 @@ function joinMainRoom(socket, io) {
     // Notify others of new player
     socket.to('mainRoom').emit('mainRoomPlayerJoined', {
         username: result.username,
-        onlineCount: result.onlineCount
+        onlineCount: result.onlineCount,
+        onlineUsers: gameManager.getOnlineUsernames()
     });
 
     socketLogger.info('Player joined main room', {

--- a/server/socket/profileHandlers.js
+++ b/server/socket/profileHandlers.js
@@ -47,6 +47,7 @@ async function getProfile(socket, io) {
                 stats: dbUser.stats || {
                     wins: 0,
                     losses: 0,
+                    draws: 0,
                     gamesPlayed: 0,
                     totalPoints: 0,
                     totalTricksBid: 0,
@@ -203,6 +204,7 @@ async function recordGameStats(game) {
 
     // Determine winner based on final scores
     const team1Won = game.score.team1 > game.score.team2;
+    const isTie = game.score.team1 === game.score.team2;
 
     // Get all players — use original human player info for resigned positions
     const players = [
@@ -241,8 +243,9 @@ async function recordGameStats(game) {
                 {
                     $inc: {
                         'stats.gamesPlayed': 1,
-                        'stats.wins': isWinner ? 1 : 0,
-                        'stats.losses': isWinner ? 0 : 1,
+                        'stats.wins': isTie ? 0 : (isWinner ? 1 : 0),
+                        'stats.losses': isTie ? 0 : (isWinner ? 0 : 1),
+                        'stats.draws': isTie ? 1 : 0,
                         'stats.totalPoints': teamScore,
                         'stats.totalTricksBid': playerBids,
                         'stats.totalTricksTaken': playerTricks,


### PR DESCRIPTION
## Summary

Addresses 13 issues found during device testing across iOS client, web client, and server.

### iOS Client
- **Spectator bottom player position**: Moved avatar up (+80 → +140) to clear spectating toast
- **In-progress player count**: `Lobby.from()` falls back to `players.count` when `playerCount` missing (fixes "0/4 players")
- **OT animation reliability**: Moved over-trump detection from SpriteKit scene (async Combine) to socket handler where `playedCards` state is guaranteed consistent; added `overTrumpSubject`
- **Bore bid confirmation**: Bore buttons now set selection instead of submitting directly — requires tapping "Bid" button to confirm (matches numeric bid flow)
- **Spectator score labels**: Shows player initials (e.g. "Z & D") instead of "Your Team"/"Opponents" when spectating
- **Tappable online count**: "X online" opens a sheet listing online usernames
- **Card play log removed**: Removed client-side log entries for card plays (matches web client behavior)
- **Lobby join fix**: `lobbyPlayerJoined` handler replaces full player list from server data instead of trying to parse single player from wrong dict level

### Server
- **Spectator gameStart broadcast**: Both `startHand` and `cleanupNextHand` now send spectator-safe `gameStart` (trump, score, hand info, empty hand array) so spectators see updates between hands
- **Online usernames**: Added `getOnlineUsernames()` to GameManager; included `onlineUsers` in `mainRoomJoined` and `mainRoomPlayerJoined` events
- **Tie game stats**: Added tie detection — ties increment `stats.draws` instead of counting as losses; added `draws: 0` to default stats
- **Tournament game filter**: `getInProgressGames()` skips games belonging to active tournaments
- **Rainbow scoring clarity**: Refactored missed-bid rainbow bonus from confusing double-negative (`score -= penalty - bonus`) to explicit separate operations

### Web Client
- **Spectator trick history**: Creates card-back placeholder stacks for already-won tricks when joining mid-hand (server only stores counts, not cards)
- **Spectator trick inspection**: Spectators can hover/inspect opponent tricks (top-left area) — regular players still only inspect their own team's tricks
- **Spectator chat color**: Spectator messages now render green (#4ade80) instead of grey, making them visually distinct from system log entries

## Test plan
- [x] Server tests pass (214/214)
- [x] Client tests pass (240/240)
- [ ] Spectator issues: Join a game as spectator mid-hand — verify trick placeholders appear for both teams, hover works on both areas, header shows initials, trump/score updates between hands, chat is green
- [ ] Lobby issues: Create lobby on one device, join from another — verify joiner appears immediately; check in-progress games show correct player count; tap online count to see user list
- [ ] Game mechanics: Bore should require bid button confirmation; OT should animate consistently
- [ ] Tournament: Start a tournament, verify individual games don't appear in main room
- [ ] Tie game: End with tied score, verify draws stat increments

🤖 Generated with [Claude Code](https://claude.com/claude-code)