### PR TITLE
Fix tournament zombie state and add cancel tournament

### DIFF
--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -43,6 +43,7 @@ export const CLIENT_EVENTS = {
   SPECTATE_TOURNAMENT: 'spectateTournament',
   SPECTATE_TOURNAMENT_GAME: 'spectateTournamentGame',
   RETURN_TO_TOURNAMENT: 'returnToTournament',
+  CANCEL_TOURNAMENT: 'cancelTournament',
 
   // Profile
   GET_PROFILE: 'getProfile',
@@ -145,5 +146,6 @@ export const SERVER_EVENTS = {
   TOURNAMENT_ROUND_COMPLETE: 'tournamentRoundComplete',
   TOURNAMENT_COMPLETE: 'tournamentComplete',
   TOURNAMENT_LEFT: 'tournamentLeft',
+  TOURNAMENT_CANCELLED: 'tournamentCancelled',
   ACTIVE_TOURNAMENT_FOUND: 'activeTournamentFound',
 };

--- a/client/src/handlers/index.js
+++ b/client/src/handlers/index.js
@@ -99,6 +99,7 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onTournamentRoundComplete,
     onTournamentComplete,
     onTournamentLeft,
+    onTournamentCancelled,
     onActiveTournamentFound,
   } = callbacks;
 
@@ -197,6 +198,7 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onTournamentRoundComplete,
     onTournamentComplete,
     onTournamentLeft,
+    onTournamentCancelled,
     onActiveTournamentFound,
   });
 }

--- a/client/src/handlers/tournamentHandlers.js
+++ b/client/src/handlers/tournamentHandlers.js
@@ -30,6 +30,7 @@ export function registerTournamentHandlers(socketManager, callbacks = {}) {
     onTournamentRoundComplete,
     onTournamentComplete,
     onTournamentLeft,
+    onTournamentCancelled,
     onActiveTournamentFound,
   } = callbacks;
 
@@ -91,6 +92,11 @@ export function registerTournamentHandlers(socketManager, callbacks = {}) {
   socketManager.on(SERVER_EVENTS.TOURNAMENT_LEFT, (data) => {
     console.log('Tournament left:', data);
     onTournamentLeft?.(data);
+  });
+
+  socketManager.on(SERVER_EVENTS.TOURNAMENT_CANCELLED, (data) => {
+    console.log('Tournament cancelled:', data);
+    onTournamentCancelled?.(data);
   });
 
   socketManager.on(SERVER_EVENTS.ACTIVE_TOURNAMENT_FOUND, (data) => {

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -3046,6 +3046,13 @@ function initializeApp() {
       removeTournamentLobby();
     },
 
+    onTournamentCancelled: () => {
+      gameState.tournamentId = null;
+      removeTournamentLobby();
+      showInfo('Tournament has been cancelled by the host');
+      socket.emit('joinMainRoom');
+    },
+
     onActiveTournamentFound: (data) => {
       gameState.tournamentId = data.tournamentId;
       uiManager.showScreen(SCREENS.TOURNAMENT_LOBBY, data);

--- a/client/src/ui/screens/TournamentLobby.js
+++ b/client/src/ui/screens/TournamentLobby.js
@@ -337,6 +337,24 @@ export function showTournamentLobby(data, socket, username) {
         beginBtn.style.cursor = 'not-allowed';
       });
       buttonRow.appendChild(beginBtn);
+
+      // Cancel Tournament button (creator only)
+      const cancelBtn = document.createElement('button');
+      cancelBtn.id = 'tournamentCancelBtn';
+      cancelBtn.textContent = 'Cancel Tournament';
+      cancelBtn.style.cssText = `
+        padding: 12px 24px;
+        font-size: 16px;
+        border-radius: 8px;
+        border: none;
+        background: #991b1b;
+        color: #fff;
+        cursor: pointer;
+      `;
+      cancelBtn.addEventListener('click', () => {
+        socket.emit('cancelTournament');
+      });
+      buttonRow.appendChild(cancelBtn);
     }
 
     // Leave button

--- a/iOSClient/BABOnline/Constants/SocketEvents.swift
+++ b/iOSClient/BABOnline/Constants/SocketEvents.swift
@@ -54,6 +54,7 @@ enum SocketEvents {
         static let spectateTournament = "spectateTournament"
         static let spectateTournamentGame = "spectateTournamentGame"
         static let returnToTournament = "returnToTournament"
+        static let cancelTournament = "cancelTournament"
     }
 
     // MARK: - Server → Client
@@ -137,6 +138,7 @@ enum SocketEvents {
         static let tournamentRoundComplete = "tournamentRoundComplete"
         static let tournamentComplete = "tournamentComplete"
         static let tournamentLeft = "tournamentLeft"
+        static let tournamentCancelled = "tournamentCancelled"
         static let activeTournamentFound = "activeTournamentFound"
 
         // Leaderboard

--- a/iOSClient/BABOnline/Networking/Emitters/TournamentEmitter.swift
+++ b/iOSClient/BABOnline/Networking/Emitters/TournamentEmitter.swift
@@ -46,4 +46,8 @@ enum TournamentEmitter {
     static func returnToTournament() {
         socket.emit(SocketEvents.Client.returnToTournament)
     }
+
+    static func cancelTournament() {
+        socket.emit(SocketEvents.Client.cancelTournament)
+    }
 }

--- a/iOSClient/BABOnline/Networking/Handlers/TournamentSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/TournamentSocketHandler.swift
@@ -163,6 +163,16 @@ final class TournamentSocketHandler {
             }
         }
 
+        socket.on(SocketEvents.Server.tournamentCancelled) { [weak self] _, _ in
+            guard let self else { return }
+            DispatchQueue.main.async {
+                self.tournamentState.reset()
+                self.appState.screen = .mainRoom
+                LobbyEmitter.joinMainRoom()
+                print("[Tournament] Tournament cancelled by host")
+            }
+        }
+
         socket.on(SocketEvents.Server.activeTournamentFound) { data, _ in
             guard let dict = data.first as? [String: Any] else { return }
             DispatchQueue.main.async {

--- a/iOSClient/BABOnline/Views/Tournament/TournamentLobbyView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentLobbyView.swift
@@ -156,6 +156,19 @@ struct TournamentLobbyView: View {
                     .disabled(!allReady)
                 }
             }
+
+            // Cancel Tournament button (creator only, visible in all phases)
+            if isCreator {
+                Button(action: cancelTournament) {
+                    Text("Cancel Tournament")
+                        .font(.subheadline.bold())
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color(red: 0.6, green: 0.1, blue: 0.1))
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -183,5 +196,9 @@ struct TournamentLobbyView: View {
 
     private func leaveTournament() {
         TournamentEmitter.leaveTournament()
+    }
+
+    private func cancelTournament() {
+        TournamentEmitter.cancelTournament()
     }
 }

--- a/server/game/GameManager.js
+++ b/server/game/GameManager.js
@@ -741,11 +741,25 @@ class GameManager {
                     game.markPlayerDisconnected(position);
                 }
             }
+            // Also remove from tournament if in one (e.g. during round_active)
+            let wasInTournament = false;
+            let tournamentResult = null;
+            const tournamentId = this.playerTournaments.get(socketId);
+            if (tournamentId) {
+                const tournament = this.tournaments.get(tournamentId);
+                if (tournament) {
+                    tournamentResult = this.leaveTournament(socketId);
+                    wasInTournament = true;
+                }
+            }
+
             return {
                 wasInLobby,
                 wasInMainRoom,
                 wasInGame: true,
                 wasLazy,
+                wasInTournament,
+                tournamentResult,
                 game,
                 gameId,
                 // Don't abort immediately - give time to reconnect
@@ -753,13 +767,13 @@ class GameManager {
             };
         }
 
-        // Handle tournament lobby disconnect (not in a game)
+        // Handle tournament disconnect (not in a game)
         let wasInTournament = false;
         let tournamentResult = null;
         const tournamentId = this.playerTournaments.get(socketId);
         if (tournamentId) {
             const tournament = this.tournaments.get(tournamentId);
-            if (tournament && (tournament.phase === 'lobby' || tournament.phase === 'between_rounds')) {
+            if (tournament) {
                 tournamentResult = this.leaveTournament(socketId);
                 wasInTournament = true;
             }

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -150,6 +150,9 @@ function setupSocketHandlers(io) {
         socket.on('returnToTournament', () =>
             safeHandler(tournamentHandlers.returnToTournament)(socket, io, {})
         );
+        socket.on('cancelTournament', () =>
+            asyncHandler('cancelTournament', tournamentHandlers.cancelTournament)(socket, io, {})
+        );
 
         // Disconnect - cleanup rate limiter and handle game state
         socket.on('disconnect', () => {


### PR DESCRIPTION
## Summary
- **Fix zombie state**: Players disconnecting during `round_active` were kept as ghosts in the tournament, permanently blocking `allPlayersReady()` between rounds. `handleDisconnect` now removes players from the tournament regardless of phase — the game-level disconnect (grace period, bot replacement) is handled separately.
- **Add cancel tournament**: Creator-only `cancelTournament` event across server, web client, and iOS client. Broadcasts `tournamentCancelled`, clears DB state, deletes the tournament, and returns all players to the main room.

## Test plan
- [x] `npm test` — 214 server tests pass
- [x] `npm run test:client` — 240 client tests pass
- [ ] Create tournament with bots → start round → leave game → verify tournament auto-cleans up (no zombie in main room)
- [ ] Create tournament → cancel from lobby → all players returned to main room
- [ ] Create tournament → start round → cancel mid-round → verify cleanup and main room update

🤖 Generated with [Claude Code](https://claude.com/claude-code)