### PR TITLE
Fix full lobby join button and self-message unread indicator (iOS)

### DIFF
--- a/iOSClient/BABOnline/Networking/Handlers/ChatSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/ChatSocketHandler.swift
@@ -23,7 +23,7 @@ final class ChatSocketHandler {
                 self.gameState.gameLog.append(chatMsg)
 
                 // Increment unread count for player/spectator messages
-                if type == .player || type == .spectator {
+                if (type == .player || type == .spectator) && username != self.gameState.username {
                     self.gameState.unreadChatCount += 1
                 }
 

--- a/iOSClient/BABOnline/Views/MainRoom/LobbyListView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/LobbyListView.swift
@@ -88,6 +88,14 @@ struct LobbyRowView: View {
                         .background(Color(red: 0.376, green: 0.647, blue: 0.98)) // #60a5fa
                         .cornerRadius(8)
                 }
+            } else if lobby.playerCount >= 4 {
+                Text("Full")
+                    .font(.callout.bold())
+                    .foregroundColor(Color.Theme.textDim)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 8)
+                    .background(Color(red: 0.42, green: 0.44, blue: 0.47))
+                    .cornerRadius(8)
             } else {
                 Button(action: {
                     LobbyEmitter.joinLobby(lobbyId: lobby.id)


### PR DESCRIPTION
## Summary
- **Full lobby button**: Show a disabled "Full" button instead of a clickable "Join" when a lobby has 4/4 players, matching web client behavior. Previously users could tap "Join" on a full lobby which would fail server-side.
- **Unread chat indicator**: Skip incrementing `unreadChatCount` for the current user's own messages. Previously sending a message would trigger the unread badge for yourself.

## Test plan
- [ ] Create a lobby, fill to 4 players. From another iOS device, verify the lobby shows "Full" (gray, non-clickable) instead of "Join". Once the game starts, verify it moves to "In Progress" with a "Spectate" button.
- [ ] Join a game, open game log, send a message. Verify the unread badge does NOT increment for your own messages but DOES increment for other players' messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)