### PR TITLE
Fix spectator inspection of opponent won tricks

### DIFF
--- a/client/src/phaser/managers/TrickManager.js
+++ b/client/src/phaser/managers/TrickManager.js
@@ -281,8 +281,8 @@ export class TrickManager {
 
     // Animate cards to stack position
     trickCards.forEach((card, index) => {
-      // If not our team's trick, show card backs
-      if (!isMyTeam) {
+      // If not our team's trick, show card backs (unless spectating)
+      if (!isMyTeam && !this._isSpectatorMode) {
         card.setTexture('cardBack');
       }
 
@@ -327,10 +327,7 @@ export class TrickManager {
         trickNumber,
       });
 
-      // Spectators can also inspect opponent tricks
-      if (this._isSpectatorMode) {
-        this._setupTrickHover(trickCards, winningPosition);
-      }
+      this._setupTrickHover(trickCards, winningPosition);
     }
 
     // Clear current trick


### PR DESCRIPTION
## Summary
- **Card faces visible**: Spectators now see face-up cards in opponent trick stacks instead of card backs, so they can see what was actually played
- **Hover enabled**: Removed the spectator-mode gate on opponent trick hover — all trick stacks are now hoverable (harmless for regular players since their opponent cards are face-down anyway, consistent with `restoreTrickPlaceholders` which already does this)

## Test plan
- [ ] Spectate a game from the start. As tricks are won by opponents, verify card faces remain visible (not flipped to backs) and hovering fans them out
- [ ] Play a game normally. Verify opponent trick cards still show as card backs and team tricks are still hoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)