### PR TITLE
iOS: Background socket keep-alive + HSI display

### DIFF
--- a/iOSClient/BABOnline/State/GameState.swift
+++ b/iOSClient/BABOnline/State/GameState.swift
@@ -502,6 +502,17 @@ final class GameState: ObservableObject {
             updatePlayerNames()
         }
 
+        // Restore HSI values
+        if let hsi = data["hsiValues"] as? [String: Any] {
+            var parsed: [Int: Double] = [:]
+            for (key, val) in hsi {
+                if let pos = Int(key), let v = val as? Double {
+                    parsed[pos] = v
+                }
+            }
+            hsiValues = parsed
+        }
+
         phase = bidding ? .bidding : .playing
         isUICreated = true
     }

--- a/iOSClient/BABOnline/Views/Game/GameContainerView.swift
+++ b/iOSClient/BABOnline/Views/Game/GameContainerView.swift
@@ -117,6 +117,32 @@ struct GameContainerView: View {
                 }
             }
 
+            // HSI display (bottom-right, above card hand)
+            if (gameState.phase == .bidding || gameState.phase == .playing),
+               !gameState.isSpectator,
+               let myPos = gameState.position,
+               let hsi = gameState.hsiValues[myPos] {
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        Text("HSI: \(String(format: "%.1f", hsi))")
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundColor(Color(white: 0.67))
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .background(Color.black.opacity(0.7))
+                            .cornerRadius(4)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .stroke(Color(white: 0.4), lineWidth: 1)
+                            )
+                            .padding(.trailing, 12)
+                            .padding(.bottom, 190)
+                    }
+                }
+            }
+
             // Draw phase overlay
             if gameState.phase == .draw {
                 DrawPhaseView()


### PR DESCRIPTION
## Summary
- **Background socket keep-alive**: Uses `UIApplication.beginBackgroundTask` to keep the WebSocket alive for ~30s when the app is backgrounded, avoiding unnecessary disconnect/reconnect cycles during brief app switches (e.g., checking a notification). If the user returns within the keep-alive window and the socket is still connected, no reconnection happens at all. If the keep-alive expires (>30s), falls back to the existing `forceReconnect()` behavior.
- **HSI display**: Adds a "HSI: X.X" label to the bottom-right of the game screen during bidding/playing phases (non-spectator only), matching the web client's style (monospaced font, dark background, gray border).
- **HSI on rejoin fix**: Parses `hsiValues` from the server's rejoin payload in `restoreFromRejoin()`, so the HSI label persists through mid-hand reconnections.

## Test plan
- [ ] Build to a physical device, start a game, switch to another app for ~10 seconds, return — should not see "Reconnecting..." toast and other players should not see disconnect message
- [ ] Stay in another app for >30 seconds, return — should see normal reconnect flow (existing behavior)
- [ ] Start a hand in a game — should see "HSI: X.X" label at bottom-right during bidding/playing phases
- [ ] Disconnect and rejoin mid-hand — HSI should still display correctly
- [ ] Join as spectator — HSI label should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)