### PR TITLE
iOS: Add game log score breakdown and spectator team names

### DIFF
--- a/iOSClient/BABOnline/SpriteKit/Nodes/DrawPhaseNode.swift
+++ b/iOSClient/BABOnline/SpriteKit/Nodes/DrawPhaseNode.swift
@@ -34,7 +34,7 @@ class DrawPhaseNode: SKNode {
         nameLabel.fontName = "Helvetica-Bold"
         nameLabel.fontSize = 16
         nameLabel.fontColor = isLocalPlayer ? UIColor(red: 0.3, green: 0.9, blue: 0.4, alpha: 1) : .white
-        nameLabel.position = CGPoint(x: slotX, y: displayY + (cardH / 2) + 14)
+        nameLabel.position = CGPoint(x: slotX, y: displayY + (cardH / 2) + 22)
         nameLabel.zPosition = 300
         addChild(nameLabel)
         drawnDisplays.append(nameLabel)


### PR DESCRIPTION
## Summary
- Replace the simple "Hand complete — Score: X to Y" game log entry with a detailed multi-line breakdown showing team names, individual bids, tricks won, score change (+/-), and new total for each team (e.g. `Alice/Bob: Bid 3/4, Won 9, +72 → 172`)
- Append annotations for bore multipliers (`(2x)`, `(4x)`, etc.) and rainbow bonuses (`(rainbow +10)`) when applicable
- Fix spectator bidding-complete log to show actual player names (`Alice/Bob: 5/3, Charlie/Diana: 4/2`) instead of "Your team"/"Opponents"

## Test plan
- [ ] Complete a hand — game log should show `--- HAND COMPLETE ---` followed by per-team lines with names, bids, tricks won, score change, and new total
- [ ] Get a rainbow hand (4 cards, all different suits) — game log should show `(rainbow +10)` annotation
- [ ] Bid bore — game log should show `(2x)` or higher multiplier annotation
- [ ] Spectate a game through bidding — log should show player names, not "Your team"/"Opponents"
- [ ] Spectate through hand completion — team names should use actual player names

🤖 Generated with [Claude Code](https://claude.com/claude-code)