### PR TITLE
Fix spectator incorrectly seeing lazy mode UI

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -2797,7 +2797,7 @@ function initializeApp() {
       }
 
       // If it's the local player entering lazy mode, disable card interaction
-      if (data.position === gameState.position) {
+      if (data.position === gameState.position && !gameState.isSpectator) {
         gameState.isLazy = true;
         if (scene && scene.cardManager) {
           scene.cardManager.setInteractive(false);
@@ -2837,7 +2837,7 @@ function initializeApp() {
       }
 
       // If it's the local player returning to active mode, re-enable card interaction
-      if (data.position === gameState.position) {
+      if (data.position === gameState.position && !gameState.isSpectator) {
         gameState.isLazy = false;
         if (scene && scene.cardManager) {
           scene.cardManager.setInteractive(true);

--- a/client/src/phaser/scenes/GameScene.js
+++ b/client/src/phaser/scenes/GameScene.js
@@ -1598,7 +1598,7 @@ export class GameScene extends Phaser.Scene {
    */
   handlePlayerLazyMode(data) {
     console.log('🎮 GameScene.handlePlayerLazyMode()');
-    if (data.position === this.state.position) {
+    if (data.position === this.state.position && !this.state.isSpectator) {
       // Update local player's avatar to show bot info
       if (this._playerInfo) {
         const pic = data.botPic;
@@ -1625,7 +1625,7 @@ export class GameScene extends Phaser.Scene {
    */
   handlePlayerActiveMode(data) {
     console.log('🎮 GameScene.handlePlayerActiveMode()');
-    if (data.position === this.state.position) {
+    if (data.position === this.state.position && !this.state.isSpectator) {
       // Restore local player's avatar
       if (this._playerInfo) {
         const pic = data.pic;

--- a/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
@@ -386,7 +386,7 @@ final class GameSocketHandler {
                 self.gameState.players[pos] = GameState.PlayerInfo(username: botUsername, pic: botPic)
                 self.gameState.updatePlayerNames()
 
-                if pos == self.gameState.position {
+                if pos == self.gameState.position && !self.gameState.isSpectator {
                     self.gameState.isLazy = true
                 }
             }
@@ -403,7 +403,7 @@ final class GameSocketHandler {
                 self.gameState.players[pos] = GameState.PlayerInfo(username: username, pic: pic)
                 self.gameState.updatePlayerNames()
 
-                if pos == self.gameState.position {
+                if pos == self.gameState.position && !self.gameState.isSpectator {
                     self.gameState.isLazy = false
                 }
             }


### PR DESCRIPTION
## Summary
- Spectators view the game from position 1's perspective (`position = 1`). When the player at position 1 used `/lazy`, the `playerLazyMode` handler matched on `data.position === gameState.position`, incorrectly setting `isLazy = true` on the spectator.
- This caused spectators to see the green "type /active to take back control" toast (instead of the blue "type /leave to exit" toast) and all slash commands in autocomplete instead of just `/leave`.
- Added `!isSpectator` guard to the position check in `playerLazyMode` and `playerActiveMode` handlers across both web and iOS clients (6 locations, 3 files).

## Test plan
- [ ] Start a game with bots, spectate from another client
- [ ] Have position 1 go `/lazy` — spectator should still see blue "type /leave to exit" toast and only `/leave` in autocomplete
- [ ] Have position 1 go `/active` — no change for spectator
- [ ] Verify a non-spectator player can still use `/lazy` and `/active` normally
- [ ] `npm test` — 214 server tests pass
- [ ] `npm run test:client` — 240 client tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)