### PR TITLE
Fix spectator UI + refactor onGameStart to flat structure

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1661,7 +1661,7 @@ function initializeApp() {
       // Create DOM backgrounds via LayoutManager
       if (scene && scene.layoutManager) {
         scene.layoutManager.update();
-        scene.layoutManager.createDomBackgrounds();
+        scene.layoutManager.createDomBackgrounds({ skipHandArea: gameState.isSpectator });
       }
 
       // Add .in-game class for game log layout
@@ -2305,7 +2305,7 @@ function initializeApp() {
       // Create DOM backgrounds via LayoutManager (show immediately)
       if (scene.layoutManager) {
         scene.layoutManager.update();
-        scene.layoutManager.createDomBackgrounds();
+        scene.layoutManager.createDomBackgrounds({ skipHandArea: gameState.isSpectator });
       }
 
       // Display trump card via scene method (show immediately)

--- a/client/src/ui/components/ScoreModal.js
+++ b/client/src/ui/components/ScoreModal.js
@@ -95,13 +95,21 @@ export function formatHandCompleteMessages(options) {
  * @returns {Array} Array of message strings to add to game log
  */
 export function formatGameEndMessages(options) {
-  const { myPosition, playerData, teamScore, oppScore } = options;
+  const { myPosition, playerData, teamScore, oppScore, isSpectator } = options;
 
   const { teamName, oppName } = getTeamNames(myPosition, playerData);
 
   // Determine winner
   let resultMsg;
-  if (teamScore > oppScore) {
+  if (isSpectator) {
+    if (teamScore > oppScore) {
+      resultMsg = `${teamName} wins!`;
+    } else if (teamScore < oppScore) {
+      resultMsg = `${oppName} wins!`;
+    } else {
+      resultMsg = 'TIE GAME';
+    }
+  } else if (teamScore > oppScore) {
     resultMsg = 'VICTORY';
   } else if (teamScore < oppScore) {
     resultMsg = 'DEFEAT';
@@ -122,11 +130,14 @@ export function formatGameEndMessages(options) {
  * @param {Function} options.onReturnToLobby - Called when user clicks return button
  * @returns {Object} { overlay, destroy }
  */
-export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onReturnToLobby, buttonText }) {
+export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onReturnToLobby, buttonText, isSpectator, teamName, oppName }) {
   // Determine winner message
   let resultMsg;
   let resultColor;
-  if (teamScore > oppScore) {
+  if (isSpectator) {
+    resultMsg = 'GAME OVER';
+    resultColor = '#94a3b8';
+  } else if (teamScore > oppScore) {
     resultMsg = 'VICTORY';
     resultColor = '#4ade80';
   } else if (teamScore < oppScore) {
@@ -173,7 +184,11 @@ export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onRetu
     color: white;
     margin-bottom: 30px;
   `;
-  scoreDiv.textContent = `Final Score: ${teamScore} - ${oppScore}`;
+  if (isSpectator && teamName && oppName) {
+    scoreDiv.textContent = `${teamName}: ${teamScore}  —  ${oppName}: ${oppScore}`;
+  } else {
+    scoreDiv.textContent = `Final Score: ${teamScore} - ${oppScore}`;
+  }
   overlay.appendChild(scoreDiv);
 
   // Player stats grid (if available)

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -405,6 +405,13 @@ async function handleDrawComplete(io, game) {
     game.drawIDs = [];
     game.phase = 'bidding';
 
+    // Notify main room that a new in-progress game is available to spectate
+    io.to('mainRoom').emit('lobbiesUpdated', {
+        lobbies: gameManager.getAllLobbies(),
+        inProgressGames: gameManager.getInProgressGames(),
+        tournaments: gameManager.getAllTournaments()
+    });
+
     // createUI must come BEFORE gameStart (client expects this order)
     game.broadcast(io, 'createUI', {});
 


### PR DESCRIPTION
## Summary

Batch of spectator UI fixes and structural refactoring of the web client's game event handlers.

### Refactor: Flatten nested handler blocks
- **`onGameStart`** and **`processRejoinOrRestore`** both had ~100+ line blocks gated on `if (scene && data.position)`, coupling unrelated rendering operations together. Spectators don't receive `data.position`, so the entire visual setup was skipped on hand transitions — causing a blank board.
- Flattened both into independent sections, each guarded only on what it actually needs — matching the iOS client's `GameSocketHandler.handleGameStart` pattern.
- This properly fixes the spectator hand-transition rendering bug, superseding #142 (which patched it with an `effectivePosition` workaround).

### Spectator-specific guards added
- **Player info box**, **HSI display**, **bid UI**, **card legality** — skip for spectators
- **Hand area background** — pass `skipHandArea: true` for spectators in both `onGameStart` and `processRejoinOrRestore` (was already done for initial spectator join)
- **Opponent card count** — use `data.currentHand || data.hand?.length` so spectators (who get empty hand arrays) still see opponent card backs
- **Avatars** — no longer gated on `data.hand`, so spectators see avatars on hand transitions

### Spectator game-end display
- Spectators previously saw "VICTORY"/"DEFEAT" from Team 1's perspective (since they view from position 1)
- Now show neutral **"GAME OVER"** (gray) with both team names and scores (`Danny/Zach: 45 — Sharon/Mike: 32`)
- Game log shows `"[team] wins!"` instead of VICTORY/DEFEAT for spectators
- `showFinalScoreOverlay` and `formatGameEndMessages` accept `isSpectator`/`teamName`/`oppName` options

### In-progress games visibility in main room
- When a game transitions to bidding phase, broadcast `lobbiesUpdated` to the main room so the game appears in the spectate list without needing to refresh

### Spectator lazy mode UI fix (from prior commit)
- Fix spectator incorrectly seeing lazy mode toast/avatar when P1 goes `/lazy`

Supersedes #142.

## Test plan
- [x] Play a full game as normal player — hand transitions, avatars, trump, bid UI, scores all work
- [x] Spectate a game — all visuals render correctly on hand transitions (no blank board)
- [x] Spectate while P1 goes `/lazy` — spectator toast stays blue, no bot avatar swap
- [x] Spectate a game to completion — game-end overlay shows "GAME OVER" with both team names/scores
- [x] Normal player sees VICTORY/DEFEAT as before
- [x] No hand area background shown for spectators
- [x] In-progress game appears in main room without refresh
- [x] Client tests pass (`npm run test:client` — 240/240)
- [x] Server tests pass (`npm test` — 214/214)

🤖 Generated with [Claude Code](https://claude.com/claude-code)