### PR TITLE
Fix iOS spectator game-end showing Victory/Defeat

### DIFF
--- a/iOSClient/BABOnline/Views/Game/GameEndView.swift
+++ b/iOSClient/BABOnline/Views/Game/GameEndView.swift
@@ -12,12 +12,18 @@ struct GameEndView: View {
             VStack(spacing: 24) {
                 if let data = gameState.gameEndData {
                     // Winner banner
-                    let myTeam = Positions.getTeamNumber(gameState.position ?? 1)
-                    let didWin = data.winningTeam == myTeam
+                    if gameState.isSpectator {
+                        Text("Game Over")
+                            .font(.system(size: 36, weight: .bold, design: .rounded))
+                            .foregroundColor(Color.Theme.textSecondary)
+                    } else {
+                        let myTeam = Positions.getTeamNumber(gameState.position ?? 1)
+                        let didWin = data.winningTeam == myTeam
 
-                    Text(didWin ? "Victory!" : "Defeat")
-                        .font(.system(size: 36, weight: .bold, design: .rounded))
-                        .foregroundColor(didWin ? Color.Theme.success : Color.Theme.oppColor)
+                        Text(didWin ? "Victory!" : "Defeat")
+                            .font(.system(size: 36, weight: .bold, design: .rounded))
+                            .foregroundColor(didWin ? Color.Theme.success : Color.Theme.oppColor)
+                    }
 
                     // Score summary
                     HStack(spacing: 40) {


### PR DESCRIPTION
## Summary
- Spectators have `position = 1` (hardcoded for rendering perspective), so `GameEndView` was always showing "Victory!" or "Defeat" from Team 1's point of view
- Spectators now see neutral "Game Over" in gray text
- The score section underneath already shows both teams neutrally with names and scores, so no changes needed there
- Web client equivalent in #144

## Test plan
- [ ] Spectate a game to completion — banner shows "Game Over" in gray, scores show both teams
- [ ] Play a game as a normal player — still see "Victory!" / "Defeat" as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)