### PR TITLE
Make /leave a permanent exit from the game

### DIFF
--- a/client/src/ui/components/GameLog.js
+++ b/client/src/ui/components/GameLog.js
@@ -108,7 +108,7 @@ export function createGameLog({ onChatSubmit } = {}) {
   const ALL_SLASH_COMMANDS = [
     { command: '/lazy', description: 'Have a bot play for you' },
     { command: '/active', description: 'Take back control from bot' },
-    { command: '/leave', description: 'Exit to lobby (bot plays, rejoin anytime)' },
+    { command: '/leave', description: 'Leave the game (bot finishes for you)' },
   ];
   const SPECTATOR_SLASH_COMMANDS = [
     { command: '/leave', description: 'Exit spectating' },

--- a/iOSClient/BABOnline/Views/Game/GameLogView.swift
+++ b/iOSClient/BABOnline/Views/Game/GameLogView.swift
@@ -16,7 +16,7 @@ struct GameLogView: View {
     private static let allCommands: [SlashCommand] = [
         SlashCommand(command: "/lazy", description: "Bot plays for you"),
         SlashCommand(command: "/active", description: "Take back control"),
-        SlashCommand(command: "/leave", description: "Exit to lobby"),
+        SlashCommand(command: "/leave", description: "Leave the game (bot finishes for you)"),
     ]
 
     private var availableCommands: [SlashCommand] {

--- a/server/socket/chatHandlers.js
+++ b/server/socket/chatHandlers.js
@@ -170,7 +170,10 @@ function handleLeaveCommand(socket, io, game, position) {
     // Leave the game room (bot continues via lazyPlayers entry)
     game.leaveRoom(io, socket.id);
 
-    // Clear activeGameId so the player can create new lobbies / join tournaments
+    // Remove in-memory player→game mapping so the player can create/join lobbies
+    gameManager.playerGames.delete(socket.id);
+
+    // Clear activeGameId in DB so the player can create new lobbies / join tournaments
     const user = gameManager.getUserBySocketId(socket.id);
     if (user) {
         gameManager.clearActiveGame(user.username);

--- a/server/socket/mainRoomHandlers.js
+++ b/server/socket/mainRoomHandlers.js
@@ -204,7 +204,7 @@ function joinAsSpectator(socket, io, data) {
 
     // Check if this user is actually a lazy player for this game
     const lazyPosition = game.getOriginalPlayerPosition(user.username);
-    if (lazyPosition && game.isLazy(lazyPosition)) {
+    if (lazyPosition && game.isLazy(lazyPosition) && !game.lazyPlayers[lazyPosition].permanentLeave) {
         // Update originalSocketId so /active will recognize this socket
         game.lazyPlayers[lazyPosition].originalSocketId = socket.id;
 


### PR DESCRIPTION
## Summary

- `/leave` now permanently exits the game: sets a `permanentLeave` flag on the lazy player entry, clears `activeGameId` in the database, and prevents re-entry via `/active` or spectator lazy-rejoin
- Fixes the issue where players who used `/leave` were blocked from creating new lobbies or joining tournaments (with no error message explaining why)
- Bot continues playing for the rest of the game via the intact `lazyPlayers` entry

## Test plan

- [x] `npm test` — 214 server tests pass
- [x] `npm run test:client` — 240 client tests pass
- [ ] Manual: `/leave` a game → main room → create new lobby → should work
- [ ] Manual: After `/leave`, spectate old game → only `/leave` in autocomplete, no `/active`
- [ ] Manual: Bot continues playing in the left game

🤖 Generated with [Claude Code](https://claude.com/claude-code)