### PR TITLE
Add /support page for App Store review

### DIFF
--- a/iOSClient/BABOnline/Views/Game/BidOverlayView.swift
+++ b/iOSClient/BABOnline/Views/Game/BidOverlayView.swift
@@ -62,7 +62,7 @@ struct BidOverlayView: View {
 
                 // Submit button
                 Button(action: submitBid) {
-                    Text("Bid")
+                    Text("Submit")
                         .font(.callout.bold())
                         .padding(.horizontal, 24)
                         .padding(.vertical, 8)

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -55,7 +55,77 @@ router.get('/privacy', (req, res) => {
     <p>If we update this policy, the changes will be posted on this page with an updated date.</p>
 
     <h2>Contact</h2>
-    <p>Questions or deletion requests: <a href="https://github.com/dannytakahashi/bab-online/issues">github.com/dannytakahashi/bab-online/issues</a></p>
+    <p>Email: <a href="mailto:support@zalberico.com">support@zalberico.com</a></p>
+    <p>Bug reports &amp; feature requests: <a href="https://github.com/dannytakahashi/bab-online/issues">github.com/dannytakahashi/bab-online/issues</a></p>
+    <p>See our <a href="/support">Support Page</a> for FAQs and more information.</p>
+</body>
+</html>`);
+});
+
+// Support page
+router.get('/support', (req, res) => {
+    res.send(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BAB Online - Support</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 700px; margin: 40px auto; padding: 0 20px; color: #e0e0e0; background: #1a1a1a; line-height: 1.6; }
+        h1 { color: #4dcc73; }
+        h2 { color: #ccc; margin-top: 2em; }
+        h3 { color: #aaa; margin-top: 1.5em; }
+        p { margin: 0.8em 0; }
+        a { color: #4dcc73; }
+        details { margin: 0.8em 0; }
+        summary { cursor: pointer; font-weight: bold; color: #ccc; padding: 0.4em 0; }
+        summary:hover { color: #4dcc73; }
+        details p { margin-left: 1em; }
+    </style>
+</head>
+<body>
+    <h1>BAB Online — Support</h1>
+
+    <h2>About</h2>
+    <p>BAB Online is a 4-player online multiplayer trick-taking card game (Back Alley Bridge). Play with friends or bots, bid on tricks, and compete for the highest score across 13 hands. Free to play with no ads or in-app purchases.</p>
+
+    <h2>Contact Us</h2>
+    <p>Email: <a href="mailto:support@zalberico.com">support@zalberico.com</a></p>
+    <p>Bug reports &amp; feature requests: <a href="https://github.com/dannytakahashi/bab-online/issues">github.com/dannytakahashi/bab-online/issues</a></p>
+
+    <h2>Frequently Asked Questions</h2>
+
+    <details>
+        <summary>How do I play?</summary>
+        <p>BAB Online is a trick-taking card game for 4 players in two teams. Each hand, you bid how many tricks you think you can win, then play your cards. You earn points for meeting your bid and lose points for missing it. The game progresses through 13 hands of varying sizes, and the team with the most points at the end wins.</p>
+    </details>
+
+    <details>
+        <summary>How do I delete my account?</summary>
+        <p>To request deletion of your account and all associated data, email <a href="mailto:support@zalberico.com">support@zalberico.com</a> with your username. We will delete your account within 48 hours.</p>
+    </details>
+
+    <details>
+        <summary>I'm having connection issues</summary>
+        <p>If you're experiencing disconnections or trouble joining games:</p>
+        <p>1. Check your internet connection and try switching between Wi-Fi and cellular data.</p>
+        <p>2. Close and reopen the app — it will automatically reconnect and rejoin any in-progress game.</p>
+        <p>3. If you were in a game, you have 60 seconds to reconnect before other players can replace you with a bot.</p>
+        <p>If problems persist, please contact us at <a href="mailto:support@zalberico.com">support@zalberico.com</a>.</p>
+    </details>
+
+    <details>
+        <summary>What data do you collect?</summary>
+        <p>We only collect your username, a hashed password, and game statistics. We do not collect your real name, email address, location, or device identifiers. See our <a href="/privacy">Privacy Policy</a> for full details.</p>
+    </details>
+
+    <details>
+        <summary>Can I play with fewer than 4 people?</summary>
+        <p>Yes! You can fill empty seats with bot players. There are 5 bot personalities with different play styles. You can also play solo with 3 bots.</p>
+    </details>
+
+    <h2>Links</h2>
+    <p><a href="/privacy">Privacy Policy</a></p>
 </body>
 </html>`);
 });


### PR DESCRIPTION
## Summary
- Add `/support` route with app description, contact email (support@zalberico.com), FAQ section, and privacy policy link
- Update `/privacy` contact section with direct email and link to the new support page
- Addresses App Store rejection: support URL must be a proper support page, not just a GitHub issues link

## Test plan
- [ ] `npm run dev` → visit `http://localhost:3000/support` — page renders correctly
- [ ] Visit `http://localhost:3000/privacy` — contact section shows email + support page link
- [ ] Both pages render well on mobile viewport
- [ ] All server tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)