### PR TITLE
Fix iOS mid-game reconnection bugs

### DIFF
--- a/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
+++ b/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
@@ -232,6 +232,11 @@ class GameSKScene: SKScene {
         }
 
         trickManager?.setup(gameState: gameState)
+
+        // Render any cards already played in the current trick (e.g. after reconnect)
+        for played in gameState.playedCards {
+            trickManager?.placeCard(played.card, position: played.position)
+        }
     }
 
     // MARK: - Event Handlers


### PR DESCRIPTION
## Summary

- **Card tinting**: Derive `hasPlayedCard` from restored `playedCards` in `restoreFromRejoin()` so cards aren't all marked unplayable on quick reconnect
- **Trick rendering**: Render existing `playedCards` in `setupGameUI()` so force-quit reconnect shows cards already played in the current trick
- **Tricks count**: Read server's `tricks` key (`{ team1, team2 }`) as fallback since server doesn't send `teamTricks`/`oppTricks` directly — score bar was always showing "Tricks: 0"
- **Trump broken**: Read `isTrumpBroken` as fallback for `trumpBroken` to match the actual server key name, so trump restrictions are correctly restored

## Test plan

- [ ] Play a game on iOS, toggle airplane mode mid-hand, reconnect — cards should be correctly tinted and score bar shows correct tricks
- [ ] Play a game on iOS, force quit mid-hand, relaunch and reconnect — played cards should be visible in trick area, tricks count correct
- [ ] Break trump before disconnecting, reconnect — leading with trump should still be allowed
- [ ] Verify next hand continues working normally after any reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)