### PR TITLE
Add peer-to-peer WebRTC voice chat

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,7 +9,8 @@
         img-src 'self' data: blob:;
         connect-src 'self' ws://localhost:3000 wss://bab-online-production.up.railway.app https://bab-online-production.up.railway.app;
         font-src 'self' https://fonts.gstatic.com;
-        style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;">
+        style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+        media-src 'self' blob:;">
 
     <title>BAB Online</title>
     <script src="https://cdn.jsdelivr.net/npm/phaser@3.55.2/dist/phaser.min.js"></script>

--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -51,6 +51,11 @@ export const CLIENT_EVENTS = {
 
   // Leaderboard
   GET_LEADERBOARD: 'getLeaderboard',
+
+  // Voice Chat
+  VOICE_OFFER: 'voiceOffer',
+  VOICE_ANSWER: 'voiceAnswer',
+  VOICE_ICE_CANDIDATE: 'voiceIceCandidate',
 };
 
 // Server -> Client Events
@@ -148,4 +153,12 @@ export const SERVER_EVENTS = {
   TOURNAMENT_LEFT: 'tournamentLeft',
   TOURNAMENT_CANCELLED: 'tournamentCancelled',
   ACTIVE_TOURNAMENT_FOUND: 'activeTournamentFound',
+
+  // Voice Chat
+  VOICE_OFFER: 'voiceOffer',
+  VOICE_ANSWER: 'voiceAnswer',
+  VOICE_ICE_CANDIDATE: 'voiceIceCandidate',
+  VOICE_PEER_LIST: 'voicePeerList',
+  VOICE_PEER_JOINED: 'voicePeerJoined',
+  VOICE_PEER_LEFT: 'voicePeerLeft',
 };

--- a/client/src/handlers/authHandlers.js
+++ b/client/src/handlers/authHandlers.js
@@ -74,7 +74,7 @@ export function registerAuthHandlers(socketManager, callbacks = {}) {
 
   // Force logout (another session signed in)
   socketManager.on(SERVER_EVENTS.FORCE_LOGOUT, (data) => {
-    console.warn('⚠️ Force logout:', data.reason);
+    console.warn('⚠️ Force logout:', data?.reason);
 
     // Clear stored credentials
     sessionStorage.removeItem('username');

--- a/client/src/handlers/index.js
+++ b/client/src/handlers/index.js
@@ -12,6 +12,7 @@ import { registerChatHandlers } from './chatHandlers.js';
 import { registerProfileHandlers } from './profileHandlers.js';
 import { registerLeaderboardHandlers } from './leaderboardHandlers.js';
 import { registerTournamentHandlers } from './tournamentHandlers.js';
+import { registerVoiceHandlers } from './voiceHandlers.js';
 
 /**
  * Register all socket event handlers.
@@ -184,6 +185,9 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onLeaderboardError,
   });
 
+  // Register voice handlers (no callbacks needed - self-contained)
+  registerVoiceHandlers(socketManager);
+
   // Register tournament handlers
   registerTournamentHandlers(socketManager, {
     onTournamentCreated,
@@ -218,3 +222,4 @@ export { registerChatHandlers } from './chatHandlers.js';
 export { registerProfileHandlers } from './profileHandlers.js';
 export { registerLeaderboardHandlers } from './leaderboardHandlers.js';
 export { registerTournamentHandlers } from './tournamentHandlers.js';
+export { registerVoiceHandlers } from './voiceHandlers.js';

--- a/client/src/handlers/voiceHandlers.js
+++ b/client/src/handlers/voiceHandlers.js
@@ -1,0 +1,49 @@
+/**
+ * Voice chat socket event handlers.
+ *
+ * Registers listeners for WebRTC signaling events and delegates
+ * to VoiceChatManager. Uses global listeners (socketManager.on)
+ * since voice spans lobby → game.
+ */
+
+import { SERVER_EVENTS } from '../constants/events.js';
+import { getVoiceChatManager } from '../voice/VoiceChatManager.js';
+
+/**
+ * Register voice chat handlers.
+ * @param {import('../socket/SocketManager.js').SocketManager} socketManager
+ */
+export function registerVoiceHandlers(socketManager) {
+  const voiceManager = getVoiceChatManager();
+
+  socketManager.on(SERVER_EVENTS.VOICE_PEER_LIST, (data) => {
+    if (!voiceManager.active) return;
+    const { peers } = data;
+    peers.forEach(peer => {
+      voiceManager.connectToPeer(peer.socketId, peer.username);
+    });
+  });
+
+  socketManager.on(SERVER_EVENTS.VOICE_PEER_JOINED, (data) => {
+    // A new peer joined — they will send us an offer, so we just wait.
+    // No action needed here; we handle their offer in VOICE_OFFER.
+    console.log('Voice peer joined:', data.username);
+  });
+
+  socketManager.on(SERVER_EVENTS.VOICE_PEER_LEFT, (data) => {
+    voiceManager.removePeer(data.socketId);
+  });
+
+  socketManager.on(SERVER_EVENTS.VOICE_OFFER, async (data) => {
+    if (!voiceManager.active) return;
+    await voiceManager.handleOffer(data.fromSocketId, data.offer);
+  });
+
+  socketManager.on(SERVER_EVENTS.VOICE_ANSWER, async (data) => {
+    await voiceManager.handleAnswer(data.fromSocketId, data.answer);
+  });
+
+  socketManager.on(SERVER_EVENTS.VOICE_ICE_CANDIDATE, async (data) => {
+    await voiceManager.handleIceCandidate(data.fromSocketId, data.candidate);
+  });
+}

--- a/client/src/ui/components/VoiceChatUI.js
+++ b/client/src/ui/components/VoiceChatUI.js
@@ -1,0 +1,273 @@
+/**
+ * Voice Chat UI Components
+ *
+ * A. Mute button - circular button fixed bottom-right
+ * B. Tab overlay - player list with speaking indicators and per-player mute
+ */
+
+import { getVoiceChatManager } from '../../voice/VoiceChatManager.js';
+import { getSocketManager } from '../../socket/SocketManager.js';
+import { getGameState } from '../../state/GameState.js';
+
+// ============================================
+// Mute Button
+// ============================================
+
+/**
+ * Create the voice mute toggle button.
+ */
+export function createMuteButton() {
+  removeMuteButton();
+
+  const voiceManager = getVoiceChatManager();
+  const btn = document.createElement('button');
+  btn.id = 'voice-mute-btn';
+  btn.innerHTML = getMicIcon(false);
+  btn.title = 'Toggle microphone (M)';
+  btn.style.cssText = `
+    position: absolute;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    background: rgba(30, 30, 50, 0.8);
+    color: #fff;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s;
+    padding: 0;
+    z-index: 300;
+  `;
+
+  btn.addEventListener('click', () => {
+    const muted = voiceManager.toggleSelfMute();
+    btn.innerHTML = getMicIcon(muted);
+    btn.style.background = muted ? 'rgba(220, 38, 38, 0.8)' : 'rgba(30, 30, 50, 0.8)';
+  });
+
+  // Position below the HSI box if it exists, otherwise use fallback
+  _positionMuteButton(btn);
+  document.body.appendChild(btn);
+  return btn;
+}
+
+/**
+ * Position the mute button below the HSI box, or fallback to bottom-right.
+ */
+function _positionMuteButton(btn) {
+  const hsiBox = document.getElementById('player-hsi-box');
+  if (hsiBox) {
+    const rect = hsiBox.getBoundingClientRect();
+    btn.style.left = `${rect.left + rect.width / 2 - 18}px`;
+    btn.style.top = `${rect.bottom + 6}px`;
+  } else {
+    btn.style.bottom = '20px';
+    btn.style.right = '20px';
+    btn.style.top = '';
+    btn.style.left = '';
+  }
+}
+
+/**
+ * Reposition the mute button below the HSI box (call after avatar is created or on resize).
+ */
+export function reattachMuteButton() {
+  const btn = document.getElementById('voice-mute-btn');
+  if (!btn) return;
+  _positionMuteButton(btn);
+}
+
+export function removeMuteButton() {
+  const existing = document.getElementById('voice-mute-btn');
+  if (existing) existing.remove();
+}
+
+function getMicIcon(muted) {
+  if (muted) {
+    return `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="1" y1="1" x2="23" y2="23"></line>
+      <path d="M9 9v3a3 3 0 0 0 5.12 2.12M15 9.34V4a3 3 0 0 0-5.94-.6"></path>
+      <path d="M17 16.95A7 7 0 0 1 5 12v-2m14 0v2c0 .76-.13 1.49-.36 2.18"></path>
+      <line x1="12" y1="19" x2="12" y2="23"></line>
+      <line x1="8" y1="23" x2="16" y2="23"></line>
+    </svg>`;
+  }
+  return `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path>
+    <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
+    <line x1="12" y1="19" x2="12" y2="23"></line>
+    <line x1="8" y1="23" x2="16" y2="23"></line>
+  </svg>`;
+}
+
+// ============================================
+// Tab Overlay
+// ============================================
+
+let overlayUpdateInterval = null;
+
+/**
+ * Show the voice overlay (called on Tab press).
+ */
+export function showVoiceOverlay() {
+  removeVoiceOverlay();
+
+  const voiceManager = getVoiceChatManager();
+  if (!voiceManager.active) return;
+
+  const overlay = document.createElement('div');
+  overlay.id = 'voice-overlay';
+  overlay.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+  `;
+
+  const panel = document.createElement('div');
+  panel.style.cssText = `
+    background: #1a1a2e;
+    border-radius: 12px;
+    padding: 24px;
+    min-width: 280px;
+    max-width: 400px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  `;
+
+  const title = document.createElement('h3');
+  title.textContent = 'Voice Chat';
+  title.style.cssText = 'margin: 0 0 16px 0; color: #fff; text-align: center;';
+  panel.appendChild(title);
+
+  const playerList = document.createElement('div');
+  playerList.id = 'voice-overlay-players';
+  panel.appendChild(playerList);
+
+  const hint = document.createElement('p');
+  hint.textContent = 'Release Tab to close';
+  hint.style.cssText = 'margin: 16px 0 0 0; color: #666; text-align: center; font-size: 12px;';
+  panel.appendChild(hint);
+
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+
+  // Initial render + start polling
+  updateOverlayPlayers();
+  overlayUpdateInterval = setInterval(updateOverlayPlayers, SPEAKING_POLL_UI);
+}
+
+const SPEAKING_POLL_UI = 100;
+
+// Track overlay rows so we update in-place instead of recreating
+let _overlayRows = new Map(); // id → { row, dot, muteBtn }
+
+function updateOverlayPlayers() {
+  const container = document.getElementById('voice-overlay-players');
+  if (!container) return;
+
+  const voiceManager = getVoiceChatManager();
+  const socketManager = getSocketManager();
+  const gameState = getGameState();
+
+  // Build current entry list
+  const entries = [];
+  entries.push({
+    id: 'self',
+    username: gameState.username || socketManager.username || 'You',
+    isSelf: true
+  });
+  for (const peer of voiceManager.getPeers()) {
+    entries.push({ id: peer.socketId, username: peer.username, isSelf: false });
+  }
+
+  // Create rows for new entries, remove stale ones
+  const currentIds = new Set(entries.map(e => e.id));
+  for (const [id, els] of _overlayRows) {
+    if (!currentIds.has(id)) {
+      els.row.remove();
+      _overlayRows.delete(id);
+    }
+  }
+
+  for (const entry of entries) {
+    if (!_overlayRows.has(entry.id)) {
+      // Create row once
+      const row = document.createElement('div');
+      row.style.cssText = `
+        display: flex; align-items: center; padding: 8px 12px;
+        margin-bottom: 4px; border-radius: 8px; transition: background 0.15s;
+      `;
+
+      const dot = document.createElement('div');
+      dot.style.cssText = `
+        width: 10px; height: 10px; border-radius: 50%;
+        margin-right: 10px; transition: background 0.15s; flex-shrink: 0;
+      `;
+      row.appendChild(dot);
+
+      const name = document.createElement('span');
+      name.textContent = entry.username + (entry.isSelf ? ' (You)' : '');
+      name.style.cssText = 'color: #fff; flex: 1; font-size: 14px;';
+      row.appendChild(name);
+
+      const muteBtn = document.createElement('button');
+      muteBtn.style.cssText = `
+        border: none; border-radius: 6px; color: #fff;
+        padding: 4px 8px; cursor: pointer; font-size: 12px; flex-shrink: 0;
+      `;
+      const entryId = entry.id;
+      const isSelf = entry.isSelf;
+      muteBtn.addEventListener('click', () => {
+        if (isSelf) {
+          const muted = voiceManager.toggleSelfMute();
+          const mainBtn = document.getElementById('voice-mute-btn');
+          if (mainBtn) {
+            mainBtn.innerHTML = getMicIcon(muted);
+            mainBtn.style.background = muted ? 'rgba(220, 38, 38, 0.8)' : 'rgba(30, 30, 50, 0.8)';
+          }
+        } else {
+          if (voiceManager.isPeerMuted(entryId)) {
+            voiceManager.unmutePeer(entryId);
+          } else {
+            voiceManager.mutePeer(entryId);
+          }
+        }
+      });
+      row.appendChild(muteBtn);
+
+      container.appendChild(row);
+      _overlayRows.set(entry.id, { row, dot, muteBtn, isSelf: entry.isSelf });
+    }
+
+    // Update dynamic state (speaking, muted) on existing elements
+    const els = _overlayRows.get(entry.id);
+    const isSpeaking = voiceManager.isSpeaking(entry.id);
+    const isMuted = entry.isSelf ? voiceManager.selfMuted : voiceManager.isPeerMuted(entry.id);
+
+    els.row.style.background = isSpeaking ? 'rgba(74, 222, 128, 0.15)' : 'rgba(255, 255, 255, 0.05)';
+    els.dot.style.background = isSpeaking ? '#4ade80' : '#444';
+    els.muteBtn.textContent = isMuted ? 'Unmute' : 'Mute';
+    els.muteBtn.style.background = isMuted ? 'rgba(220, 38, 38, 0.6)' : 'rgba(255, 255, 255, 0.1)';
+  }
+}
+
+/**
+ * Remove the voice overlay (called on Tab release).
+ */
+export function removeVoiceOverlay() {
+  if (overlayUpdateInterval) {
+    clearInterval(overlayUpdateInterval);
+    overlayUpdateInterval = null;
+  }
+  _overlayRows.clear();
+  const existing = document.getElementById('voice-overlay');
+  if (existing) existing.remove();
+}

--- a/client/src/ui/screens/GameLobby.js
+++ b/client/src/ui/screens/GameLobby.js
@@ -54,15 +54,20 @@ export function updateLobbyPlayersList(container, players, currentUsername) {
     playerRow.style.alignItems = 'center';
     playerRow.style.padding = '8px 0';
     playerRow.style.borderBottom = '1px solid #374151';
+    playerRow.style.height = '36px';
 
     const nameContainer = document.createElement('span');
     nameContainer.style.display = 'flex';
     nameContainer.style.alignItems = 'center';
     nameContainer.style.gap = '6px';
+    nameContainer.style.overflow = 'hidden';
+    nameContainer.style.whiteSpace = 'nowrap';
+    nameContainer.style.minWidth = '0';
 
     const nameSpan = document.createElement('span');
     nameSpan.innerText = player.username;
     nameSpan.style.fontSize = '16px';
+    nameSpan.style.lineHeight = '1.2';
     if (player.isBot) {
       nameSpan.style.color = '#a78bfa'; // Purple for bots
     }
@@ -73,6 +78,8 @@ export function updateLobbyPlayersList(container, players, currentUsername) {
     rightSide.style.display = 'flex';
     rightSide.style.alignItems = 'center';
     rightSide.style.gap = '8px';
+    rightSide.style.flexShrink = '0';
+    rightSide.style.whiteSpace = 'nowrap';
 
     const statusSpan = document.createElement('span');
     if (player.ready) {
@@ -85,20 +92,25 @@ export function updateLobbyPlayersList(container, players, currentUsername) {
     statusSpan.style.fontSize = '14px';
     rightSide.appendChild(statusSpan);
 
-    // Add remove button for bot players (hide once ready)
-    if (player.isBot && !player.ready) {
+    // Add remove button for bot players, or invisible spacer for alignment
+    if (!player.ready) {
       const removeBtn = document.createElement('button');
       removeBtn.innerText = '✕';
-      removeBtn.title = 'Remove bot';
       removeBtn.style.background = 'none';
       removeBtn.style.border = 'none';
-      removeBtn.style.color = '#ef4444';
-      removeBtn.style.cursor = 'pointer';
       removeBtn.style.fontSize = '16px';
       removeBtn.style.fontWeight = 'bold';
       removeBtn.style.padding = '0 4px';
       removeBtn.style.lineHeight = '1';
-      removeBtn.dataset.botSocketId = player.socketId;
+
+      if (player.isBot) {
+        removeBtn.title = 'Remove bot';
+        removeBtn.style.color = '#ef4444';
+        removeBtn.style.cursor = 'pointer';
+        removeBtn.dataset.botSocketId = player.socketId;
+      } else {
+        removeBtn.style.visibility = 'hidden';
+      }
       rightSide.appendChild(removeBtn);
     }
 
@@ -115,6 +127,7 @@ export function updateLobbyPlayersList(container, players, currentUsername) {
     emptyRow.style.alignItems = 'center';
     emptyRow.style.padding = '8px 0';
     emptyRow.style.borderBottom = i < 3 ? '1px solid #374151' : 'none';
+    emptyRow.style.height = '36px';
 
     const emptySpan = document.createElement('span');
     emptySpan.innerText = '— Empty Slot —';

--- a/client/src/voice/VoiceChatManager.js
+++ b/client/src/voice/VoiceChatManager.js
@@ -1,0 +1,397 @@
+/**
+ * VoiceChatManager - WebRTC peer-to-peer voice chat.
+ *
+ * Full-mesh topology: each human player maintains a direct RTCPeerConnection
+ * to every other human. The server only relays signaling messages.
+ */
+
+import { CLIENT_EVENTS } from '../constants/events.js';
+
+const ICE_CONFIG = {
+  iceServers: [
+    { urls: 'stun:stun.l.google.com:19302' },
+    { urls: 'stun:stun1.l.google.com:19302' }
+  ]
+};
+
+const SPEAKING_THRESHOLD = 0.01;
+const SPEAKING_POLL_INTERVAL = 100;
+
+export class VoiceChatManager {
+  constructor() {
+    /** @type {MediaStream|null} */
+    this.localStream = null;
+
+    /** @type {Map<string, {connection: RTCPeerConnection, audioEl: HTMLAudioElement, username: string, stream: MediaStream|null}>} */
+    this.peers = new Map();
+
+    this.socketManager = null;
+    this.selfMuted = false;
+    this.active = false;
+
+    // Speaking detection
+    this._audioContext = null;
+    this._analysers = new Map(); // socketId|'self' → { analyser, dataArray }
+    this._speakingStates = new Map(); // socketId|'self' → boolean
+    this._speakingInterval = null;
+    this._speakingCallbacks = [];
+
+    // Per-peer mute state
+    this._peerMuted = new Map(); // socketId → boolean
+  }
+
+  /**
+   * Initialize voice chat: capture mic and set up signaling listeners.
+   * @param {import('../socket/SocketManager.js').SocketManager} socketManager
+   */
+  async initialize(socketManager) {
+    if (this.active) return;
+
+    this.socketManager = socketManager;
+
+    try {
+      this.localStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      console.warn('Mic permission denied:', err.message);
+      throw err;
+    }
+
+    this.active = true;
+
+    // Set up speaking detection for local stream
+    this._setupAudioContext();
+    this._addAnalyser('self', this.localStream);
+    this._startSpeakingDetection();
+  }
+
+  /**
+   * Create a peer connection and send an offer (initiator side).
+   * Called when we receive voicePeerList — we initiate to existing peers.
+   */
+  async connectToPeer(socketId, username) {
+    if (!this.active || !this.localStream) return;
+    if (this.peers.has(socketId)) return;
+
+    const pc = this._createPeerConnection(socketId, username);
+
+    // Add local audio tracks
+    this.localStream.getAudioTracks().forEach(track => {
+      pc.addTrack(track, this.localStream);
+    });
+
+    // Create and send offer
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+
+    this.socketManager.emit(CLIENT_EVENTS.VOICE_OFFER, {
+      targetSocketId: socketId,
+      offer: pc.localDescription
+    });
+  }
+
+  /**
+   * Handle an incoming offer from a peer (responder side).
+   */
+  async handleOffer(fromSocketId, offer, username) {
+    if (!this.active || !this.localStream) return;
+
+    // If we already have a connection, close it and recreate
+    if (this.peers.has(fromSocketId)) {
+      this._closePeer(fromSocketId);
+    }
+
+    const pc = this._createPeerConnection(fromSocketId, username || 'Unknown');
+
+    // Add local audio tracks
+    this.localStream.getAudioTracks().forEach(track => {
+      pc.addTrack(track, this.localStream);
+    });
+
+    await pc.setRemoteDescription(new RTCSessionDescription(offer));
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(answer);
+
+    this.socketManager.emit(CLIENT_EVENTS.VOICE_ANSWER, {
+      targetSocketId: fromSocketId,
+      answer: pc.localDescription
+    });
+  }
+
+  /**
+   * Handle an incoming answer from a peer.
+   */
+  async handleAnswer(fromSocketId, answer) {
+    const peer = this.peers.get(fromSocketId);
+    if (!peer) return;
+
+    await peer.connection.setRemoteDescription(new RTCSessionDescription(answer));
+  }
+
+  /**
+   * Handle an incoming ICE candidate.
+   */
+  async handleIceCandidate(fromSocketId, candidate) {
+    const peer = this.peers.get(fromSocketId);
+    if (!peer) return;
+
+    try {
+      await peer.connection.addIceCandidate(new RTCIceCandidate(candidate));
+    } catch (err) {
+      console.warn('Failed to add ICE candidate:', err.message);
+    }
+  }
+
+  /**
+   * Remove a peer connection (peer left).
+   */
+  removePeer(socketId) {
+    this._closePeer(socketId);
+  }
+
+  /**
+   * Toggle self-mute (disable/enable local audio tracks).
+   * @returns {boolean} New muted state
+   */
+  toggleSelfMute() {
+    this.selfMuted = !this.selfMuted;
+
+    if (this.localStream) {
+      this.localStream.getAudioTracks().forEach(track => {
+        track.enabled = !this.selfMuted;
+      });
+    }
+
+    return this.selfMuted;
+  }
+
+  /**
+   * Mute a specific peer's audio output.
+   */
+  mutePeer(socketId) {
+    this._peerMuted.set(socketId, true);
+    const peer = this.peers.get(socketId);
+    if (peer && peer.audioEl) {
+      peer.audioEl.muted = true;
+    }
+  }
+
+  /**
+   * Unmute a specific peer's audio output.
+   */
+  unmutePeer(socketId) {
+    this._peerMuted.set(socketId, false);
+    const peer = this.peers.get(socketId);
+    if (peer && peer.audioEl) {
+      peer.audioEl.muted = false;
+    }
+  }
+
+  /**
+   * Check if a peer is muted.
+   */
+  isPeerMuted(socketId) {
+    return this._peerMuted.get(socketId) || false;
+  }
+
+  /**
+   * Register a speaking change callback.
+   * @param {(socketId: string, isSpeaking: boolean) => void} callback
+   * socketId is 'self' for local user
+   */
+  onSpeakingChange(callback) {
+    this._speakingCallbacks.push(callback);
+  }
+
+  /**
+   * Get all connected peers with their info.
+   * @returns {Array<{socketId: string, username: string}>}
+   */
+  getPeers() {
+    const result = [];
+    for (const [socketId, peer] of this.peers) {
+      result.push({ socketId, username: peer.username });
+    }
+    return result;
+  }
+
+  /**
+   * Check if a peer or self is currently speaking.
+   */
+  isSpeaking(socketId) {
+    return this._speakingStates.get(socketId) || false;
+  }
+
+  /**
+   * Shut down all voice connections and clean up.
+   */
+  shutdown() {
+    this.active = false;
+
+    // Stop speaking detection
+    if (this._speakingInterval) {
+      clearInterval(this._speakingInterval);
+      this._speakingInterval = null;
+    }
+
+    // Close all peer connections
+    for (const socketId of this.peers.keys()) {
+      this._closePeer(socketId);
+    }
+    this.peers.clear();
+
+    // Stop local stream
+    if (this.localStream) {
+      this.localStream.getTracks().forEach(track => track.stop());
+      this.localStream = null;
+    }
+
+    // Close audio context
+    if (this._audioContext) {
+      this._audioContext.close().catch(() => {});
+      this._audioContext = null;
+    }
+
+    this._analysers.clear();
+    this._speakingStates.clear();
+    this._speakingCallbacks = [];
+    this._peerMuted.clear();
+    this.selfMuted = false;
+    this.socketManager = null;
+  }
+
+  // ============================================
+  // Private Methods
+  // ============================================
+
+  _createPeerConnection(socketId, username) {
+    const pc = new RTCPeerConnection(ICE_CONFIG);
+
+    const audioEl = document.createElement('audio');
+    audioEl.autoplay = true;
+    audioEl.id = `voice-audio-${socketId}`;
+    document.body.appendChild(audioEl);
+
+    // Apply existing mute state if any
+    if (this._peerMuted.get(socketId)) {
+      audioEl.muted = true;
+    }
+
+    this.peers.set(socketId, {
+      connection: pc,
+      audioEl,
+      username,
+      stream: null
+    });
+
+    // ICE candidate handling
+    pc.onicecandidate = (event) => {
+      if (event.candidate && this.socketManager) {
+        this.socketManager.emit(CLIENT_EVENTS.VOICE_ICE_CANDIDATE, {
+          targetSocketId: socketId,
+          candidate: event.candidate
+        });
+      }
+    };
+
+    // Remote stream handling
+    pc.ontrack = (event) => {
+      const peer = this.peers.get(socketId);
+      if (peer) {
+        peer.stream = event.streams[0];
+        peer.audioEl.srcObject = event.streams[0];
+
+        // Set up speaking detection for this peer
+        this._addAnalyser(socketId, event.streams[0]);
+      }
+    };
+
+    // Connection state monitoring
+    pc.onconnectionstatechange = () => {
+      if (pc.connectionState === 'failed' || pc.connectionState === 'closed') {
+        console.log(`Voice peer ${socketId} connection ${pc.connectionState}`);
+      }
+    };
+
+    return pc;
+  }
+
+  _closePeer(socketId) {
+    const peer = this.peers.get(socketId);
+    if (!peer) return;
+
+    peer.connection.close();
+    if (peer.audioEl) {
+      peer.audioEl.srcObject = null;
+      peer.audioEl.remove();
+    }
+
+    this._analysers.delete(socketId);
+    this._speakingStates.delete(socketId);
+    this.peers.delete(socketId);
+  }
+
+  _setupAudioContext() {
+    if (this._audioContext) return;
+    this._audioContext = new (window.AudioContext || window.webkitAudioContext)();
+  }
+
+  _addAnalyser(id, stream) {
+    if (!this._audioContext || !stream) return;
+
+    try {
+      const source = this._audioContext.createMediaStreamSource(stream);
+      const analyser = this._audioContext.createAnalyser();
+      analyser.fftSize = 256;
+      source.connect(analyser);
+
+      const dataArray = new Float32Array(analyser.fftSize);
+      this._analysers.set(id, { analyser, dataArray });
+    } catch (err) {
+      console.warn('Failed to create analyser for', id, err.message);
+    }
+  }
+
+  _startSpeakingDetection() {
+    if (this._speakingInterval) return;
+
+    this._speakingInterval = setInterval(() => {
+      for (const [id, { analyser, dataArray }] of this._analysers) {
+        analyser.getFloatTimeDomainData(dataArray);
+
+        // Calculate RMS
+        let sum = 0;
+        for (let i = 0; i < dataArray.length; i++) {
+          sum += dataArray[i] * dataArray[i];
+        }
+        const rms = Math.sqrt(sum / dataArray.length);
+
+        const wasSpeaking = this._speakingStates.get(id) || false;
+        const isSpeaking = rms > SPEAKING_THRESHOLD;
+
+        if (isSpeaking !== wasSpeaking) {
+          this._speakingStates.set(id, isSpeaking);
+          this._speakingCallbacks.forEach(cb => {
+            try { cb(id, isSpeaking); } catch (e) { /* ignore */ }
+          });
+        }
+      }
+    }, SPEAKING_POLL_INTERVAL);
+  }
+}
+
+// Singleton
+let instance = null;
+
+export function getVoiceChatManager() {
+  if (!instance) {
+    instance = new VoiceChatManager();
+  }
+  return instance;
+}
+
+export function resetVoiceChatManager() {
+  if (instance) {
+    instance.shutdown();
+  }
+  instance = null;
+}

--- a/client/styles/components.css
+++ b/client/styles/components.css
@@ -870,3 +870,15 @@
     height: 100%;
     object-fit: contain;
 }
+
+/* ==========================================================================
+   Voice Chat Speaking Indicators
+   ========================================================================== */
+
+.opponent-avatar-container.voice-speaking .opponent-avatar-img {
+    box-shadow: 0 0 20px 8px rgba(74, 222, 128, 0.6);
+}
+
+#player-avatar-container.voice-speaking .player-avatar-img {
+    box-shadow: 0 0 20px 8px rgba(74, 222, 128, 0.6);
+}

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -12,6 +12,7 @@ const chatHandlers = require('./chatHandlers');
 const reconnectHandlers = require('./reconnectHandlers');
 const profileHandlers = require('./profileHandlers');
 const tournamentHandlers = require('./tournamentHandlers');
+const voiceHandlers = require('./voiceHandlers');
 const { asyncHandler, syncHandler, safeHandler, rateLimiter } = require('./errorHandler');
 const { socketLogger } = require('../utils/logger');
 
@@ -152,6 +153,17 @@ function setupSocketHandlers(io) {
         );
         socket.on('cancelTournament', () =>
             asyncHandler('cancelTournament', tournamentHandlers.cancelTournament)(socket, io, {})
+        );
+
+        // Voice chat signaling relay
+        socket.on('voiceOffer', (data) =>
+            safeHandler(voiceHandlers.voiceOffer)(socket, io, data)
+        );
+        socket.on('voiceAnswer', (data) =>
+            safeHandler(voiceHandlers.voiceAnswer)(socket, io, data)
+        );
+        socket.on('voiceIceCandidate', (data) =>
+            safeHandler(voiceHandlers.voiceIceCandidate)(socket, io, data)
         );
 
         // Disconnect - cleanup rate limiter and handle game state

--- a/server/socket/lobbyHandlers.js
+++ b/server/socket/lobbyHandlers.js
@@ -240,6 +240,13 @@ function leaveLobby(socket, io) {
             leftUsername: user?.username || 'Unknown',
             needsMorePlayers: result.needsMorePlayers
         });
+
+        // Notify remaining human players that this peer left voice
+        if (!gameManager.isBot(player.socketId)) {
+            io.to(player.socketId).emit('voicePeerLeft', {
+                socketId: socket.id
+            });
+        }
     });
 }
 

--- a/server/socket/reconnectHandlers.js
+++ b/server/socket/reconnectHandlers.js
@@ -139,6 +139,18 @@ async function rejoinGame(socket, io, data) {
         username
     });
 
+    // Voice chat: send peer list to reconnecting player and notify others
+    const voicePeers = [];
+    for (const [sid, player] of game.players) {
+        if (sid !== socket.id && !player.isBot && !game.getDisconnectedPlayers().includes(player.position)) {
+            voicePeers.push({ socketId: sid, username: player.username });
+            io.to(sid).emit('voicePeerJoined', { socketId: socket.id, username });
+        }
+    }
+    if (voicePeers.length > 0) {
+        socket.emit('voicePeerList', { peers: voicePeers });
+    }
+
     const rcMessage = `${username} reconnected.`;
     game.addLogEntry(rcMessage, null, 'system');
     game.broadcast(io, 'gameLogEntry', { message: rcMessage, type: 'system' });

--- a/server/socket/voiceHandlers.js
+++ b/server/socket/voiceHandlers.js
@@ -1,0 +1,43 @@
+/**
+ * Voice chat signaling relay handlers.
+ * Forwards WebRTC signaling messages (SDP offers/answers, ICE candidates)
+ * between peers. No audio touches the server.
+ */
+
+const { socketLogger } = require('../utils/logger');
+
+function voiceOffer(socket, io, data) {
+    const { targetSocketId, offer } = data;
+    if (!targetSocketId || !offer) return;
+
+    io.to(targetSocketId).emit('voiceOffer', {
+        fromSocketId: socket.id,
+        offer
+    });
+}
+
+function voiceAnswer(socket, io, data) {
+    const { targetSocketId, answer } = data;
+    if (!targetSocketId || !answer) return;
+
+    io.to(targetSocketId).emit('voiceAnswer', {
+        fromSocketId: socket.id,
+        answer
+    });
+}
+
+function voiceIceCandidate(socket, io, data) {
+    const { targetSocketId, candidate } = data;
+    if (!targetSocketId || !candidate) return;
+
+    io.to(targetSocketId).emit('voiceIceCandidate', {
+        fromSocketId: socket.id,
+        candidate
+    });
+}
+
+module.exports = {
+    voiceOffer,
+    voiceAnswer,
+    voiceIceCandidate
+};


### PR DESCRIPTION
## Summary
- Full-mesh WebRTC voice chat for lobbies and in-game, with server-side signaling relay only (no audio on server)
- Mute button below player avatar, Tab-hold overlay with per-player mute and speaking indicators, M key shortcut
- Voice starts on lobby join, persists through game, tears down on leave/end, re-establishes on reconnect
- Green glow on avatars when speaking, CSP updated for WebRTC audio
- Fix pre-existing force logout crash and lobby player row height inconsistency

## Test plan
- [ ] Open 2+ browsers, sign in, join same lobby — verify mic prompt, WebRTC connects, audio heard
- [ ] Click mute button or press M — verify others stop hearing you, button turns red
- [ ] Hold Tab — verify overlay with player list, speaking indicators, per-player mute
- [ ] Ready up and start game — verify voice persists through lobby→game transition
- [ ] Leave lobby or finish game — verify voice tears down, UI removed
- [ ] Disconnect and reconnect — verify voice re-establishes
- [ ] Add bots to lobby — verify no voice connection attempts to bots
- [ ] Deny mic permission — verify game still works, warning toast shown
- [ ] Test on iOS Safari — verify no crashes (voice features may have quirks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)