### PR TITLE
Fix stat recording and add avg HSI to end-game screen

### DIFF
--- a/client/src/ui/components/ScoreModal.js
+++ b/client/src/ui/components/ScoreModal.js
@@ -206,7 +206,7 @@ export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onRetu
     const statsHeader = document.createElement('div');
     statsHeader.style.cssText = `
       display: grid;
-      grid-template-columns: 2fr 1fr 1fr 1fr;
+      grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
       gap: 12px;
       padding-bottom: 12px;
       border-bottom: 1px solid #444;
@@ -221,6 +221,7 @@ export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onRetu
       <div style="text-align: center;">Bids</div>
       <div style="text-align: center;">Tricks</div>
       <div style="text-align: center;">Faults</div>
+      <div style="text-align: center;">Avg HSI</div>
     `;
     statsContainer.appendChild(statsHeader);
 
@@ -236,7 +237,7 @@ export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onRetu
       const playerRow = document.createElement('div');
       playerRow.style.cssText = `
         display: grid;
-        grid-template-columns: 2fr 1fr 1fr 1fr;
+        grid-template-columns: 2fr 1fr 1fr 1fr 1fr;
         gap: 12px;
         padding: 8px 0;
         color: white;
@@ -247,6 +248,7 @@ export function showFinalScoreOverlay({ teamScore, oppScore, playerStats, onRetu
         <div style="text-align: center;">${stats.totalBids}</div>
         <div style="text-align: center;">${stats.totalTricks}</div>
         <div style="text-align: center; color: ${stats.setsCaused > 0 ? '#ef4444' : 'inherit'};">${stats.setsCaused}</div>
+        <div style="text-align: center;">${stats.avgHSI}</div>
       `;
       statsContainer.appendChild(playerRow);
     }

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -755,11 +755,13 @@ async function handleHandComplete(game, io) {
 
         // Build player stats with usernames for final score screen
         const playerStatsWithNames = {};
+        const totalHands = game.handStats.totalHands;
         for (let pos = 1; pos <= 4; pos++) {
             const player = game.getPlayerByPosition(pos);
             playerStatsWithNames[pos] = {
                 username: player?.username || `P${pos}`,
-                ...game.playerStats[pos]
+                ...game.playerStats[pos],
+                avgHSI: totalHands > 0 ? Math.round(game.playerStats[pos].totalHSI / totalHands) : 0
             };
         }
 

--- a/server/socket/profileHandlers.js
+++ b/server/socket/profileHandlers.js
@@ -202,6 +202,13 @@ async function uploadProfilePic(socket, io, data) {
 async function recordGameStats(game) {
     const usersCollection = getUsersCollection();
 
+    // Skip stat recording if any player is a bot
+    const hasBots = [1, 2, 3, 4].some(pos => game.isBot(game.positions[pos]));
+    if (hasBots) {
+        authLogger.info('Skipping stat recording — game contains bots', { gameId: game.gameId });
+        return;
+    }
+
     // Determine winner based on final scores
     const team1Won = game.score.team1 > game.score.team2;
     const isTie = game.score.team1 === game.score.team2;


### PR DESCRIPTION
## Summary
- Skip recording game stats to the database when bots are present, so bot games don't skew player profiles
- Add average Hand Strength Index (HSI) column to the end-of-game stats screen

## Test plan
- [x] `npm test` — 214 server tests pass
- [x] `npm run test:client` — 240 client tests pass
- [ ] Complete a game with bots, verify stats are not recorded to profile
- [ ] Complete a full game, confirm Avg HSI column appears on end screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)