### PR TITLE
Fix voice chat participant discovery

### DIFF
--- a/client/src/handlers/voiceHandlers.js
+++ b/client/src/handlers/voiceHandlers.js
@@ -17,7 +17,6 @@ export function registerVoiceHandlers(socketManager) {
   const voiceManager = getVoiceChatManager();
 
   socketManager.on(SERVER_EVENTS.VOICE_PEER_LIST, (data) => {
-    if (!voiceManager.active) return;
     const { peers } = data;
     peers.forEach(peer => {
       voiceManager.connectToPeer(peer.socketId, peer.username);
@@ -25,9 +24,7 @@ export function registerVoiceHandlers(socketManager) {
   });
 
   socketManager.on(SERVER_EVENTS.VOICE_PEER_JOINED, (data) => {
-    // A new peer joined — they will send us an offer, so we just wait.
-    // No action needed here; we handle their offer in VOICE_OFFER.
-    console.log('Voice peer joined:', data.username);
+    voiceManager.connectToPeer(data.socketId, data.username);
   });
 
   socketManager.on(SERVER_EVENTS.VOICE_PEER_LEFT, (data) => {
@@ -35,8 +32,7 @@ export function registerVoiceHandlers(socketManager) {
   });
 
   socketManager.on(SERVER_EVENTS.VOICE_OFFER, async (data) => {
-    if (!voiceManager.active) return;
-    await voiceManager.handleOffer(data.fromSocketId, data.offer);
+    await voiceManager.handleOffer(data.fromSocketId, data.offer, data.username);
   });
 
   socketManager.on(SERVER_EVENTS.VOICE_ANSWER, async (data) => {

--- a/client/src/ui/components/VoiceChatUI.js
+++ b/client/src/ui/components/VoiceChatUI.js
@@ -218,13 +218,43 @@ function updateOverlayPlayers() {
       name.style.cssText = 'color: #fff; flex: 1; font-size: 14px;';
       row.appendChild(name);
 
+      let slider = null;
+      let volLabel = null;
+      const entryId = entry.id;
+      const isSelf = entry.isSelf;
+
+      // Volume slider for remote peers only
+      if (!isSelf) {
+        const sliderWrap = document.createElement('div');
+        sliderWrap.style.cssText = 'display: flex; align-items: center; margin-right: 8px; flex-shrink: 0;';
+
+        slider = document.createElement('input');
+        slider.type = 'range';
+        slider.min = '0';
+        slider.max = '200';
+        slider.value = String(Math.round(voiceManager.getPeerVolume(entryId) * 100));
+        slider.style.cssText = 'width: 80px; accent-color: #4ade80; cursor: pointer;';
+
+        volLabel = document.createElement('span');
+        volLabel.textContent = slider.value + '%';
+        volLabel.style.cssText = 'color: #aaa; font-size: 11px; width: 36px; text-align: right; margin-left: 4px;';
+
+        slider.addEventListener('input', () => {
+          const pct = Number(slider.value);
+          voiceManager.setPeerVolume(entryId, pct / 100);
+          volLabel.textContent = pct + '%';
+        });
+
+        sliderWrap.appendChild(slider);
+        sliderWrap.appendChild(volLabel);
+        row.appendChild(sliderWrap);
+      }
+
       const muteBtn = document.createElement('button');
       muteBtn.style.cssText = `
         border: none; border-radius: 6px; color: #fff;
         padding: 4px 8px; cursor: pointer; font-size: 12px; flex-shrink: 0;
       `;
-      const entryId = entry.id;
-      const isSelf = entry.isSelf;
       muteBtn.addEventListener('click', () => {
         if (isSelf) {
           const muted = voiceManager.toggleSelfMute();
@@ -244,7 +274,7 @@ function updateOverlayPlayers() {
       row.appendChild(muteBtn);
 
       container.appendChild(row);
-      _overlayRows.set(entry.id, { row, dot, muteBtn, isSelf: entry.isSelf });
+      _overlayRows.set(entry.id, { row, dot, muteBtn, slider, volLabel, isSelf });
     }
 
     // Update dynamic state (speaking, muted) on existing elements
@@ -256,6 +286,14 @@ function updateOverlayPlayers() {
     els.dot.style.background = isSpeaking ? '#4ade80' : '#444';
     els.muteBtn.textContent = isMuted ? 'Unmute' : 'Mute';
     els.muteBtn.style.background = isMuted ? 'rgba(220, 38, 38, 0.6)' : 'rgba(255, 255, 255, 0.1)';
+
+    // Dim slider when muted
+    if (els.slider) {
+      els.slider.style.opacity = isMuted ? '0.4' : '1';
+    }
+    if (els.volLabel) {
+      els.volLabel.style.opacity = isMuted ? '0.4' : '1';
+    }
   }
 }
 

--- a/client/src/ui/screens/SignIn.js
+++ b/client/src/ui/screens/SignIn.js
@@ -69,6 +69,13 @@ export function createSignInScreen({ onSignIn, onCreateAccount }) {
     'i bid on that one.',
     'you need to get my one.',
     'surely...',
+    'no guts, no glory!',
+    'the locusts descend!',
+    'eat fast, kick ass!',
+    "5...what's trump?",
+    "this is a man's game!",
+    'you should be dealing already!',
+    "i did it frank's way, that bastard!",
   ];
   const splash = document.createElement('span');
   splash.textContent = splashPhrases[Math.floor(Math.random() * splashPhrases.length)];

--- a/client/src/voice/VoiceChatManager.js
+++ b/client/src/voice/VoiceChatManager.js
@@ -6,6 +6,7 @@
  */
 
 import { CLIENT_EVENTS } from '../constants/events.js';
+import { getGameState } from '../state/GameState.js';
 
 const ICE_CONFIG = {
   iceServers: [
@@ -22,7 +23,7 @@ export class VoiceChatManager {
     /** @type {MediaStream|null} */
     this.localStream = null;
 
-    /** @type {Map<string, {connection: RTCPeerConnection, audioEl: HTMLAudioElement, username: string, stream: MediaStream|null}>} */
+    /** @type {Map<string, {connection: RTCPeerConnection, username: string, stream: MediaStream|null}>} */
     this.peers = new Map();
 
     this.socketManager = null;
@@ -38,6 +39,17 @@ export class VoiceChatManager {
 
     // Per-peer mute state
     this._peerMuted = new Map(); // socketId → boolean
+
+    // Per-peer volume control (Web Audio API)
+    this._gainNodes = new Map(); // socketId → GainNode
+    this._peerVolumes = new Map(); // socketId → number (0.0–2.0, default 1.0)
+
+    // Local username for offer relay
+    this._localUsername = null;
+
+    // Buffered events received before initialization completes
+    this._pendingPeers = [];
+    this._pendingOffers = [];
   }
 
   /**
@@ -57,11 +69,22 @@ export class VoiceChatManager {
     }
 
     this.active = true;
+    this._localUsername = getGameState().username || null;
 
     // Set up speaking detection for local stream
     this._setupAudioContext();
     this._addAnalyser('self', this.localStream);
     this._startSpeakingDetection();
+
+    // Flush buffered events that arrived before initialization
+    for (const p of this._pendingPeers) {
+      this.connectToPeer(p.socketId, p.username);
+    }
+    this._pendingPeers = [];
+    for (const o of this._pendingOffers) {
+      this.handleOffer(o.fromSocketId, o.offer, o.username);
+    }
+    this._pendingOffers = [];
   }
 
   /**
@@ -69,7 +92,10 @@ export class VoiceChatManager {
    * Called when we receive voicePeerList — we initiate to existing peers.
    */
   async connectToPeer(socketId, username) {
-    if (!this.active || !this.localStream) return;
+    if (!this.active || !this.localStream) {
+      this._pendingPeers.push({ socketId, username });
+      return;
+    }
     if (this.peers.has(socketId)) return;
 
     const pc = this._createPeerConnection(socketId, username);
@@ -85,7 +111,8 @@ export class VoiceChatManager {
 
     this.socketManager.emit(CLIENT_EVENTS.VOICE_OFFER, {
       targetSocketId: socketId,
-      offer: pc.localDescription
+      offer: pc.localDescription,
+      username: this._localUsername
     });
   }
 
@@ -93,7 +120,10 @@ export class VoiceChatManager {
    * Handle an incoming offer from a peer (responder side).
    */
   async handleOffer(fromSocketId, offer, username) {
-    if (!this.active || !this.localStream) return;
+    if (!this.active || !this.localStream) {
+      this._pendingOffers.push({ fromSocketId, offer, username });
+      return;
+    }
 
     // If we already have a connection, close it and recreate
     if (this.peers.has(fromSocketId)) {
@@ -169,9 +199,9 @@ export class VoiceChatManager {
    */
   mutePeer(socketId) {
     this._peerMuted.set(socketId, true);
-    const peer = this.peers.get(socketId);
-    if (peer && peer.audioEl) {
-      peer.audioEl.muted = true;
+    const gainNode = this._gainNodes.get(socketId);
+    if (gainNode) {
+      gainNode.gain.value = 0;
     }
   }
 
@@ -180,9 +210,9 @@ export class VoiceChatManager {
    */
   unmutePeer(socketId) {
     this._peerMuted.set(socketId, false);
-    const peer = this.peers.get(socketId);
-    if (peer && peer.audioEl) {
-      peer.audioEl.muted = false;
+    const gainNode = this._gainNodes.get(socketId);
+    if (gainNode) {
+      gainNode.gain.value = this._peerVolumes.get(socketId) ?? 1.0;
     }
   }
 
@@ -191,6 +221,27 @@ export class VoiceChatManager {
    */
   isPeerMuted(socketId) {
     return this._peerMuted.get(socketId) || false;
+  }
+
+  /**
+   * Set a peer's volume (0.0–2.0). Does not apply if peer is muted.
+   */
+  setPeerVolume(socketId, volume) {
+    const clamped = Math.max(0, Math.min(2, volume));
+    this._peerVolumes.set(socketId, clamped);
+    if (!this._peerMuted.get(socketId)) {
+      const gainNode = this._gainNodes.get(socketId);
+      if (gainNode) {
+        gainNode.gain.value = clamped;
+      }
+    }
+  }
+
+  /**
+   * Get a peer's stored volume (default 1.0).
+   */
+  getPeerVolume(socketId) {
+    return this._peerVolumes.get(socketId) ?? 1.0;
   }
 
   /**
@@ -255,6 +306,11 @@ export class VoiceChatManager {
     this._speakingStates.clear();
     this._speakingCallbacks = [];
     this._peerMuted.clear();
+    this._gainNodes.clear();
+    this._peerVolumes.clear();
+    this._pendingPeers = [];
+    this._pendingOffers = [];
+    this._localUsername = null;
     this.selfMuted = false;
     this.socketManager = null;
   }
@@ -266,19 +322,8 @@ export class VoiceChatManager {
   _createPeerConnection(socketId, username) {
     const pc = new RTCPeerConnection(ICE_CONFIG);
 
-    const audioEl = document.createElement('audio');
-    audioEl.autoplay = true;
-    audioEl.id = `voice-audio-${socketId}`;
-    document.body.appendChild(audioEl);
-
-    // Apply existing mute state if any
-    if (this._peerMuted.get(socketId)) {
-      audioEl.muted = true;
-    }
-
     this.peers.set(socketId, {
       connection: pc,
-      audioEl,
       username,
       stream: null
     });
@@ -293,14 +338,11 @@ export class VoiceChatManager {
       }
     };
 
-    // Remote stream handling
+    // Remote stream handling — playback via GainNode (set up in _addAnalyser)
     pc.ontrack = (event) => {
       const peer = this.peers.get(socketId);
       if (peer) {
         peer.stream = event.streams[0];
-        peer.audioEl.srcObject = event.streams[0];
-
-        // Set up speaking detection for this peer
         this._addAnalyser(socketId, event.streams[0]);
       }
     };
@@ -320,11 +362,8 @@ export class VoiceChatManager {
     if (!peer) return;
 
     peer.connection.close();
-    if (peer.audioEl) {
-      peer.audioEl.srcObject = null;
-      peer.audioEl.remove();
-    }
 
+    this._gainNodes.delete(socketId);
     this._analysers.delete(socketId);
     this._speakingStates.delete(socketId);
     this.peers.delete(socketId);
@@ -343,6 +382,16 @@ export class VoiceChatManager {
       const analyser = this._audioContext.createAnalyser();
       analyser.fftSize = 256;
       source.connect(analyser);
+
+      // For remote peers, route audio through a GainNode for volume control
+      if (id !== 'self') {
+        const gainNode = this._audioContext.createGain();
+        const volume = this._peerVolumes.get(id) ?? 1.0;
+        gainNode.gain.value = this._peerMuted.get(id) ? 0 : volume;
+        source.connect(gainNode);
+        gainNode.connect(this._audioContext.destination);
+        this._gainNodes.set(id, gainNode);
+      }
 
       const dataArray = new Float32Array(analyser.fftSize);
       this._analysers.set(id, { analyser, dataArray });

--- a/server/socket/voiceHandlers.js
+++ b/server/socket/voiceHandlers.js
@@ -7,12 +7,13 @@
 const { socketLogger } = require('../utils/logger');
 
 function voiceOffer(socket, io, data) {
-    const { targetSocketId, offer } = data;
+    const { targetSocketId, offer, username } = data;
     if (!targetSocketId || !offer) return;
 
     io.to(targetSocketId).emit('voiceOffer', {
         fromSocketId: socket.id,
-        offer
+        offer,
+        username
     });
 }
 


### PR DESCRIPTION
## Summary
- **Fix "Unknown" labels**: Relay username through WebRTC offer signaling so peers display correct names
- **Fix missing participants**: Both sides now initiate connections on `voicePeerJoined` instead of only the new joiner
- **Fix timing race**: Buffer incoming peer/offer events during mic initialization so late joiners and slow permission grants still connect
- **Add per-peer volume control**: Replace HTML audio elements with Web Audio API GainNodes and add volume sliders to the voice overlay UI
- **Bonus**: Add more splash text phrases to sign-in screen

## Test plan
- [ ] 2-tab smoke test: both tabs see each other with correct usernames
- [ ] 4-player test: all peers visible in voice overlay for every player
- [ ] Late joiner: player joining voice after others still connects to everyone
- [ ] Slow mic permission: delaying mic grant still results in successful connections
- [ ] Volume sliders: adjusting slider changes peer volume, muting dims slider

🤖 Generated with [Claude Code](https://claude.com/claude-code)