### PR TITLE
Fix WebRTC glare causing broken voice connections

### DIFF
--- a/client/src/handlers/voiceHandlers.js
+++ b/client/src/handlers/voiceHandlers.js
@@ -24,7 +24,9 @@ export function registerVoiceHandlers(socketManager) {
   });
 
   socketManager.on(SERVER_EVENTS.VOICE_PEER_JOINED, (data) => {
-    voiceManager.connectToPeer(data.socketId, data.username);
+    // Don't initiate here — the new joiner will initiate to us via voicePeerList.
+    // If both sides initiate simultaneously, WebRTC glare breaks both connections.
+    console.log('Voice peer joined:', data.socketId, data.username);
   });
 
   socketManager.on(SERVER_EVENTS.VOICE_PEER_LEFT, (data) => {

--- a/client/src/voice/VoiceChatManager.js
+++ b/client/src/voice/VoiceChatManager.js
@@ -76,15 +76,23 @@ export class VoiceChatManager {
     this._addAnalyser('self', this.localStream);
     this._startSpeakingDetection();
 
-    // Flush buffered events that arrived before initialization
-    for (const p of this._pendingPeers) {
-      this.connectToPeer(p.socketId, p.username);
-    }
+    // Flush buffered events that arrived before initialization.
+    // Process offers first — if we have an offer from a peer, we don't need
+    // to also initiate to them (that would cause WebRTC glare).
+    const offerPeerIds = new Set(this._pendingOffers.map(o => o.fromSocketId));
+    const pendingPeers = this._pendingPeers;
+    const pendingOffers = this._pendingOffers;
     this._pendingPeers = [];
-    for (const o of this._pendingOffers) {
+    this._pendingOffers = [];
+
+    for (const o of pendingOffers) {
       this.handleOffer(o.fromSocketId, o.offer, o.username);
     }
-    this._pendingOffers = [];
+    for (const p of pendingPeers) {
+      if (!offerPeerIds.has(p.socketId)) {
+        this.connectToPeer(p.socketId, p.username);
+      }
+    }
   }
 
   /**
@@ -105,15 +113,20 @@ export class VoiceChatManager {
       pc.addTrack(track, this.localStream);
     });
 
-    // Create and send offer
-    const offer = await pc.createOffer();
-    await pc.setLocalDescription(offer);
+    try {
+      // Create and send offer
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
 
-    this.socketManager.emit(CLIENT_EVENTS.VOICE_OFFER, {
-      targetSocketId: socketId,
-      offer: pc.localDescription,
-      username: this._localUsername
-    });
+      this.socketManager.emit(CLIENT_EVENTS.VOICE_OFFER, {
+        targetSocketId: socketId,
+        offer: pc.localDescription,
+        username: this._localUsername
+      });
+    } catch (err) {
+      // PC may have been closed by a concurrent handleOffer — safe to ignore
+      console.log('connectToPeer aborted for', socketId, err.message);
+    }
   }
 
   /**
@@ -137,14 +150,18 @@ export class VoiceChatManager {
       pc.addTrack(track, this.localStream);
     });
 
-    await pc.setRemoteDescription(new RTCSessionDescription(offer));
-    const answer = await pc.createAnswer();
-    await pc.setLocalDescription(answer);
+    try {
+      await pc.setRemoteDescription(new RTCSessionDescription(offer));
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
 
-    this.socketManager.emit(CLIENT_EVENTS.VOICE_ANSWER, {
-      targetSocketId: fromSocketId,
-      answer: pc.localDescription
-    });
+      this.socketManager.emit(CLIENT_EVENTS.VOICE_ANSWER, {
+        targetSocketId: fromSocketId,
+        answer: pc.localDescription
+      });
+    } catch (err) {
+      console.warn('handleOffer failed for', fromSocketId, err.message);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Revert `VOICE_PEER_JOINED` from initiating connections** — only the joiner initiates via `voicePeerList`. When both sides send offers simultaneously (glare), `handleOffer` closes both initiator PCs and the resulting answers target dead connections, leaving neither side connected.
- **Fix flush order** — process pending offers before pending peers, skipping peers that already have a pending offer. Prevents glare during initialization flush.
- **Add try-catch to `connectToPeer`/`handleOffer`** — gracefully handle PCs closed mid-async-operation instead of throwing unhandled rejections.

## Test plan
- [ ] 2-tab test: both tabs see each other with correct usernames
- [ ] 4-player test: all peers visible in voice overlay
- [ ] Late joiner: joining after others still connects to everyone
- [ ] Check console for `connectToPeer aborted` or `handleOffer failed` — should not appear in normal flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)