### PR TITLE
Add WebRTC voice chat to iOS client

### DIFF
--- a/iOSClient/BABOnline.xcodeproj/project.pbxproj
+++ b/iOSClient/BABOnline.xcodeproj/project.pbxproj
@@ -92,6 +92,12 @@
 		BB1234567890ABCDEF00000D /* LeaderboardEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000D /* LeaderboardEmitter.swift */; };
 		BB1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift */; };
 		BB1234567890ABCDEF00000F /* LeaderboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF00000F /* LeaderboardView.swift */; };
+		DD0000000000000000000003 /* VoiceChatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000000000000000000002 /* VoiceChatManager.swift */; };
+		DD0000000000000000000005 /* VoiceEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000000000000000000004 /* VoiceEmitter.swift */; };
+		DD0000000000000000000007 /* VoiceSocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000000000000000000006 /* VoiceSocketHandler.swift */; };
+		DD0000000000000000000009 /* VoiceMuteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0000000000000000000008 /* VoiceMuteButton.swift */; };
+		DD000000000000000000000B /* VoicePanelSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD000000000000000000000A /* VoicePanelSheet.swift */; };
+		DD000000000000000000000E /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = DD000000000000000000000D /* WebRTC */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -180,6 +186,11 @@
 		AA1234567890ABCDEF00000D /* LeaderboardEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardEmitter.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardSocketHandler.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF00000F /* LeaderboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderboardView.swift; sourceTree = "<group>"; };
+		DD0000000000000000000002 /* VoiceChatManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceChatManager.swift; sourceTree = "<group>"; };
+		DD0000000000000000000004 /* VoiceEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceEmitter.swift; sourceTree = "<group>"; };
+		DD0000000000000000000006 /* VoiceSocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSocketHandler.swift; sourceTree = "<group>"; };
+		DD0000000000000000000008 /* VoiceMuteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMuteButton.swift; sourceTree = "<group>"; };
+		DD000000000000000000000A /* VoicePanelSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicePanelSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -188,6 +199,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				454C9420CAF6A9EEC90F4080 /* SocketIO in Frameworks */,
+				DD000000000000000000000E /* WebRTC in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -214,6 +226,7 @@
 				AA1234567890ABCDEF00000D /* LeaderboardEmitter.swift */,
 				ABFB49C1B9B998424D06A9B7 /* LobbyEmitter.swift */,
 				AA1234567890ABCDEF000003 /* TournamentEmitter.swift */,
+				DD0000000000000000000004 /* VoiceEmitter.swift */,
 			);
 			path = Emitters;
 			sourceTree = "<group>";
@@ -235,6 +248,7 @@
 				AA1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift */,
 				7FD14869A6FDEFEF8A26EB44 /* LobbySocketHandler.swift */,
 				AA1234567890ABCDEF000004 /* TournamentSocketHandler.swift */,
+				DD0000000000000000000006 /* VoiceSocketHandler.swift */,
 			);
 			path = Handlers;
 			sourceTree = "<group>";
@@ -313,6 +327,7 @@
 				EAECBA8F695BF16DD5F1E652 /* State */,
 				D3586572A4C8C5B0BD5A3B1C /* Utils */,
 				5D696315870C4CCDCC8C684B /* Views */,
+				DD0000000000000000000001 /* Voice */,
 			);
 			path = BABOnline;
 			sourceTree = "<group>";
@@ -327,6 +342,8 @@
 				B7D19DF413AEB22E4D8F0CB7 /* GameEndView.swift */,
 				1C12922A47ABEF52E6CD513E /* GameLogView.swift */,
 				E0C0084565BB95FB47383922 /* ScoreBarView.swift */,
+				DD0000000000000000000008 /* VoiceMuteButton.swift */,
+				DD000000000000000000000A /* VoicePanelSheet.swift */,
 			);
 			path = Game;
 			sourceTree = "<group>";
@@ -469,6 +486,14 @@
 			path = Actions;
 			sourceTree = "<group>";
 		};
+		DD0000000000000000000001 /* Voice */ = {
+			isa = PBXGroup;
+			children = (
+				DD0000000000000000000002 /* VoiceChatManager.swift */,
+			);
+			path = Voice;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -487,6 +512,7 @@
 			name = BABOnline;
 			packageProductDependencies = (
 				369628F9131811122EB62EAD /* SocketIO */,
+				DD000000000000000000000D /* WebRTC */,
 			);
 			productName = BABOnline;
 			productReference = 7F8955A183A4B54328782B3C /* BAB Online.app */;
@@ -518,6 +544,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket" */,
+				DD000000000000000000000C /* XCRemoteSwiftPackageReference "WebRTC" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -626,6 +653,11 @@
 				BB1234567890ABCDEF00000A /* TournamentResultsView.swift in Sources */,
 				01BE20189A36B2369389142A /* UsernameColor.swift in Sources */,
 				39B5487AEDCCC050AFED060C /* View+Haptics.swift in Sources */,
+				DD0000000000000000000003 /* VoiceChatManager.swift in Sources */,
+				DD0000000000000000000005 /* VoiceEmitter.swift in Sources */,
+				DD0000000000000000000007 /* VoiceSocketHandler.swift in Sources */,
+				DD0000000000000000000009 /* VoiceMuteButton.swift in Sources */,
+				DD000000000000000000000B /* VoicePanelSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -713,6 +745,7 @@
 				PRODUCT_NAME = "BAB Online";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -805,6 +838,7 @@
 				PRODUCT_NAME = "BAB Online";
 				SDKROOT = iphoneos;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -841,6 +875,14 @@
 				minimumVersion = 16.1.1;
 			};
 		};
+		DD000000000000000000000C /* XCRemoteSwiftPackageReference "WebRTC" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/stasel/WebRTC.git";
+			requirement = {
+				kind = exactVersion;
+				version = 140.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -848,6 +890,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 68E432C06209C0685B308F4A /* XCRemoteSwiftPackageReference "socket" */;
 			productName = SocketIO;
+		};
+		DD000000000000000000000D /* WebRTC */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DD000000000000000000000C /* XCRemoteSwiftPackageReference "WebRTC" */;
+			productName = WebRTC;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOSClient/BABOnline/BABOnlineApp.swift
+++ b/iOSClient/BABOnline/BABOnlineApp.swift
@@ -55,6 +55,9 @@ struct BABOnlineApp: App {
     private func handleScenePhase(_ phase: ScenePhase) {
         switch phase {
         case .active:
+            // Restore voice mic state
+            VoiceChatManager.shared.handleForeground()
+
             if socketService.isBackgroundTaskActive {
                 // Returned within the background keep-alive window (~30s).
                 // Socket likely still connected — end the task and only reconnect if needed.
@@ -72,6 +75,9 @@ struct BABOnlineApp: App {
                 socketService.forceReconnect()
             }
         case .background:
+            // Mute voice mic for privacy while backgrounded
+            VoiceChatManager.shared.handleBackground()
+
             print("[App] Backgrounded — starting socket keep-alive")
             socketService.beginBackgroundKeepAlive()
         default:

--- a/iOSClient/BABOnline/Constants/SocketEvents.swift
+++ b/iOSClient/BABOnline/Constants/SocketEvents.swift
@@ -55,6 +55,11 @@ enum SocketEvents {
         static let spectateTournamentGame = "spectateTournamentGame"
         static let returnToTournament = "returnToTournament"
         static let cancelTournament = "cancelTournament"
+
+        // Voice
+        static let voiceOffer = "voiceOffer"
+        static let voiceAnswer = "voiceAnswer"
+        static let voiceIceCandidate = "voiceIceCandidate"
     }
 
     // MARK: - Server → Client
@@ -143,6 +148,14 @@ enum SocketEvents {
 
         // Leaderboard
         static let leaderboardResponse = "leaderboardResponse"
+
+        // Voice
+        static let voiceOffer = "voiceOffer"
+        static let voiceAnswer = "voiceAnswer"
+        static let voiceIceCandidate = "voiceIceCandidate"
+        static let voicePeerList = "voicePeerList"
+        static let voicePeerJoined = "voicePeerJoined"
+        static let voicePeerLeft = "voicePeerLeft"
 
         // Connection
         static let connect = "connect"

--- a/iOSClient/BABOnline/Info.plist
+++ b/iOSClient/BABOnline/Info.plist
@@ -33,6 +33,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>BAB Online uses the microphone for voice chat with other players during games.</string>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/iOSClient/BABOnline/Networking/Emitters/VoiceEmitter.swift
+++ b/iOSClient/BABOnline/Networking/Emitters/VoiceEmitter.swift
@@ -1,0 +1,56 @@
+import Foundation
+import WebRTC
+
+enum VoiceEmitter {
+    private static var socket: SocketService { .shared }
+
+    static func sendOffer(targetSocketId: String, offer: RTCSessionDescription, username: String?) {
+        socket.emit(SocketEvents.Client.voiceOffer, [
+            "targetSocketId": targetSocketId,
+            "offer": ["type": offer.type.webString, "sdp": offer.sdp],
+            "username": username ?? ""
+        ])
+    }
+
+    static func sendAnswer(targetSocketId: String, answer: RTCSessionDescription) {
+        socket.emit(SocketEvents.Client.voiceAnswer, [
+            "targetSocketId": targetSocketId,
+            "answer": ["type": answer.type.webString, "sdp": answer.sdp]
+        ])
+    }
+
+    static func sendIceCandidate(targetSocketId: String, candidate: RTCIceCandidate) {
+        socket.emit(SocketEvents.Client.voiceIceCandidate, [
+            "targetSocketId": targetSocketId,
+            "candidate": [
+                "candidate": candidate.sdp,
+                "sdpMLineIndex": candidate.sdpMLineIndex,
+                "sdpMid": candidate.sdpMid ?? ""
+            ]
+        ])
+    }
+}
+
+// MARK: - RTCSdpType extension
+
+extension RTCSdpType {
+    var webString: String {
+        switch self {
+        case .offer: return "offer"
+        case .prAnswer: return "pranswer"
+        case .answer: return "answer"
+        case .rollback: return "rollback"
+        @unknown default: return "offer"
+        }
+    }
+
+    init?(from string: String) {
+        switch string {
+        case "offer": self = .offer
+        case "pranswer": self = .prAnswer
+        case "answer": self = .answer
+        case "rollback": self = .rollback
+        default: return nil
+        }
+    }
+}

--- a/iOSClient/BABOnline/Networking/Handlers/VoiceSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/VoiceSocketHandler.swift
@@ -1,0 +1,81 @@
+import Foundation
+import WebRTC
+
+/// Handles incoming voice signaling events from the server.
+/// Delegates all processing to VoiceChatManager.shared.
+final class VoiceSocketHandler {
+    private let socket: SocketService
+
+    init(socket: SocketService) {
+        self.socket = socket
+    }
+
+    func register() {
+        // Peer list — server tells us which humans are already in voice
+        socket.on(SocketEvents.Server.voicePeerList) { data, _ in
+            guard let dict = data.first as? [String: Any],
+                  let peers = dict["peers"] as? [[String: Any]] else { return }
+
+            for peer in peers {
+                guard let socketId = peer["socketId"] as? String,
+                      let username = peer["username"] as? String else { continue }
+                VoiceChatManager.shared.connectToPeer(socketId, username: username)
+            }
+        }
+
+        // New peer joined — log only (they will initiate from their side via voicePeerList)
+        socket.on(SocketEvents.Server.voicePeerJoined) { data, _ in
+            guard let dict = data.first as? [String: Any],
+                  let socketId = dict["socketId"] as? String,
+                  let username = dict["username"] as? String else { return }
+            print("[Voice] Peer joined: \(socketId) \(username)")
+        }
+
+        // Peer left
+        socket.on(SocketEvents.Server.voicePeerLeft) { data, _ in
+            guard let dict = data.first as? [String: Any],
+                  let socketId = dict["socketId"] as? String else { return }
+            VoiceChatManager.shared.removePeer(socketId)
+        }
+
+        // SDP offer from a peer
+        socket.on(SocketEvents.Server.voiceOffer) { data, _ in
+            guard let dict = data.first as? [String: Any],
+                  let fromSocketId = dict["fromSocketId"] as? String,
+                  let offerDict = dict["offer"] as? [String: Any],
+                  let sdpString = offerDict["sdp"] as? String,
+                  let typeString = offerDict["type"] as? String,
+                  let sdpType = RTCSdpType(from: typeString) else { return }
+
+            let username = dict["username"] as? String ?? "Unknown"
+            let sdp = RTCSessionDescription(type: sdpType, sdp: sdpString)
+            VoiceChatManager.shared.handleOffer(fromSocketId: fromSocketId, offer: sdp, username: username)
+        }
+
+        // SDP answer from a peer
+        socket.on(SocketEvents.Server.voiceAnswer) { data, _ in
+            guard let dict = data.first as? [String: Any],
+                  let fromSocketId = dict["fromSocketId"] as? String,
+                  let answerDict = dict["answer"] as? [String: Any],
+                  let sdpString = answerDict["sdp"] as? String,
+                  let typeString = answerDict["type"] as? String,
+                  let sdpType = RTCSdpType(from: typeString) else { return }
+
+            let sdp = RTCSessionDescription(type: sdpType, sdp: sdpString)
+            VoiceChatManager.shared.handleAnswer(fromSocketId: fromSocketId, answer: sdp)
+        }
+
+        // ICE candidate from a peer
+        socket.on(SocketEvents.Server.voiceIceCandidate) { data, _ in
+            guard let dict = data.first as? [String: Any],
+                  let fromSocketId = dict["fromSocketId"] as? String,
+                  let candidateDict = dict["candidate"] as? [String: Any],
+                  let candidateString = candidateDict["candidate"] as? String,
+                  let sdpMLineIndex = candidateDict["sdpMLineIndex"] as? Int32 else { return }
+
+            let sdpMid = candidateDict["sdpMid"] as? String
+            let candidate = RTCIceCandidate(sdp: candidateString, sdpMLineIndex: sdpMLineIndex, sdpMid: sdpMid)
+            VoiceChatManager.shared.handleIceCandidate(fromSocketId: fromSocketId, candidate: candidate)
+        }
+    }
+}

--- a/iOSClient/BABOnline/Networking/SocketEventRouter.swift
+++ b/iOSClient/BABOnline/Networking/SocketEventRouter.swift
@@ -10,6 +10,7 @@ final class SocketEventRouter {
     private let chatHandler: ChatSocketHandler
     private let tournamentHandler: TournamentSocketHandler
     private let leaderboardHandler: LeaderboardSocketHandler
+    private let voiceHandler: VoiceSocketHandler
 
     init(
         socket: SocketService,
@@ -28,6 +29,7 @@ final class SocketEventRouter {
         self.chatHandler = ChatSocketHandler(socket: socket, gameState: gameState)
         self.tournamentHandler = TournamentSocketHandler(socket: socket, tournamentState: tournamentState, gameState: gameState, appState: appState)
         self.leaderboardHandler = LeaderboardSocketHandler(socket: socket, leaderboardState: leaderboardState)
+        self.voiceHandler = VoiceSocketHandler(socket: socket)
     }
 
     func registerAll() {
@@ -37,5 +39,6 @@ final class SocketEventRouter {
         chatHandler.register()
         tournamentHandler.register()
         leaderboardHandler.register()
+        voiceHandler.register()
     }
 }

--- a/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
+++ b/iOSClient/BABOnline/SpriteKit/GameSKScene.swift
@@ -194,6 +194,23 @@ class GameSKScene: SKScene {
             .store(in: &cancellables)
 
         // Draw phase results and teams announced — handled by SwiftUI DrawPhaseView
+
+        // Voice speaking indicators
+        VoiceChatManager.shared.speakingChangedSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] (socketId, isSpeaking) in
+                guard let self, socketId != "self" else { return }
+                // Map socketId → position using playerData
+                guard let playerData = self.gameState.playerData else { return }
+                for (index, sid) in playerData.sockets.enumerated() {
+                    if sid == socketId, index < playerData.positions.count {
+                        let position = playerData.positions[index]
+                        self.opponentManager?.setSpeaking(position: position, speaking: isSpeaking)
+                        break
+                    }
+                }
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Phase Handling

--- a/iOSClient/BABOnline/SpriteKit/Managers/SKOpponentManager.swift
+++ b/iOSClient/BABOnline/SpriteKit/Managers/SKOpponentManager.swift
@@ -105,6 +105,15 @@ class SKOpponentManager {
         }
     }
 
+    func setSpeaking(position: Int, speaking: Bool) {
+        guard let node = opponents[position] else { return }
+        if speaking {
+            node.showSpeakingGlow()
+        } else {
+            node.hideSpeakingGlow()
+        }
+    }
+
     func clearAllBids() {
         // Bids are managed by SKBidManager — no-op here
     }

--- a/iOSClient/BABOnline/SpriteKit/Nodes/OpponentHandNode.swift
+++ b/iOSClient/BABOnline/SpriteKit/Nodes/OpponentHandNode.swift
@@ -7,6 +7,7 @@ class OpponentHandNode: SKNode {
 
     private let nameLabel: SKLabelNode
     private var turnGlow: SKShapeNode?
+    private var speakingGlow: SKShapeNode?
     private var avatarNode: SKShapeNode?
     private var avatarSprite: SKSpriteNode?
     private let avatarRadius: CGFloat = 20
@@ -78,6 +79,25 @@ class OpponentHandNode: SKNode {
         turnGlow = nil
     }
 
+    // MARK: - Speaking Glow
+
+    func showSpeakingGlow() {
+        guard speakingGlow == nil else { return }
+        let glow = SKShapeNode(circleOfRadius: 28)
+        glow.fillColor = UIColor(red: 0.1, green: 0.9, blue: 0.3, alpha: 0.4)
+        glow.strokeColor = UIColor(red: 0.1, green: 0.9, blue: 0.3, alpha: 0.7)
+        glow.lineWidth = 1.5
+        glow.zPosition = -2
+        glow.run(CardAnimations.pulseGlow())
+        addChild(glow)
+        speakingGlow = glow
+    }
+
+    func hideSpeakingGlow() {
+        speakingGlow?.removeFromParent()
+        speakingGlow = nil
+    }
+
     func updatePic(_ pic: String) {
         guard let circle = avatarNode else { return }
         // Remove existing avatar content (initial letter or crop node)
@@ -94,6 +114,8 @@ class OpponentHandNode: SKNode {
     func cleanup() {
         turnGlow?.removeFromParent()
         turnGlow = nil
+        speakingGlow?.removeFromParent()
+        speakingGlow = nil
     }
 
     // MARK: - Profile Pic

--- a/iOSClient/BABOnline/Views/Game/GameContainerView.swift
+++ b/iOSClient/BABOnline/Views/Game/GameContainerView.swift
@@ -13,6 +13,8 @@ struct GameContainerView: View {
     }()
 
     @State private var showGameLog = false
+    @State private var showVoicePanel = false
+    @ObservedObject private var voiceManager = VoiceChatManager.shared
 
     var body: some View {
         ZStack {
@@ -117,28 +119,39 @@ struct GameContainerView: View {
                 }
             }
 
-            // HSI display (bottom-right, above card hand)
-            if (gameState.phase == .bidding || gameState.phase == .playing),
-               !gameState.isSpectator,
-               let myPos = gameState.position,
-               let hsi = gameState.hsiValues[myPos] {
+            // HSI display and voice mute button (bottom-right, above card hand)
+            if gameState.phase == .bidding || gameState.phase == .playing {
                 VStack {
                     Spacer()
                     HStack {
                         Spacer()
-                        Text("HSI: \(String(format: "%.1f", hsi))")
-                            .font(.system(size: 12, design: .monospaced))
-                            .foregroundColor(Color(white: 0.67))
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 3)
-                            .background(Color.black.opacity(0.7))
-                            .cornerRadius(4)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 4)
-                                    .stroke(Color(white: 0.4), lineWidth: 1)
-                            )
-                            .padding(.trailing, 12)
-                            .padding(.bottom, 190)
+                        VStack(alignment: .trailing, spacing: 8) {
+                            // HSI display
+                            if !gameState.isSpectator,
+                               let myPos = gameState.position,
+                               let hsi = gameState.hsiValues[myPos] {
+                                Text("HSI: \(String(format: "%.1f", hsi))")
+                                    .font(.system(size: 12, design: .monospaced))
+                                    .foregroundColor(Color(white: 0.67))
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 3)
+                                    .background(Color.black.opacity(0.7))
+                                    .cornerRadius(4)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .stroke(Color(white: 0.4), lineWidth: 1)
+                                    )
+                            }
+
+                            // Voice mute button
+                            if voiceManager.isActive {
+                                VoiceMuteButton(onLongPress: {
+                                    showVoicePanel = true
+                                })
+                            }
+                        }
+                        .padding(.trailing, 12)
+                        .padding(.bottom, 190)
                     }
                 }
             }
@@ -162,6 +175,11 @@ struct GameContainerView: View {
         }
         .onDisappear {
             scene.cleanupAll()
+            VoiceChatManager.shared.shutdown()
+        }
+        .sheet(isPresented: $showVoicePanel) {
+            VoicePanelSheet()
+                .presentationDetents([.medium])
         }
     }
 }

--- a/iOSClient/BABOnline/Views/Game/GameContainerView.swift
+++ b/iOSClient/BABOnline/Views/Game/GameContainerView.swift
@@ -39,6 +39,46 @@ struct GameContainerView: View {
                 }
             }
 
+            // HSI display and voice mute button (bottom-right, above card hand)
+            // Placed before game log in ZStack so it renders underneath
+            // Hide when bid overlay is visible to avoid overlap
+            if (gameState.phase == .bidding || gameState.phase == .playing)
+                && !(gameState.isBidding && gameState.isMyTurn && !gameState.isReadOnly) {
+                VStack {
+                    Spacer()
+                    HStack {
+                        Spacer()
+                        VStack(alignment: .trailing, spacing: 8) {
+                            // HSI display
+                            if !gameState.isSpectator,
+                               let myPos = gameState.position,
+                               let hsi = gameState.hsiValues[myPos] {
+                                Text("HSI: \(String(format: "%.1f", hsi))")
+                                    .font(.system(size: 12, design: .monospaced))
+                                    .foregroundColor(Color(white: 0.67))
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 3)
+                                    .background(Color.black.opacity(0.7))
+                                    .cornerRadius(4)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .stroke(Color(white: 0.4), lineWidth: 1)
+                                    )
+                            }
+
+                            // Voice mute button
+                            if voiceManager.isActive {
+                                VoiceMuteButton(onLongPress: {
+                                    showVoicePanel = true
+                                })
+                            }
+                        }
+                        .padding(.trailing, 12)
+                        .padding(.bottom, 190)
+                    }
+                }
+            }
+
             // Game log toggle button
             if gameState.phase == .bidding || gameState.phase == .playing {
                 VStack {
@@ -116,45 +156,6 @@ struct GameContainerView: View {
                         .background(Color.green.opacity(0.8))
                         .cornerRadius(8)
                         .padding(.bottom, 12)
-                }
-            }
-
-            // HSI display and voice mute button (bottom-right, above card hand)
-            // Hide when bid overlay is visible to avoid overlap
-            if (gameState.phase == .bidding || gameState.phase == .playing)
-                && !(gameState.isBidding && gameState.isMyTurn && !gameState.isReadOnly) {
-                VStack {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        VStack(alignment: .trailing, spacing: 8) {
-                            // HSI display
-                            if !gameState.isSpectator,
-                               let myPos = gameState.position,
-                               let hsi = gameState.hsiValues[myPos] {
-                                Text("HSI: \(String(format: "%.1f", hsi))")
-                                    .font(.system(size: 12, design: .monospaced))
-                                    .foregroundColor(Color(white: 0.67))
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 3)
-                                    .background(Color.black.opacity(0.7))
-                                    .cornerRadius(4)
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: 4)
-                                            .stroke(Color(white: 0.4), lineWidth: 1)
-                                    )
-                            }
-
-                            // Voice mute button
-                            if voiceManager.isActive {
-                                VoiceMuteButton(onLongPress: {
-                                    showVoicePanel = true
-                                })
-                            }
-                        }
-                        .padding(.trailing, 12)
-                        .padding(.bottom, 190)
-                    }
                 }
             }
 

--- a/iOSClient/BABOnline/Views/Game/GameContainerView.swift
+++ b/iOSClient/BABOnline/Views/Game/GameContainerView.swift
@@ -120,7 +120,9 @@ struct GameContainerView: View {
             }
 
             // HSI display and voice mute button (bottom-right, above card hand)
-            if gameState.phase == .bidding || gameState.phase == .playing {
+            // Hide when bid overlay is visible to avoid overlap
+            if (gameState.phase == .bidding || gameState.phase == .playing)
+                && !(gameState.isBidding && gameState.isMyTurn && !gameState.isReadOnly) {
                 VStack {
                     Spacer()
                     HStack {

--- a/iOSClient/BABOnline/Views/Game/VoiceMuteButton.swift
+++ b/iOSClient/BABOnline/Views/Game/VoiceMuteButton.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Floating circular mic mute/unmute button for voice chat.
+struct VoiceMuteButton: View {
+    @ObservedObject var voiceManager = VoiceChatManager.shared
+    let onLongPress: () -> Void
+
+    var body: some View {
+        Button(action: {
+            voiceManager.toggleSelfMute()
+            HapticManager.lightImpact()
+        }) {
+            Image(systemName: voiceManager.isSelfMuted ? "mic.slash.fill" : "mic.fill")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 44, height: 44)
+                .background(voiceManager.isSelfMuted ? Color.red.opacity(0.9) : Color(white: 0.2).opacity(0.9))
+                .clipShape(Circle())
+                .overlay(
+                    Circle()
+                        .stroke(voiceManager.isSelfSpeaking && !voiceManager.isSelfMuted
+                                ? Color.green : Color(white: 0.4),
+                                lineWidth: voiceManager.isSelfSpeaking && !voiceManager.isSelfMuted ? 2 : 1)
+                )
+        }
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5)
+                .onEnded { _ in
+                    HapticManager.mediumImpact()
+                    onLongPress()
+                }
+        )
+    }
+}

--- a/iOSClient/BABOnline/Views/Game/VoicePanelSheet.swift
+++ b/iOSClient/BABOnline/Views/Game/VoicePanelSheet.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Bottom sheet showing voice chat participants with mute controls.
+struct VoicePanelSheet: View {
+    @ObservedObject var voiceManager = VoiceChatManager.shared
+
+    var body: some View {
+        NavigationView {
+            List {
+                // Self row
+                HStack(spacing: 12) {
+                    speakingDot(isSpeaking: voiceManager.isSelfSpeaking && !voiceManager.isSelfMuted)
+
+                    Text("You")
+                        .foregroundColor(Color.Theme.textPrimary)
+                        .fontWeight(.medium)
+
+                    Spacer()
+
+                    Button(action: {
+                        voiceManager.toggleSelfMute()
+                        HapticManager.lightImpact()
+                    }) {
+                        Image(systemName: voiceManager.isSelfMuted ? "mic.slash.fill" : "mic.fill")
+                            .foregroundColor(voiceManager.isSelfMuted ? .red : Color.Theme.textSecondary)
+                            .frame(width: 32, height: 32)
+                    }
+                }
+                .listRowBackground(Color.Theme.surface)
+
+                // Peer rows
+                ForEach(Array(voiceManager.peerInfos.keys.sorted()), id: \.self) { socketId in
+                    if let info = voiceManager.peerInfos[socketId] {
+                        HStack(spacing: 12) {
+                            speakingDot(isSpeaking: voiceManager.speakingPeers.contains(socketId))
+
+                            Text(info.username)
+                                .foregroundColor(Color.Theme.textPrimary)
+
+                            Spacer()
+
+                            Button(action: {
+                                voiceManager.togglePeerMute(socketId)
+                                HapticManager.lightImpact()
+                            }) {
+                                Image(systemName: info.isMuted ? "speaker.slash.fill" : "speaker.wave.2.fill")
+                                    .foregroundColor(info.isMuted ? .red : Color.Theme.textSecondary)
+                                    .frame(width: 32, height: 32)
+                            }
+                        }
+                        .listRowBackground(Color.Theme.surface)
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(Color.Theme.background)
+            .navigationTitle("Voice Chat")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private func speakingDot(isSpeaking: Bool) -> some View {
+        Circle()
+            .fill(isSpeaking ? Color.green : Color(white: 0.3))
+            .frame(width: 10, height: 10)
+            .animation(.easeInOut(duration: 0.2), value: isSpeaking)
+    }
+}

--- a/iOSClient/BABOnline/Views/GameLobby/GameLobbyView.swift
+++ b/iOSClient/BABOnline/Views/GameLobby/GameLobbyView.swift
@@ -88,6 +88,26 @@ struct GameLobbyView: View {
                 UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             }
         }
+        .onAppear {
+            startVoice()
+        }
+        .onDisappear {
+            // Only shut down voice if we're not transitioning to game
+            // (game screen takes over voice lifecycle)
+            if appState.screen != .game {
+                VoiceChatManager.shared.shutdown()
+            }
+        }
+    }
+
+    private func startVoice() {
+        Task {
+            do {
+                try await VoiceChatManager.shared.initialize()
+            } catch {
+                print("[Lobby] Voice init failed: \(error.localizedDescription)")
+            }
+        }
     }
 
     private func addRandomBot() {

--- a/iOSClient/BABOnline/Views/GameLobby/GameLobbyView.swift
+++ b/iOSClient/BABOnline/Views/GameLobby/GameLobbyView.swift
@@ -6,6 +6,8 @@ struct GameLobbyView: View {
     @EnvironmentObject var lobbyState: LobbyState
 
     @State private var isReady = false
+    @State private var showVoicePanel = false
+    @ObservedObject private var voiceManager = VoiceChatManager.shared
 
     var body: some View {
         ZStack {
@@ -30,8 +32,17 @@ struct GameLobbyView: View {
 
                     Spacer()
 
-                    Text("\(lobbyState.playerCount)/4")
-                        .foregroundColor(Color.Theme.textSecondary)
+                    HStack(spacing: 12) {
+                        if voiceManager.isActive {
+                            VoiceMuteButton(onLongPress: {
+                                showVoicePanel = true
+                            })
+                            .scaleEffect(0.8)
+                        }
+
+                        Text("\(lobbyState.playerCount)/4")
+                            .foregroundColor(Color.Theme.textSecondary)
+                    }
                 }
                 .padding()
 
@@ -90,6 +101,10 @@ struct GameLobbyView: View {
         }
         .onAppear {
             startVoice()
+        }
+        .sheet(isPresented: $showVoicePanel) {
+            VoicePanelSheet()
+                .presentationDetents([.medium])
         }
         .onDisappear {
             // Only shut down voice if we're not transitioning to game

--- a/iOSClient/BABOnline/Voice/VoiceChatManager.swift
+++ b/iOSClient/BABOnline/Voice/VoiceChatManager.swift
@@ -1,0 +1,561 @@
+import Foundation
+import AVFoundation
+import Combine
+import WebRTC
+
+/// Manages WebRTC peer-to-peer voice chat.
+/// Full-mesh topology: one RTCPeerConnection per human peer.
+/// Server only relays signaling messages (SDP offers/answers, ICE candidates).
+final class VoiceChatManager: ObservableObject {
+    static let shared = VoiceChatManager()
+
+    // MARK: - Published State
+
+    @Published var isActive = false
+    @Published var isSelfMuted = false
+    @Published var micPermissionDenied = false
+    @Published var isSelfSpeaking = false
+    @Published var speakingPeers = Set<String>()  // socket IDs currently speaking
+    @Published var peerInfos: [String: PeerInfo] = [:]  // socketId → info
+
+    /// Combine subject for SpriteKit to subscribe to speaking changes.
+    /// Emits (socketId, isSpeaking) — socketId is "self" for local user.
+    let speakingChangedSubject = PassthroughSubject<(String, Bool), Never>()
+
+    // MARK: - Peer Info
+
+    struct PeerInfo {
+        let username: String
+        var isMuted: Bool = false
+    }
+
+    // MARK: - Private State
+
+    private static let iceConfig: RTCConfiguration = {
+        let config = RTCConfiguration()
+        config.iceServers = [
+            RTCIceServer(urlStrings: ["stun:stun.l.google.com:19302"]),
+            RTCIceServer(urlStrings: ["stun:stun1.l.google.com:19302"])
+        ]
+        config.sdpSemantics = .unifiedPlan
+        return config
+    }()
+
+    private static let speakingThreshold: Float = 0.005
+    private static let speakingPollInterval: TimeInterval = 0.1
+    private static let speakingHoldMs: TimeInterval = 0.4
+
+    private let factory: RTCPeerConnectionFactory = {
+        RTCInitializeSSL()
+        let encoderFactory = RTCDefaultVideoEncoderFactory()
+        let decoderFactory = RTCDefaultVideoDecoderFactory()
+        return RTCPeerConnectionFactory(encoderFactory: encoderFactory, decoderFactory: decoderFactory)
+    }()
+
+    private var localAudioTrack: RTCAudioTrack?
+    private var peers: [String: PeerState] = [:]  // socketId → connection state
+    private var localUsername: String?
+
+    // Speaking detection
+    private var speakingTimer: Timer?
+    private var speakingLastActive: [String: Date] = [:]  // socketId|"self" → last above-threshold time
+    private var speakingStates: [String: Bool] = [:]
+
+    // Buffered events (arrive before init completes)
+    private var pendingPeers: [(socketId: String, username: String)] = []
+    private var pendingOffers: [(fromSocketId: String, offer: RTCSessionDescription, username: String)] = []
+
+    // Background handling
+    private var wasMutedBeforeBackground = false
+
+    private struct PeerState {
+        let connection: RTCPeerConnection
+        let username: String
+        var remoteTrack: RTCAudioTrack?
+    }
+
+    // Constraints
+    private let mediaConstraints = RTCMediaConstraints(
+        mandatoryConstraints: nil,
+        optionalConstraints: ["DtlsSrtpKeyAgreement": "true"]
+    )
+
+    private let offerAnswerConstraints = RTCMediaConstraints(
+        mandatoryConstraints: [
+            "OfferToReceiveAudio": "true",
+            "OfferToReceiveVideo": "false"
+        ],
+        optionalConstraints: nil
+    )
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    /// Initialize voice chat: request mic, configure audio session, start capture.
+    func initialize() async throws {
+        guard !isActive else { return }
+
+        // Request mic permission
+        let granted = await AVAudioSession.sharedInstance().requestRecordPermission()
+        guard granted else {
+            await MainActor.run { micPermissionDenied = true }
+            throw VoiceError.micPermissionDenied
+        }
+
+        // Configure audio session
+        try configureAudioSession()
+
+        // Create local audio track
+        let audioSource = factory.audioSource(with: mediaConstraints)
+        let audioTrack = factory.audioTrack(with: audioSource, trackId: "audio0")
+        audioTrack.isEnabled = true
+        localAudioTrack = audioTrack
+
+        localUsername = await MainActor.run { SocketService.shared.authState?.username }
+
+        await MainActor.run {
+            isActive = true
+            isSelfMuted = false
+            micPermissionDenied = false
+        }
+
+        // Start speaking detection
+        startSpeakingDetection()
+
+        // Flush buffered events
+        await flushPendingEvents()
+
+        print("[Voice] Initialized, username: \(localUsername ?? "nil")")
+    }
+
+    /// Shut down all voice connections and clean up.
+    func shutdown() {
+        guard isActive else { return }
+        isActive = false
+
+        // Stop speaking detection
+        speakingTimer?.invalidate()
+        speakingTimer = nil
+
+        // Close all peer connections
+        for (socketId, peer) in peers {
+            peer.connection.close()
+            print("[Voice] Closed peer: \(socketId)")
+        }
+        peers.removeAll()
+
+        // Stop local audio
+        localAudioTrack?.isEnabled = false
+        localAudioTrack = nil
+
+        // Deactivate audio session to remove mic indicator
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+
+        // Clear state
+        speakingLastActive.removeAll()
+        speakingStates.removeAll()
+        pendingPeers.removeAll()
+        pendingOffers.removeAll()
+        localUsername = nil
+        wasMutedBeforeBackground = false
+
+        DispatchQueue.main.async { [weak self] in
+            self?.isSelfMuted = false
+            self?.isSelfSpeaking = false
+            self?.speakingPeers.removeAll()
+            self?.peerInfos.removeAll()
+        }
+
+        print("[Voice] Shutdown complete")
+    }
+
+    // MARK: - Peer Connection Management
+
+    /// Create a peer connection and send an offer (initiator side).
+    /// Called when we receive voicePeerList — we initiate to existing peers.
+    func connectToPeer(_ socketId: String, username: String) {
+        guard isActive, localAudioTrack != nil else {
+            print("[Voice] Buffering connectToPeer \(socketId) \(username)")
+            pendingPeers.append((socketId: socketId, username: username))
+            return
+        }
+
+        if peers[socketId] != nil {
+            print("[Voice] Already connected to \(socketId)")
+            return
+        }
+
+        print("[Voice] connectToPeer \(socketId) \(username)")
+
+        let pc = createPeerConnection(socketId: socketId, username: username)
+
+        // Add local audio track
+        if let track = localAudioTrack {
+            pc.add(track, streamIds: ["stream0"])
+        }
+
+        // Create and send offer
+        pc.offer(for: offerAnswerConstraints) { [weak self] sdp, error in
+            guard let self, let sdp = sdp else {
+                print("[Voice] Failed to create offer: \(error?.localizedDescription ?? "unknown")")
+                return
+            }
+
+            pc.setLocalDescription(sdp) { error in
+                if let error {
+                    print("[Voice] Failed to set local description: \(error.localizedDescription)")
+                    return
+                }
+
+                VoiceEmitter.sendOffer(
+                    targetSocketId: socketId,
+                    offer: sdp,
+                    username: self.localUsername
+                )
+            }
+        }
+    }
+
+    /// Handle an incoming offer from a peer (responder side).
+    func handleOffer(fromSocketId: String, offer: RTCSessionDescription, username: String) {
+        guard isActive, localAudioTrack != nil else {
+            print("[Voice] Buffering handleOffer \(fromSocketId) \(username)")
+            pendingOffers.append((fromSocketId: fromSocketId, offer: offer, username: username))
+            return
+        }
+
+        print("[Voice] handleOffer from \(fromSocketId) \(username)")
+
+        // If we already have a connection, close it and recreate
+        if peers[fromSocketId] != nil {
+            closePeer(fromSocketId)
+        }
+
+        let pc = createPeerConnection(socketId: fromSocketId, username: username)
+
+        // Add local audio track
+        if let track = localAudioTrack {
+            pc.add(track, streamIds: ["stream0"])
+        }
+
+        pc.setRemoteDescription(offer) { [weak self] error in
+            guard let self else { return }
+            if let error {
+                print("[Voice] Failed to set remote description: \(error.localizedDescription)")
+                return
+            }
+
+            pc.answer(for: self.offerAnswerConstraints) { sdp, error in
+                guard let sdp = sdp else {
+                    print("[Voice] Failed to create answer: \(error?.localizedDescription ?? "unknown")")
+                    return
+                }
+
+                pc.setLocalDescription(sdp) { error in
+                    if let error {
+                        print("[Voice] Failed to set local answer: \(error.localizedDescription)")
+                        return
+                    }
+
+                    VoiceEmitter.sendAnswer(targetSocketId: fromSocketId, answer: sdp)
+                }
+            }
+        }
+    }
+
+    /// Handle an incoming answer from a peer.
+    func handleAnswer(fromSocketId: String, answer: RTCSessionDescription) {
+        guard let peer = peers[fromSocketId] else {
+            print("[Voice] handleAnswer: no peer for \(fromSocketId)")
+            return
+        }
+
+        print("[Voice] handleAnswer from \(fromSocketId)")
+        peer.connection.setRemoteDescription(answer) { error in
+            if let error {
+                print("[Voice] Failed to set remote answer: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Handle an incoming ICE candidate.
+    func handleIceCandidate(fromSocketId: String, candidate: RTCIceCandidate) {
+        guard let peer = peers[fromSocketId] else { return }
+
+        peer.connection.add(candidate) { error in
+            if let error {
+                print("[Voice] Failed to add ICE candidate: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Remove a peer connection (peer left).
+    func removePeer(_ socketId: String) {
+        closePeer(socketId)
+    }
+
+    // MARK: - Mute Controls
+
+    /// Toggle self-mute (disable/enable local audio track).
+    func toggleSelfMute() {
+        isSelfMuted.toggle()
+        localAudioTrack?.isEnabled = !isSelfMuted
+    }
+
+    /// Mute a specific peer's remote audio.
+    func mutePeer(_ socketId: String) {
+        peerInfos[socketId]?.isMuted = true
+        peers[socketId]?.remoteTrack?.isEnabled = false
+    }
+
+    /// Unmute a specific peer's remote audio.
+    func unmutePeer(_ socketId: String) {
+        peerInfos[socketId]?.isMuted = false
+        peers[socketId]?.remoteTrack?.isEnabled = true
+    }
+
+    /// Toggle a peer's mute state.
+    func togglePeerMute(_ socketId: String) {
+        if peerInfos[socketId]?.isMuted == true {
+            unmutePeer(socketId)
+        } else {
+            mutePeer(socketId)
+        }
+    }
+
+    // MARK: - Background Handling
+
+    /// Call when app enters background — mute mic for privacy.
+    func handleBackground() {
+        guard isActive else { return }
+        wasMutedBeforeBackground = isSelfMuted
+        if !isSelfMuted {
+            localAudioTrack?.isEnabled = false
+        }
+    }
+
+    /// Call when app returns to foreground — restore mic state.
+    func handleForeground() {
+        guard isActive else { return }
+        if !wasMutedBeforeBackground {
+            localAudioTrack?.isEnabled = true
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private func configureAudioSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .allowBluetoothHFP])
+        try session.setActive(true)
+    }
+
+    private func createPeerConnection(socketId: String, username: String) -> RTCPeerConnection {
+        let pc = factory.peerConnection(with: Self.iceConfig, constraints: mediaConstraints, delegate: nil)!
+
+        let delegate = PeerConnectionDelegate(manager: self, socketId: socketId)
+        pc.delegate = delegate
+        // Store delegate to keep it alive (stored on the peer state, referenced via associated object)
+        objc_setAssociatedObject(pc, "delegate", delegate, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
+        peers[socketId] = PeerState(connection: pc, username: username)
+        DispatchQueue.main.async { [weak self] in
+            self?.peerInfos[socketId] = PeerInfo(username: username)
+        }
+
+        return pc
+    }
+
+    private func closePeer(_ socketId: String) {
+        guard let peer = peers.removeValue(forKey: socketId) else { return }
+        peer.connection.close()
+        speakingLastActive.removeValue(forKey: socketId)
+        speakingStates.removeValue(forKey: socketId)
+
+        DispatchQueue.main.async { [weak self] in
+            self?.peerInfos.removeValue(forKey: socketId)
+            self?.speakingPeers.remove(socketId)
+            self?.speakingChangedSubject.send((socketId, false))
+        }
+
+        print("[Voice] Closed peer: \(socketId)")
+    }
+
+    private func flushPendingEvents() async {
+        let offerPeerIds = Set(pendingOffers.map { $0.fromSocketId })
+        let bufferedPeers = pendingPeers
+        let bufferedOffers = pendingOffers
+        pendingPeers.removeAll()
+        pendingOffers.removeAll()
+
+        print("[Voice] Flushing \(bufferedOffers.count) offers, \(bufferedPeers.count) peers")
+
+        for offer in bufferedOffers {
+            handleOffer(fromSocketId: offer.fromSocketId, offer: offer.offer, username: offer.username)
+        }
+        for peer in bufferedPeers {
+            if !offerPeerIds.contains(peer.socketId) {
+                connectToPeer(peer.socketId, username: peer.username)
+            }
+        }
+    }
+
+    // MARK: - Speaking Detection
+
+    private func startSpeakingDetection() {
+        speakingTimer?.invalidate()
+        speakingTimer = Timer.scheduledTimer(withTimeInterval: Self.speakingPollInterval, repeats: true) { [weak self] _ in
+            self?.pollSpeakingLevels()
+        }
+    }
+
+    private func pollSpeakingLevels() {
+        // Poll audio levels for all peers using WebRTC stats
+        for (socketId, peer) in peers {
+            peer.connection.statistics { [weak self] report in
+                guard let self else { return }
+                var maxLevel: Float = 0
+
+                for (_, stats) in report.statistics {
+                    // Look for inbound RTP audio stats with audioLevel
+                    if stats.type == "inbound-rtp",
+                       let kind = stats.values["kind"] as? String, kind == "audio",
+                       let level = stats.values["audioLevel"] as? Double {
+                        maxLevel = max(maxLevel, Float(level))
+                    }
+                }
+
+                self.updateSpeakingState(id: socketId, level: maxLevel)
+            }
+        }
+
+        // For local mic, check if track is enabled and use outbound stats
+        if let track = localAudioTrack, track.isEnabled {
+            // Use a simple approach: check all peer connections for outbound audio stats
+            if let firstPeer = peers.values.first {
+                firstPeer.connection.statistics { [weak self] report in
+                    guard let self else { return }
+                    var maxLevel: Float = 0
+
+                    for (_, stats) in report.statistics {
+                        if stats.type == "outbound-rtp",
+                           let kind = stats.values["kind"] as? String, kind == "audio",
+                           let level = stats.values["audioLevel"] as? Double {
+                            maxLevel = max(maxLevel, Float(level))
+                        }
+                        // Also check media-source stats
+                        if stats.type == "media-source",
+                           let kind = stats.values["kind"] as? String, kind == "audio",
+                           let level = stats.values["audioLevel"] as? Double {
+                            maxLevel = max(maxLevel, Float(level))
+                        }
+                    }
+
+                    self.updateSpeakingState(id: "self", level: maxLevel)
+                }
+            }
+        } else {
+            // Muted — not speaking
+            updateSpeakingState(id: "self", level: 0)
+        }
+    }
+
+    private func updateSpeakingState(id: String, level: Float) {
+        let now = Date()
+        if level > Self.speakingThreshold {
+            speakingLastActive[id] = now
+        }
+
+        let wasSpeaking = speakingStates[id] ?? false
+        let lastActive = speakingLastActive[id] ?? .distantPast
+        let isSpeaking = now.timeIntervalSince(lastActive) < Self.speakingHoldMs
+
+        if isSpeaking != wasSpeaking {
+            speakingStates[id] = isSpeaking
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                if id == "self" {
+                    self.isSelfSpeaking = isSpeaking
+                } else {
+                    if isSpeaking {
+                        self.speakingPeers.insert(id)
+                    } else {
+                        self.speakingPeers.remove(id)
+                    }
+                }
+                self.speakingChangedSubject.send((id, isSpeaking))
+            }
+        }
+    }
+
+    // MARK: - Internal (for PeerConnectionDelegate)
+
+    func setRemoteTrack(_ track: RTCAudioTrack, for socketId: String) {
+        peers[socketId]?.remoteTrack = track
+    }
+
+    // MARK: - Errors
+
+    enum VoiceError: Error {
+        case micPermissionDenied
+    }
+}
+
+// MARK: - RTCPeerConnectionDelegate
+
+private class PeerConnectionDelegate: NSObject, RTCPeerConnectionDelegate {
+    weak var manager: VoiceChatManager?
+    let socketId: String
+
+    init(manager: VoiceChatManager, socketId: String) {
+        self.manager = manager
+        self.socketId = socketId
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange stateChanged: RTCSignalingState) {
+        print("[Voice] Peer \(socketId) signaling: \(stateChanged.rawValue)")
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {
+        print("[Voice] Peer \(socketId) added stream with \(stream.audioTracks.count) audio tracks")
+        if let audioTrack = stream.audioTracks.first {
+            audioTrack.isEnabled = true
+            DispatchQueue.main.async { [weak self] in
+                guard let self, let manager = self.manager else { return }
+                manager.setRemoteTrack(audioTrack, for: self.socketId)
+            }
+        }
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove stream: RTCMediaStream) {}
+
+    func peerConnectionShouldNegotiate(_ peerConnection: RTCPeerConnection) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceConnectionState) {
+        print("[Voice] Peer \(socketId) ICE: \(newState.rawValue)")
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceGatheringState) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didGenerate candidate: RTCIceCandidate) {
+        VoiceEmitter.sendIceCandidate(targetSocketId: socketId, candidate: candidate)
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove candidates: [RTCIceCandidate]) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didOpen dataChannel: RTCDataChannel) {}
+}
+
+// MARK: - AVAudioSession extension for async permission
+
+extension AVAudioSession {
+    func requestRecordPermission() async -> Bool {
+        await withCheckedContinuation { continuation in
+            AVAudioApplication.requestRecordPermission { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds peer-to-peer WebRTC voice chat to the iOS client, mirroring the existing web client implementation
- No server changes needed — uses existing signaling relay for SDP offers/answers and ICE candidates
- Includes mute button, voice panel with peer controls, and speaking glow indicators on opponent avatars

## New Files
- **VoiceChatManager.swift** — Core WebRTC manager (singleton ObservableObject) handling peer connections, speaking detection, self-mute, and background/foreground audio session management
- **VoiceEmitter.swift** — Socket emitter for SDP offers/answers and ICE candidates
- **VoiceSocketHandler.swift** — Handles 6 server voice events (peerList, peerJoined, peerLeft, offer, answer, iceCandidate)
- **VoiceMuteButton.swift** — Floating mic toggle button with speaking indicator
- **VoicePanelSheet.swift** — Bottom sheet showing all peers with mute controls

## Modified Files
- **SocketEvents.swift** — Added voice chat event constants
- **Info.plist** — Microphone usage description
- **SocketEventRouter.swift** — Registered VoiceSocketHandler
- **GameLobbyView.swift** — Initialize voice on lobby join
- **GameContainerView.swift** — Mute button overlay + voice panel sheet
- **BABOnlineApp.swift** — Auto-mute on background, restore on foreground
- **OpponentHandNode.swift** — Green pulsing speaking glow on avatars
- **SKOpponentManager.swift** — setSpeaking() delegation
- **GameSKScene.swift** — Subscribe to speaking changes, map socketId → position

## Technical Details
- Uses stasel/WebRTC SPM package (v140) with STUN servers for NAT traversal
- Full-mesh topology (one RTCPeerConnection per human peer)
- Speaking detection via WebRTC stats API polling (100ms interval, 400ms hold time)
- AVAudioSession configured for .playAndRecord + .voiceChat mode

## Test plan
- [ ] Build and run on physical iOS device (WebRTC requires real hardware)
- [ ] Join lobby with web client — verify bidirectional audio
- [ ] Test mute button toggles local audio
- [ ] Test speaking indicators on opponent avatars
- [ ] Test voice panel sheet shows peers with controls
- [ ] Test backgrounding app mutes mic, foregrounding restores
- [ ] Test game end / leave lobby shuts down voice cleanly
- [ ] Test with mic permission denied — game works normally without voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)