### PR TITLE
Add online players tooltip and player search

### DIFF
--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -48,6 +48,8 @@ export const CLIENT_EVENTS = {
   // Profile
   GET_PROFILE: 'getProfile',
   UPDATE_PROFILE_PIC: 'updateProfilePic',
+  SEARCH_PLAYERS: 'searchPlayers',
+  GET_PLAYER_PROFILE: 'getPlayerProfile',
 
   // Leaderboard
   GET_LEADERBOARD: 'getLeaderboard',
@@ -134,6 +136,10 @@ export const SERVER_EVENTS = {
   // Profile
   PROFILE_RESPONSE: 'profileResponse',
   PROFILE_PIC_UPDATE_RESPONSE: 'profilePicUpdateResponse',
+
+  // Player Search & Profile Lookup
+  SEARCH_PLAYERS_RESPONSE: 'searchPlayersResponse',
+  PLAYER_PROFILE_RESPONSE: 'playerProfileResponse',
 
   // Leaderboard
   LEADERBOARD_RESPONSE: 'leaderboardResponse',

--- a/client/src/handlers/index.js
+++ b/client/src/handlers/index.js
@@ -84,6 +84,8 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onProfilePicUpdateError,
     onCustomProfilePicUploaded,
     onCustomProfilePicUploadError,
+    onSearchPlayersResult,
+    onPlayerProfileReceived,
     // Leaderboard callbacks
     onLeaderboardReceived,
     onLeaderboardError,
@@ -177,6 +179,8 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onProfilePicUpdateError,
     onCustomProfilePicUploaded,
     onCustomProfilePicUploadError,
+    onSearchPlayersResult,
+    onPlayerProfileReceived,
   });
 
   // Register leaderboard handlers

--- a/client/src/handlers/profileHandlers.js
+++ b/client/src/handlers/profileHandlers.js
@@ -15,6 +15,8 @@
  * @param {Function} callbacks.onProfilePicUpdateError - Called on profile pic update error
  * @param {Function} callbacks.onCustomProfilePicUploaded - Called when custom pic is uploaded
  * @param {Function} callbacks.onCustomProfilePicUploadError - Called on custom pic upload error
+ * @param {Function} callbacks.onSearchPlayersResult - Called with search results
+ * @param {Function} callbacks.onPlayerProfileReceived - Called with another player's profile
  */
 export function registerProfileHandlers(socketManager, callbacks = {}) {
   const {
@@ -24,6 +26,8 @@ export function registerProfileHandlers(socketManager, callbacks = {}) {
     onProfilePicUpdateError,
     onCustomProfilePicUploaded,
     onCustomProfilePicUploadError,
+    onSearchPlayersResult,
+    onPlayerProfileReceived,
   } = callbacks;
 
   // Profile response
@@ -56,6 +60,26 @@ export function registerProfileHandlers(socketManager, callbacks = {}) {
     } else {
       console.warn('Custom profile pic upload failed:', data.message);
       onCustomProfilePicUploadError?.(data.message || 'Failed to upload profile picture');
+    }
+  });
+
+  // Player search response
+  socketManager.on('searchPlayersResponse', (data) => {
+    console.log('searchPlayersResponse received:', data);
+    if (data.success) {
+      onSearchPlayersResult?.(data.players);
+    } else {
+      console.warn('Player search failed:', data.message);
+      onSearchPlayersResult?.([]);
+    }
+  });
+
+  // Player profile response (viewing another player)
+  socketManager.on('playerProfileResponse', (data) => {
+    if (data.success) {
+      onPlayerProfileReceived?.(data.profile);
+    } else {
+      console.warn('Player profile fetch failed:', data.message);
     }
   });
 }

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -30,8 +30,9 @@ import { createSignInScreen, showSignInScreen } from './ui/screens/SignIn.js';
 import { createRegisterScreen, showRegisterScreen } from './ui/screens/Register.js';
 import { showMainRoom, addMainRoomChatMessage, updateLobbyList, removeMainRoom, updateMainRoomOnlineCount, getMainRoomUserColors } from './ui/screens/MainRoom.js';
 import { showGameLobby, updateLobbyPlayersList, addLobbyChatMessage, removeGameLobby, getCurrentLobbyId, getIsPlayerReady, getLobbyUserColors } from './ui/screens/GameLobby.js';
-import { showProfilePage, updateProfilePicDisplay, updateCustomProfilePicDisplay, removeProfilePage, isProfilePageVisible } from './ui/screens/ProfilePage.js';
+import { showProfilePage, updateProfilePicDisplay, updateCustomProfilePicDisplay, removeProfilePage, isProfilePageVisible, showPlayerProfilePage } from './ui/screens/ProfilePage.js';
 import { showLeaderboardPage, removeLeaderboardPage, isLeaderboardPageVisible } from './ui/screens/LeaderboardPage.js';
+import { updatePlayerSearchResults } from './ui/screens/PlayerSearchPage.js';
 import { showTournamentLobby, removeTournamentLobby, addTournamentChatMessage, updateTournamentPlayers, updateTournamentScoreboardUI, updateTournamentRoundIndicator, updateTournamentActiveGames, setTournamentPhase } from './ui/screens/TournamentLobby.js';
 import { showTournamentResultsOverlay, removeTournamentResultsOverlay } from './ui/components/TournamentScoreboard.js';
 import { UIManager, SCREENS, getUIManager, initializeUIManager, resetUIManager } from './ui/UIManager.js';
@@ -2071,7 +2072,7 @@ function initializeApp() {
       updateLobbyList(data.lobbies, socket, data.inProgressGames, data.tournaments);
     },
     onMainRoomPlayerJoined: (data) => {
-      updateMainRoomOnlineCount(data.onlineCount);
+      updateMainRoomOnlineCount(data.onlineCount, data.onlineUsers);
     },
 
     // Lobby callbacks
@@ -3088,6 +3089,12 @@ function initializeApp() {
     },
     onCustomProfilePicUploadError: (message) => {
       showError(message || 'Failed to upload profile picture');
+    },
+    onSearchPlayersResult: (players) => {
+      updatePlayerSearchResults(players);
+    },
+    onPlayerProfileReceived: (profile) => {
+      showPlayerProfilePage(profile);
     },
     // Leaderboard callbacks
     onLeaderboardReceived: (leaderboard) => {

--- a/client/src/ui/screens/MainRoom.js
+++ b/client/src/ui/screens/MainRoom.js
@@ -5,11 +5,13 @@
  */
 
 import { generateDistinctColor, getUsernameColor } from '../../utils/colors.js';
+import { showPlayerSearchPage } from './PlayerSearchPage.js';
 
 /**
  * Module state - tracks user colors for consistent display.
  */
 let mainRoomUserColors = {};
+let currentOnlineUsers = [];
 
 /**
  * Create a chat message element.
@@ -403,6 +405,28 @@ export function showMainRoom(data, socket) {
   });
   rightContainer.appendChild(leaderboardBtn);
 
+  // Players search button
+  const playersBtn = document.createElement('button');
+  playersBtn.innerText = 'Players';
+  playersBtn.style.padding = '8px 16px';
+  playersBtn.style.borderRadius = '6px';
+  playersBtn.style.border = 'none';
+  playersBtn.style.background = '#6366f1';
+  playersBtn.style.color = '#fff';
+  playersBtn.style.fontSize = '14px';
+  playersBtn.style.fontWeight = 'bold';
+  playersBtn.style.cursor = 'pointer';
+  playersBtn.addEventListener('click', () => {
+    showPlayerSearchPage(socket);
+  });
+  playersBtn.addEventListener('mouseenter', () => {
+    playersBtn.style.background = '#4f46e5';
+  });
+  playersBtn.addEventListener('mouseleave', () => {
+    playersBtn.style.background = '#6366f1';
+  });
+  rightContainer.appendChild(playersBtn);
+
   // Profile button
   const profileBtn = document.createElement('button');
   profileBtn.innerText = 'Profile';
@@ -425,11 +449,55 @@ export function showMainRoom(data, socket) {
   });
   rightContainer.appendChild(profileBtn);
 
+  // Store online users from initial data
+  currentOnlineUsers = data.onlineUsers || [];
+
   const onlineCount = document.createElement('div');
   onlineCount.id = 'mainRoomOnlineCount';
   onlineCount.innerText = `${data.onlineCount || 0} players online`;
   onlineCount.style.fontSize = '14px';
   onlineCount.style.color = '#9ca3af';
+  onlineCount.style.cursor = 'default';
+  onlineCount.style.position = 'relative';
+  onlineCount.addEventListener('mouseenter', () => {
+    // Remove any existing tooltip
+    const existing = document.getElementById('onlinePlayersTooltip');
+    if (existing) existing.remove();
+
+    if (currentOnlineUsers.length === 0) return;
+
+    const tooltip = document.createElement('div');
+    tooltip.id = 'onlinePlayersTooltip';
+    tooltip.style.position = 'absolute';
+    tooltip.style.top = '100%';
+    tooltip.style.right = '0';
+    tooltip.style.marginTop = '6px';
+    tooltip.style.background = 'rgba(26, 26, 46, 0.98)';
+    tooltip.style.border = '1px solid #4a5568';
+    tooltip.style.borderRadius = '8px';
+    tooltip.style.padding = '10px 14px';
+    tooltip.style.zIndex = '3000';
+    tooltip.style.minWidth = '140px';
+    tooltip.style.maxHeight = '200px';
+    tooltip.style.overflowY = 'auto';
+    tooltip.style.boxShadow = '0 4px 12px rgba(0,0,0,0.4)';
+
+    currentOnlineUsers.forEach((username) => {
+      const row = document.createElement('div');
+      row.innerText = username;
+      row.style.color = '#e5e7eb';
+      row.style.fontSize = '13px';
+      row.style.padding = '3px 0';
+      row.style.whiteSpace = 'nowrap';
+      tooltip.appendChild(row);
+    });
+
+    onlineCount.appendChild(tooltip);
+  });
+  onlineCount.addEventListener('mouseleave', () => {
+    const tooltip = document.getElementById('onlinePlayersTooltip');
+    if (tooltip) tooltip.remove();
+  });
   rightContainer.appendChild(onlineCount);
 
   headerRow.appendChild(rightContainer);
@@ -666,14 +734,19 @@ export function removeMainRoom() {
   const mainRoom = document.getElementById('mainRoomContainer');
   if (mainRoom) mainRoom.remove();
   mainRoomUserColors = {};
+  currentOnlineUsers = [];
 }
 
 /**
  * Update the online player count display.
  *
  * @param {number} count - Number of online players
+ * @param {Array} onlineUsers - Array of online usernames
  */
-export function updateMainRoomOnlineCount(count) {
+export function updateMainRoomOnlineCount(count, onlineUsers) {
+  if (onlineUsers) {
+    currentOnlineUsers = onlineUsers;
+  }
   const countEl = document.getElementById('mainRoomOnlineCount');
   if (countEl) {
     countEl.innerText = `${count} players online`;

--- a/client/src/ui/screens/PlayerSearchPage.js
+++ b/client/src/ui/screens/PlayerSearchPage.js
@@ -1,0 +1,277 @@
+/**
+ * Player Search Page Screen
+ *
+ * Modal overlay with search input and results list for finding players.
+ */
+
+let debounceTimer = null;
+let currentSocket = null;
+
+/**
+ * Get the appropriate profile picture source.
+ *
+ * @param {Object} player - Player data with profilePic/customProfilePic
+ * @returns {string} Image source
+ */
+function getProfilePicSrc(player) {
+  if (player.customProfilePic) {
+    return player.customProfilePic;
+  }
+  if (player.profilePic) {
+    return `assets/profile${player.profilePic}.png`;
+  }
+  return 'assets/profile1.png';
+}
+
+/**
+ * Show the player search modal.
+ *
+ * @param {Object} socket - Socket instance
+ */
+export function showPlayerSearchPage(socket) {
+  removePlayerSearchPage();
+  currentSocket = socket;
+
+  const overlay = document.createElement('div');
+  overlay.id = 'playerSearchPageOverlay';
+  overlay.style.position = 'fixed';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.right = '0';
+  overlay.style.bottom = '0';
+  overlay.style.background = 'rgba(0, 0, 0, 0.7)';
+  overlay.style.zIndex = '2000';
+  overlay.style.display = 'flex';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+
+  const modal = document.createElement('div');
+  modal.style.background = 'rgba(26, 26, 46, 0.98)';
+  modal.style.color = '#fff';
+  modal.style.padding = '30px';
+  modal.style.borderRadius = '12px';
+  modal.style.border = '2px solid #4a5568';
+  modal.style.width = '450px';
+  modal.style.maxWidth = '95vw';
+  modal.style.maxHeight = '80vh';
+  modal.style.display = 'flex';
+  modal.style.flexDirection = 'column';
+  modal.style.boxSizing = 'border-box';
+  modal.style.fontFamily = 'Arial, sans-serif';
+
+  // Header
+  const headerRow = document.createElement('div');
+  headerRow.style.display = 'flex';
+  headerRow.style.justifyContent = 'space-between';
+  headerRow.style.alignItems = 'center';
+  headerRow.style.marginBottom = '20px';
+
+  const title = document.createElement('div');
+  title.innerText = 'Search Players';
+  title.style.fontSize = '24px';
+  title.style.fontWeight = 'bold';
+  title.style.color = '#4ade80';
+  headerRow.appendChild(title);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.innerText = 'X';
+  closeBtn.style.background = '#ef4444';
+  closeBtn.style.border = 'none';
+  closeBtn.style.borderRadius = '50%';
+  closeBtn.style.width = '36px';
+  closeBtn.style.height = '36px';
+  closeBtn.style.color = '#fff';
+  closeBtn.style.fontSize = '18px';
+  closeBtn.style.cursor = 'pointer';
+  closeBtn.style.fontWeight = 'bold';
+  closeBtn.addEventListener('click', removePlayerSearchPage);
+  closeBtn.addEventListener('mouseenter', () => { closeBtn.style.background = '#dc2626'; });
+  closeBtn.addEventListener('mouseleave', () => { closeBtn.style.background = '#ef4444'; });
+  headerRow.appendChild(closeBtn);
+
+  modal.appendChild(headerRow);
+
+  // Search row (input + button)
+  const searchRow = document.createElement('div');
+  searchRow.style.display = 'flex';
+  searchRow.style.gap = '10px';
+  searchRow.style.marginBottom = '15px';
+
+  const searchInput = document.createElement('input');
+  searchInput.id = 'playerSearchInput';
+  searchInput.type = 'text';
+  searchInput.placeholder = 'Type a username...';
+  searchInput.style.flex = '1';
+  searchInput.style.padding = '12px';
+  searchInput.style.borderRadius = '6px';
+  searchInput.style.border = '1px solid #4a5568';
+  searchInput.style.background = '#2d3748';
+  searchInput.style.color = '#fff';
+  searchInput.style.fontSize = '16px';
+  searchInput.style.boxSizing = 'border-box';
+
+  function doSearch() {
+    clearTimeout(debounceTimer);
+    const query = searchInput.value.trim();
+    if (!query) {
+      updatePlayerSearchResults([]);
+      return;
+    }
+    console.log('Emitting searchPlayers with query:', query);
+    socket.emit('searchPlayers', { query });
+  }
+
+  searchInput.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    const query = searchInput.value.trim();
+    if (!query) {
+      updatePlayerSearchResults([]);
+      return;
+    }
+    debounceTimer = setTimeout(doSearch, 300);
+  });
+  searchInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      doSearch();
+    }
+  });
+  searchRow.appendChild(searchInput);
+
+  const searchBtn = document.createElement('button');
+  searchBtn.innerText = 'Search';
+  searchBtn.style.padding = '12px 20px';
+  searchBtn.style.borderRadius = '6px';
+  searchBtn.style.border = 'none';
+  searchBtn.style.background = '#3b82f6';
+  searchBtn.style.color = '#fff';
+  searchBtn.style.fontSize = '16px';
+  searchBtn.style.fontWeight = 'bold';
+  searchBtn.style.cursor = 'pointer';
+  searchBtn.addEventListener('click', doSearch);
+  searchBtn.addEventListener('mouseenter', () => { searchBtn.style.background = '#2563eb'; });
+  searchBtn.addEventListener('mouseleave', () => { searchBtn.style.background = '#3b82f6'; });
+  searchRow.appendChild(searchBtn);
+
+  modal.appendChild(searchRow);
+
+  // Results container
+  const results = document.createElement('div');
+  results.id = 'playerSearchResults';
+  results.style.flex = '1';
+  results.style.overflowY = 'auto';
+  results.style.display = 'flex';
+  results.style.flexDirection = 'column';
+  results.style.gap = '6px';
+
+  const hint = document.createElement('div');
+  hint.style.color = '#9ca3af';
+  hint.style.fontStyle = 'italic';
+  hint.style.textAlign = 'center';
+  hint.style.padding = '20px';
+  hint.innerText = 'Search for a player by username';
+  results.appendChild(hint);
+
+  modal.appendChild(results);
+  overlay.appendChild(modal);
+
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) removePlayerSearchPage();
+  });
+
+  document.body.appendChild(overlay);
+
+  // Auto-focus
+  setTimeout(() => searchInput.focus(), 0);
+}
+
+/**
+ * Update search results list.
+ *
+ * @param {Array} players - Array of player search results
+ */
+export function updatePlayerSearchResults(players) {
+  const container = document.getElementById('playerSearchResults');
+  if (!container) return;
+
+  container.innerHTML = '';
+
+  if (!players || players.length === 0) {
+    const input = document.getElementById('playerSearchInput');
+    const query = input?.value?.trim();
+    const msg = document.createElement('div');
+    msg.style.color = '#9ca3af';
+    msg.style.fontStyle = 'italic';
+    msg.style.textAlign = 'center';
+    msg.style.padding = '20px';
+    msg.innerText = query ? 'No players found' : 'Search for a player by username';
+    container.appendChild(msg);
+    return;
+  }
+
+  players.forEach((player) => {
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.alignItems = 'center';
+    row.style.gap = '12px';
+    row.style.padding = '10px 12px';
+    row.style.background = 'rgba(0, 0, 0, 0.3)';
+    row.style.borderRadius = '6px';
+    row.style.cursor = 'pointer';
+    row.style.transition = 'background 0.15s';
+    row.addEventListener('mouseenter', () => { row.style.background = 'rgba(59, 130, 246, 0.2)'; });
+    row.addEventListener('mouseleave', () => { row.style.background = 'rgba(0, 0, 0, 0.3)'; });
+    row.addEventListener('click', () => {
+      if (currentSocket) {
+        currentSocket.emit('getPlayerProfile', { username: player.username });
+      }
+      removePlayerSearchPage();
+    });
+
+    // Avatar
+    const avatar = document.createElement('img');
+    avatar.src = getProfilePicSrc(player);
+    avatar.style.width = '40px';
+    avatar.style.height = '40px';
+    avatar.style.borderRadius = '50%';
+    avatar.style.objectFit = 'cover';
+    avatar.style.border = '2px solid #4a5568';
+    avatar.style.flexShrink = '0';
+    row.appendChild(avatar);
+
+    // Info
+    const info = document.createElement('div');
+    info.style.flex = '1';
+    info.style.minWidth = '0';
+
+    const name = document.createElement('div');
+    name.innerText = player.username;
+    name.style.fontWeight = 'bold';
+    name.style.color = '#fff';
+    name.style.fontSize = '15px';
+    name.style.overflow = 'hidden';
+    name.style.textOverflow = 'ellipsis';
+    name.style.whiteSpace = 'nowrap';
+    info.appendChild(name);
+
+    const statsLine = document.createElement('div');
+    statsLine.style.fontSize = '12px';
+    statsLine.style.color = '#9ca3af';
+    const gp = player.gamesPlayed || 0;
+    const winRate = gp > 0 ? ((player.wins / gp) * 100).toFixed(0) : '0';
+    statsLine.innerText = `${gp} games | ${winRate}% win rate`;
+    info.appendChild(statsLine);
+
+    row.appendChild(info);
+    container.appendChild(row);
+  });
+}
+
+/**
+ * Remove the player search modal.
+ */
+export function removePlayerSearchPage() {
+  clearTimeout(debounceTimer);
+  const overlay = document.getElementById('playerSearchPageOverlay');
+  if (overlay) overlay.remove();
+  currentSocket = null;
+}

--- a/client/src/ui/screens/ProfilePage.js
+++ b/client/src/ui/screens/ProfilePage.js
@@ -599,3 +599,178 @@ export function removeProfilePage() {
 export function isProfilePageVisible() {
   return document.getElementById('profilePageOverlay') !== null;
 }
+
+/**
+ * Show a read-only profile page for viewing another player.
+ *
+ * @param {Object} profile - Profile data (username, profilePic, stats)
+ */
+export function showPlayerProfilePage(profile) {
+  // Remove any existing player profile page
+  removePlayerProfilePage();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'playerProfilePageOverlay';
+  overlay.style.position = 'fixed';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.right = '0';
+  overlay.style.bottom = '0';
+  overlay.style.background = 'rgba(0, 0, 0, 0.7)';
+  overlay.style.zIndex = '2000';
+  overlay.style.display = 'flex';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+
+  const modal = document.createElement('div');
+  modal.style.background = 'rgba(26, 26, 46, 0.98)';
+  modal.style.color = '#fff';
+  modal.style.padding = '30px';
+  modal.style.borderRadius = '12px';
+  modal.style.border = '2px solid #4a5568';
+  modal.style.width = '500px';
+  modal.style.maxWidth = '95vw';
+  modal.style.maxHeight = '90vh';
+  modal.style.overflow = 'auto';
+  modal.style.boxSizing = 'border-box';
+  modal.style.fontFamily = 'Arial, sans-serif';
+
+  // Header
+  const headerRow = document.createElement('div');
+  headerRow.style.display = 'flex';
+  headerRow.style.justifyContent = 'space-between';
+  headerRow.style.alignItems = 'center';
+  headerRow.style.marginBottom = '25px';
+
+  const title = document.createElement('div');
+  title.innerText = profile.username;
+  title.style.fontSize = '28px';
+  title.style.fontWeight = 'bold';
+  title.style.color = '#4ade80';
+  headerRow.appendChild(title);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.innerText = 'X';
+  closeBtn.style.background = '#ef4444';
+  closeBtn.style.border = 'none';
+  closeBtn.style.borderRadius = '50%';
+  closeBtn.style.width = '36px';
+  closeBtn.style.height = '36px';
+  closeBtn.style.color = '#fff';
+  closeBtn.style.fontSize = '18px';
+  closeBtn.style.cursor = 'pointer';
+  closeBtn.style.fontWeight = 'bold';
+  closeBtn.addEventListener('click', removePlayerProfilePage);
+  closeBtn.addEventListener('mouseenter', () => { closeBtn.style.background = '#dc2626'; });
+  closeBtn.addEventListener('mouseleave', () => { closeBtn.style.background = '#ef4444'; });
+  headerRow.appendChild(closeBtn);
+
+  modal.appendChild(headerRow);
+
+  // Profile picture (read-only — no upload/choose buttons)
+  const picSection = document.createElement('div');
+  picSection.style.display = 'flex';
+  picSection.style.alignItems = 'center';
+  picSection.style.gap = '20px';
+  picSection.style.marginBottom = '30px';
+  picSection.style.padding = '20px';
+  picSection.style.background = 'rgba(0, 0, 0, 0.3)';
+  picSection.style.borderRadius = '8px';
+
+  const picContainer = document.createElement('div');
+  picContainer.style.width = '100px';
+  picContainer.style.height = '100px';
+  picContainer.style.borderRadius = '50%';
+  picContainer.style.border = '3px solid #4ade80';
+  picContainer.style.overflow = 'hidden';
+  picContainer.style.flexShrink = '0';
+
+  const picImg = document.createElement('img');
+  picImg.src = getProfilePicSrc(profile);
+  picImg.style.width = '100%';
+  picImg.style.height = '100%';
+  picImg.style.objectFit = 'cover';
+  picImg.alt = 'Profile Picture';
+  picContainer.appendChild(picImg);
+
+  picSection.appendChild(picContainer);
+
+  const picLabel = document.createElement('div');
+  picLabel.innerText = profile.username;
+  picLabel.style.fontSize = '20px';
+  picLabel.style.fontWeight = 'bold';
+  picLabel.style.color = '#fff';
+  picSection.appendChild(picLabel);
+
+  modal.appendChild(picSection);
+
+  // Stats section
+  const statsHeader = document.createElement('div');
+  statsHeader.innerText = 'Statistics';
+  statsHeader.style.fontSize = '18px';
+  statsHeader.style.fontWeight = 'bold';
+  statsHeader.style.marginBottom = '15px';
+  statsHeader.style.color = '#60a5fa';
+  modal.appendChild(statsHeader);
+
+  const stats = profile.stats;
+  const gamesPlayed = stats.gamesPlayed || 0;
+
+  const statsGrid = document.createElement('div');
+  statsGrid.style.display = 'grid';
+  statsGrid.style.gridTemplateColumns = 'repeat(3, 1fr)';
+  statsGrid.style.gap = '10px';
+
+  statsGrid.appendChild(createStatItem('Games Played', String(gamesPlayed)));
+  statsGrid.appendChild(createStatItem('Wins', String(stats.wins || 0)));
+  statsGrid.appendChild(createStatItem('Losses', String(stats.losses || 0)));
+
+  const winPct = gamesPlayed > 0 ? ((stats.wins / gamesPlayed) * 100).toFixed(1) + '%' : '0%';
+  const pointsPerGame = gamesPlayed > 0 ? (stats.totalPoints / gamesPlayed).toFixed(1) : '0';
+  const bidPerGame = gamesPlayed > 0 ? (stats.totalTricksBid / gamesPlayed).toFixed(1) : '0';
+  const tricksPerGame = gamesPlayed > 0 ? (stats.totalTricksTaken / gamesPlayed).toFixed(1) : '0';
+
+  statsGrid.appendChild(createStatItem('Win Rate', winPct));
+  statsGrid.appendChild(createStatItem('Points/Game', pointsPerGame));
+  statsGrid.appendChild(createStatItem('Bids/Game', bidPerGame));
+
+  statsGrid.appendChild(createStatItem('Tricks/Game', tricksPerGame));
+  const tricksPerBid = stats.totalTricksBid > 0
+    ? (stats.totalTricksTaken / stats.totalTricksBid).toFixed(2)
+    : '0';
+  statsGrid.appendChild(createStatItem('Tricks/Bid', tricksPerBid));
+  const setRate = stats.totalHands > 0
+    ? ((stats.totalSets / stats.totalHands) * 100).toFixed(1) + '%'
+    : '0%';
+  statsGrid.appendChild(createStatItem('Set Rate', setRate));
+
+  const drag = gamesPlayed > 0
+    ? ((stats.totalSetPoints || 0) / gamesPlayed).toFixed(1)
+    : '0';
+  statsGrid.appendChild(createStatItem('Drag', drag));
+  const faultsPerGame = gamesPlayed > 0
+    ? ((stats.totalFaults || 0) / gamesPlayed).toFixed(2)
+    : '0';
+  statsGrid.appendChild(createStatItem('Faults/Game', faultsPerGame));
+  const avgHSI = (stats.totalHands || 0) > 0
+    ? ((stats.totalHSI || 0) / stats.totalHands).toFixed(1)
+    : '0';
+  statsGrid.appendChild(createStatItem('HSI', avgHSI));
+
+  modal.appendChild(statsGrid);
+  overlay.appendChild(modal);
+
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) removePlayerProfilePage();
+  });
+
+  document.body.appendChild(overlay);
+}
+
+/**
+ * Remove the read-only player profile page.
+ */
+export function removePlayerProfilePage() {
+  const overlay = document.getElementById('playerProfilePageOverlay');
+  if (overlay) overlay.remove();
+}

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -116,6 +116,12 @@ function setupSocketHandlers(io) {
         socket.on('getLeaderboard', () =>
             safeHandler(profileHandlers.getLeaderboard)(socket, io, {})
         );
+        socket.on('searchPlayers', (data) =>
+            asyncHandler('searchPlayers', profileHandlers.searchPlayers)(socket, io, data)
+        );
+        socket.on('getPlayerProfile', (data) =>
+            asyncHandler('getPlayerProfile', profileHandlers.getPlayerProfile)(socket, io, data)
+        );
 
         // Tournament events
         socket.on('createTournament', () =>

--- a/server/socket/profileHandlers.js
+++ b/server/socket/profileHandlers.js
@@ -388,11 +388,114 @@ async function getLeaderboard(socket, io) {
     }
 }
 
+/**
+ * Search for players by username
+ * @param {Socket} socket - Socket instance
+ * @param {Server} io - Socket.IO server instance
+ * @param {Object} data - Contains query string
+ */
+async function searchPlayers(socket, io, data) {
+    const usersCollection = getUsersCollection();
+
+    const { query } = data || {};
+    if (!query || typeof query !== 'string' || !query.trim()) {
+        socket.emit('searchPlayersResponse', {
+            success: false,
+            message: 'Search query is required'
+        });
+        return;
+    }
+
+    try {
+        // Escape regex special characters
+        const escaped = query.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const users = await usersCollection.find(
+            { username: { $regex: escaped, $options: 'i' } },
+            { projection: { username: 1, profilePic: 1, customProfilePic: 1, stats: 1 } }
+        ).limit(20).toArray();
+
+        const players = users.map(u => ({
+            username: u.username,
+            profilePic: u.profilePic || 1,
+            customProfilePic: u.customProfilePic || null,
+            gamesPlayed: u.stats?.gamesPlayed || 0,
+            wins: u.stats?.wins || 0
+        }));
+
+        socket.emit('searchPlayersResponse', { success: true, players });
+        authLogger.debug('Player search', { query: query.trim(), resultCount: players.length });
+    } catch (error) {
+        authLogger.error('Error searching players', { query, error: error.message });
+        socket.emit('searchPlayersResponse', { success: false, message: 'Database error' });
+    }
+}
+
+/**
+ * Get another player's profile by username
+ * @param {Socket} socket - Socket instance
+ * @param {Server} io - Socket.IO server instance
+ * @param {Object} data - Contains username string
+ */
+async function getPlayerProfile(socket, io, data) {
+    const usersCollection = getUsersCollection();
+
+    const { username } = data || {};
+    if (!username || typeof username !== 'string' || !username.trim()) {
+        socket.emit('playerProfileResponse', {
+            success: false,
+            message: 'Username is required'
+        });
+        return;
+    }
+
+    try {
+        const dbUser = await usersCollection.findOne({ username: username.trim() });
+
+        if (!dbUser) {
+            socket.emit('playerProfileResponse', {
+                success: false,
+                message: 'Player not found'
+            });
+            return;
+        }
+
+        socket.emit('playerProfileResponse', {
+            success: true,
+            profile: {
+                username: dbUser.username,
+                profilePic: dbUser.profilePic || 1,
+                customProfilePic: dbUser.customProfilePic || null,
+                stats: dbUser.stats || {
+                    wins: 0,
+                    losses: 0,
+                    draws: 0,
+                    gamesPlayed: 0,
+                    totalPoints: 0,
+                    totalTricksBid: 0,
+                    totalTricksTaken: 0,
+                    totalHands: 0,
+                    totalSets: 0,
+                    totalSetPoints: 0,
+                    totalFaults: 0,
+                    totalHSI: 0
+                }
+            }
+        });
+
+        authLogger.debug('Player profile fetched', { username: username.trim() });
+    } catch (error) {
+        authLogger.error('Error fetching player profile', { username, error: error.message });
+        socket.emit('playerProfileResponse', { success: false, message: 'Database error' });
+    }
+}
+
 module.exports = {
     getProfile,
     updateProfilePic,
     uploadProfilePic,
     recordGameStats,
     getUserProfilePic,
-    getLeaderboard
+    getLeaderboard,
+    searchPlayers,
+    getPlayerProfile
 };


### PR DESCRIPTION
## Summary
- Hover "X players online" text to see a tooltip listing all online usernames
- New "Players" button in main room header opens a search modal
- Search players by username with debounced auto-search, Search button, and Enter key support
- Click a search result to view their read-only profile with full stats
- Server handlers: `searchPlayers` (regex, top 20 results) and `getPlayerProfile` (by username)

## Test plan
- [ ] Hover "X players online" → tooltip with online usernames appears
- [ ] Click "Players" → search modal opens with input and Search button
- [ ] Type a username → results appear after 300ms debounce
- [ ] Press Enter or click Search → results appear immediately
- [ ] Click a result → read-only profile modal shows their stats
- [ ] Close buttons and click-outside-to-close work on both modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)