### PR TITLE
Add clickable player profiles in-game

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# BAB Online - Claude Context Document
+
+This document helps Claude understand the project quickly in new sessions.
+
+## What is this?
+
+BAB Online is a 4-player online multiplayer trick-taking card game ("Back Alley Bridge"). Players form 2 teams (positions 1&3 vs 2&4) and compete across 13 hands with varying card counts.
+
+**See `docs/RULES.md` for complete game rules.**
+
+## Tech Stack
+
+- **Frontend**: Phaser 3 (game engine), ES6 modules, Socket.IO client, Vite bundler
+- **Backend**: Node.js 18+, Express.js, Socket.IO server
+- **Database**: MongoDB (native client, no ORM)
+- **Testing**: Jest (server), Vitest (client)
+- **Deployment**: Railway.app via GitHub Actions
+
+## Directory Structure
+
+```
+bab-online/
+├── client/                     # Frontend
+│   ├── src/
+│   │   ├── constants/         # Event names, card ranks, hand progression
+│   │   ├── utils/             # Position math, card helpers
+│   │   ├── rules/             # Card legality (mirrors server)
+│   │   ├── state/             # GameState singleton
+│   │   ├── socket/            # SocketManager (connection + listener cleanup)
+│   │   ├── handlers/          # Socket event handlers by domain
+│   │   ├── phaser/            # Game rendering
+│   │   │   ├── scenes/        # GameScene (main Phaser scene)
+│   │   │   └── managers/      # CardManager, TrickManager, BidManager, etc.
+│   │   └── ui/                # DOM-based UI (screens, components)
+│   └── assets/                # Card images, sprites
+│
+├── server/                     # Backend
+│   ├── game/                  # Core game logic
+│   │   ├── rules.js           # Pure functions: card comparison, legality, scoring
+│   │   ├── Deck.js            # Card deck with Fisher-Yates shuffle
+│   │   ├── GameState.js       # Game state encapsulation
+│   │   ├── GameManager.js     # Singleton: manages games, queue, lobbies
+│   │   └── bot/               # AI player system
+│   ├── socket/                # Socket.IO handlers by domain
+│   │   ├── gameHandlers.js    # Core gameplay (draw, bid, play)
+│   │   ├── lobbyHandlers.js   # Pre-game lobby
+│   │   ├── authHandlers.js    # Sign-in/up
+│   │   └── validators.js      # Joi validation schemas
+│   └── __tests__/             # Jest tests
+│
+└── docs/
+    └── RULES.md               # Complete game rules
+```
+
+## Key Architecture Patterns
+
+**Server:**
+- `GameManager` singleton manages all active games and queue
+- `GameState` encapsulates all state for a single game
+- `rules.js` contains pure, stateless game logic functions (highly testable)
+- Socket handlers wrapped with validation, rate limiting, error handling
+
+**Client:**
+- `GameState` singleton replaces global variables
+- `SocketManager` tracks listeners for cleanup (prevents memory leaks)
+- Manager pattern: specialized managers (CardManager, TrickManager, etc.)
+- Client-side validation mirrors server for immediate UI feedback
+
+## Key Data Structures
+
+**Card:**
+```javascript
+{ suit: 'spades'|'hearts'|'diamonds'|'clubs'|'joker', rank: '2'-'A'|'HI'|'LO' }
+```
+
+**Server GameState:**
+- `players`: Map<socketId → {username, position, pic, isBot}>
+- `hands`: {socketId → card[]}, `bids`: {position → bid_value}
+- `phase`: 'waiting'|'drawing'|'bidding'|'playing'
+- `trump`: card, `isTrumpBroken`: boolean
+- `playedCards`: [pos1Card, pos2Card, pos3Card, pos4Card]
+- `tricks`: {team1: count, team2: count}
+
+**Bid Values:** '0'-'12' for numbers, 'B'/'2B'/'3B'/'4B' for bores (2x/4x/8x/16x multipliers)
+
+## Game Flow (Socket Events)
+
+1. **Auth**: `signIn`/`signUp` → `signInResponse`
+2. **Lobby**: `joinQueue` → `lobbyCreated` → `playerReadyUpdate` → `allPlayersReady`
+3. **Draw**: `startDraw` → `draw` → `playerDrew` → `teamsAnnounced`
+4. **Bidding**: `gameStart` → `updateTurn` → `playerBid` → `bidReceived` → `doneBidding`
+5. **Play**: `updateTurn` → `playCard` → `cardPlayed` → `trickComplete` → `handComplete`
+6. **End**: `gameEnd`
+
+## Quick Game Rules Reference
+
+- 54 cards (52 + HI/LO jokers), jokers are always trump
+- Hand sizes: 12→10→8→6→4→2→1→3→5→7→9→11→13
+- Must follow suit; trump can't lead until broken (unless hand is all trump)
+- HI joker forces opponents to play highest trump, partner plays lowest
+- Scoring: Made bid = (bid × 10 × multiplier) + overtricks; Set = -(bid × 10 × multiplier)
+- Rainbow bonus: +10 on 4-card hand if hand has all 4 suits
+
+## Commands
+
+```bash
+npm run dev          # Start server + client (hot reload)
+npm start            # Server only (port 3000)
+npm run dev:client   # Client Vite dev server (port 5173)
+npm run build:client # Production build
+
+npm test             # Server tests (Jest)
+npm run test:client  # Client tests (Vitest)
+```
+
+## Important Implementation Details
+
+- Bots have socketIds like `bot:{username}:{uuid}`, use `BotStrategy.js` for AI
+- Reconnection uses session tokens stored in MongoDB
+- Socket rooms: players join `game:{gameId}` for broadcasts
+- Event constants in `client/src/constants/events.js` prevent typos
+- Card legality logic duplicated in `server/game/rules.js` and `client/src/rules/legality.js`
+
+## Common Files to Check
+
+| Task | Files |
+|------|-------|
+| Game rules/logic | `server/game/rules.js`, `docs/RULES.md` |
+| Card play handling | `server/socket/gameHandlers.js` |
+| Client card legality | `client/src/rules/legality.js` |
+| UI screens | `client/src/ui/screens/` |
+| Visual card display | `client/src/phaser/managers/CardManager.js` |
+| State management | `server/game/GameState.js`, `client/src/state/GameState.js` |
+| Socket events list | `client/src/constants/events.js` |

--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -54,6 +54,9 @@ export const CLIENT_EVENTS = {
   // Leaderboard
   GET_LEADERBOARD: 'getLeaderboard',
 
+  // Records
+  GET_RECORDS: 'getRecords',
+
   // Voice Chat
   VOICE_OFFER: 'voiceOffer',
   VOICE_ANSWER: 'voiceAnswer',
@@ -143,6 +146,9 @@ export const SERVER_EVENTS = {
 
   // Leaderboard
   LEADERBOARD_RESPONSE: 'leaderboardResponse',
+
+  // Records
+  RECORDS_RESPONSE: 'recordsResponse',
 
   // Tournament
   TOURNAMENT_CREATED: 'tournamentCreated',

--- a/client/src/handlers/index.js
+++ b/client/src/handlers/index.js
@@ -11,6 +11,7 @@ import { registerGameHandlers, cleanupGameHandlers as cleanupGame } from './game
 import { registerChatHandlers } from './chatHandlers.js';
 import { registerProfileHandlers } from './profileHandlers.js';
 import { registerLeaderboardHandlers } from './leaderboardHandlers.js';
+import { registerRecordsHandlers } from './recordsHandlers.js';
 import { registerTournamentHandlers } from './tournamentHandlers.js';
 import { registerVoiceHandlers } from './voiceHandlers.js';
 
@@ -89,6 +90,9 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     // Leaderboard callbacks
     onLeaderboardReceived,
     onLeaderboardError,
+    // Records callbacks
+    onRecordsReceived,
+    onRecordsError,
     // Tournament callbacks
     onTournamentCreated,
     onTournamentJoined,
@@ -189,6 +193,12 @@ export function registerAllHandlers(socketManager, callbacks = {}) {
     onLeaderboardError,
   });
 
+  // Register records handlers
+  registerRecordsHandlers(socketManager, {
+    onRecordsReceived,
+    onRecordsError,
+  });
+
   // Register voice handlers (no callbacks needed - self-contained)
   registerVoiceHandlers(socketManager);
 
@@ -225,5 +235,6 @@ export { registerGameHandlers } from './gameHandlers.js';
 export { registerChatHandlers } from './chatHandlers.js';
 export { registerProfileHandlers } from './profileHandlers.js';
 export { registerLeaderboardHandlers } from './leaderboardHandlers.js';
+export { registerRecordsHandlers } from './recordsHandlers.js';
 export { registerTournamentHandlers } from './tournamentHandlers.js';
 export { registerVoiceHandlers } from './voiceHandlers.js';

--- a/client/src/handlers/recordsHandlers.js
+++ b/client/src/handlers/recordsHandlers.js
@@ -1,0 +1,31 @@
+/**
+ * Records-related socket event handlers.
+ *
+ * Handles: recordsResponse
+ */
+
+/**
+ * Register records handlers.
+ *
+ * @param {SocketManager} socketManager - Socket manager instance
+ * @param {Object} callbacks - UI callbacks
+ * @param {Function} callbacks.onRecordsReceived - Called when records data is received
+ * @param {Function} callbacks.onRecordsError - Called on records fetch error
+ */
+export function registerRecordsHandlers(socketManager, callbacks = {}) {
+  const {
+    onRecordsReceived,
+    onRecordsError,
+  } = callbacks;
+
+  // Records response
+  socketManager.on('recordsResponse', (data) => {
+    if (data.success) {
+      console.log('Records received');
+      onRecordsReceived?.(data.records);
+    } else {
+      console.warn('Records fetch failed:', data.message);
+      onRecordsError?.(data.message || 'Failed to fetch records');
+    }
+  });
+}

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -32,6 +32,7 @@ import { showMainRoom, addMainRoomChatMessage, updateLobbyList, removeMainRoom, 
 import { showGameLobby, updateLobbyPlayersList, addLobbyChatMessage, removeGameLobby, getCurrentLobbyId, getIsPlayerReady, getLobbyUserColors } from './ui/screens/GameLobby.js';
 import { showProfilePage, updateProfilePicDisplay, updateCustomProfilePicDisplay, removeProfilePage, isProfilePageVisible, showPlayerProfilePage } from './ui/screens/ProfilePage.js';
 import { showLeaderboardPage, removeLeaderboardPage, isLeaderboardPageVisible } from './ui/screens/LeaderboardPage.js';
+import { showRecordsPage, removeRecordsPage } from './ui/screens/RecordsPage.js';
 import { updatePlayerSearchResults } from './ui/screens/PlayerSearchPage.js';
 import { showTournamentLobby, removeTournamentLobby, addTournamentChatMessage, updateTournamentPlayers, updateTournamentScoreboardUI, updateTournamentRoundIndicator, updateTournamentActiveGames, setTournamentPhase } from './ui/screens/TournamentLobby.js';
 import { showTournamentResultsOverlay, removeTournamentResultsOverlay } from './ui/components/TournamentScoreboard.js';
@@ -915,9 +916,16 @@ export function setGameScene(scene) {
         display: flex;
         flex-direction: column;
         align-items: center;
-        pointer-events: none;
+        pointer-events: auto;
+        cursor: pointer;
         z-index: 100;
       `;
+
+      avatarContainer.addEventListener('click', () => {
+        if (socket) {
+          socket.emit('getPlayerProfile', { username });
+        }
+      });
 
       const avatarImg = document.createElement('img');
       avatarImg.className = 'player-avatar-img';
@@ -949,9 +957,13 @@ export function setGameScene(scene) {
       nameLabel.textContent = username;
       nameLabel.style.cssText = `
         margin-top: 5px;
+        padding: 2px 8px;
+        background: rgba(0, 0, 0, 0.7);
+        border: 1px solid #666;
+        border-radius: 4px;
         font-size: 14px;
         font-family: Arial, sans-serif;
-        color: #ffffff;
+        color: #aaa;
         text-shadow: 1px 1px 2px rgba(0,0,0,0.8);
       `;
       avatarContainer.appendChild(nameLabel);
@@ -3102,6 +3114,13 @@ function initializeApp() {
     },
     onLeaderboardError: (message) => {
       showError(message || 'Failed to load leaderboard');
+    },
+    // Records callbacks
+    onRecordsReceived: (records) => {
+      showRecordsPage(records);
+    },
+    onRecordsError: (message) => {
+      showError(message || 'Failed to load records');
     },
 
     // Tournament callbacks

--- a/client/src/phaser/managers/OpponentManager.js
+++ b/client/src/phaser/managers/OpponentManager.js
@@ -6,6 +6,7 @@
 
 import { team, rotate } from '../../utils/positions.js';
 import { CARD_CONFIG, ANIMATION_CONFIG } from '../config.js';
+import { getSocketManager } from '../../socket/SocketManager.js';
 
 /**
  * Base design dimensions for scaling.
@@ -417,9 +418,17 @@ export class OpponentManager {
       display: flex;
       flex-direction: column;
       align-items: center;
-      pointer-events: none;
+      pointer-events: auto;
+      cursor: pointer;
       z-index: 100;
     `;
+
+    container.addEventListener('click', () => {
+      const sm = getSocketManager();
+      if (sm.socket) {
+        sm.socket.emit('getPlayerProfile', { username });
+      }
+    });
 
     // Avatar image
     const img = document.createElement('img');
@@ -452,8 +461,12 @@ export class OpponentManager {
     label.textContent = username;
     label.style.cssText = `
       margin-top: 5px;
+      padding: 2px 8px;
+      background: rgba(0, 0, 0, 0.7);
+      border: 1px solid #666;
+      border-radius: 4px;
       font-size: 14px;
-      color: white;
+      color: #aaa;
       text-shadow: 1px 1px 2px black;
       white-space: nowrap;
     `;

--- a/client/src/ui/screens/MainRoom.js
+++ b/client/src/ui/screens/MainRoom.js
@@ -405,6 +405,28 @@ export function showMainRoom(data, socket) {
   });
   rightContainer.appendChild(leaderboardBtn);
 
+  // Records button
+  const recordsBtn = document.createElement('button');
+  recordsBtn.innerText = 'Records';
+  recordsBtn.style.padding = '8px 16px';
+  recordsBtn.style.borderRadius = '6px';
+  recordsBtn.style.border = 'none';
+  recordsBtn.style.background = '#6366f1';
+  recordsBtn.style.color = '#fff';
+  recordsBtn.style.fontSize = '14px';
+  recordsBtn.style.fontWeight = 'bold';
+  recordsBtn.style.cursor = 'pointer';
+  recordsBtn.addEventListener('click', () => {
+    socket.emit('getRecords');
+  });
+  recordsBtn.addEventListener('mouseenter', () => {
+    recordsBtn.style.background = '#4f46e5';
+  });
+  recordsBtn.addEventListener('mouseleave', () => {
+    recordsBtn.style.background = '#6366f1';
+  });
+  rightContainer.appendChild(recordsBtn);
+
   // Players search button
   const playersBtn = document.createElement('button');
   playersBtn.innerText = 'Players';

--- a/client/src/ui/screens/RecordsPage.js
+++ b/client/src/ui/screens/RecordsPage.js
@@ -1,0 +1,230 @@
+/**
+ * Records Page Screen
+ *
+ * Modal overlay showing game records (highest score, lowest score, biggest win)
+ * across three time periods: All Time, This Year, This Month.
+ */
+
+/**
+ * Create a single record entry element.
+ *
+ * @param {string} label - Record label
+ * @param {string} color - Label color
+ * @param {Object|null} data - Record data
+ * @param {string} type - 'score' or 'win'
+ * @returns {HTMLElement} Record entry element
+ */
+function createRecordEntry(label, color, data, type) {
+  const entry = document.createElement('div');
+  entry.style.marginBottom = '14px';
+
+  const labelEl = document.createElement('div');
+  labelEl.innerText = label;
+  labelEl.style.fontSize = '13px';
+  labelEl.style.fontWeight = 'bold';
+  labelEl.style.color = color;
+  labelEl.style.marginBottom = '4px';
+  entry.appendChild(labelEl);
+
+  if (!data) {
+    const noData = document.createElement('div');
+    noData.innerText = 'No games yet';
+    noData.style.color = '#6b7280';
+    noData.style.fontSize = '13px';
+    noData.style.fontStyle = 'italic';
+    entry.appendChild(noData);
+    return entry;
+  }
+
+  if (type === 'score') {
+    const scoreEl = document.createElement('div');
+    scoreEl.innerText = `${data.score} pts`;
+    scoreEl.style.fontSize = '20px';
+    scoreEl.style.fontWeight = 'bold';
+    scoreEl.style.color = '#fff';
+    entry.appendChild(scoreEl);
+
+    const playersEl = document.createElement('div');
+    playersEl.innerText = data.players.join(' & ');
+    playersEl.style.fontSize = '12px';
+    playersEl.style.color = '#9ca3af';
+    entry.appendChild(playersEl);
+  } else if (type === 'win') {
+    const marginEl = document.createElement('div');
+    marginEl.innerText = `${data.margin} pt margin`;
+    marginEl.style.fontSize = '20px';
+    marginEl.style.fontWeight = 'bold';
+    marginEl.style.color = '#fff';
+    entry.appendChild(marginEl);
+
+    const scoresEl = document.createElement('div');
+    scoresEl.innerText = `${data.winnerScore} - ${data.loserScore}`;
+    scoresEl.style.fontSize = '14px';
+    scoresEl.style.color = '#d1d5db';
+    scoresEl.style.marginBottom = '2px';
+    entry.appendChild(scoresEl);
+
+    const winnerEl = document.createElement('div');
+    winnerEl.innerText = `W: ${data.winnerPlayers.join(' & ')}`;
+    winnerEl.style.fontSize = '12px';
+    winnerEl.style.color = '#4ade80';
+    entry.appendChild(winnerEl);
+
+    const loserEl = document.createElement('div');
+    loserEl.innerText = `L: ${data.loserPlayers.join(' & ')}`;
+    loserEl.style.fontSize = '12px';
+    loserEl.style.color = '#f87171';
+    entry.appendChild(loserEl);
+  }
+
+  return entry;
+}
+
+/**
+ * Create a time period box.
+ *
+ * @param {string} title - Box title
+ * @param {Object|null} periodData - Record data for this period
+ * @returns {HTMLElement} Period box element
+ */
+function createPeriodBox(title, periodData) {
+  const box = document.createElement('div');
+  box.style.flex = '1';
+  box.style.minWidth = '250px';
+  box.style.background = 'rgba(0, 0, 0, 0.3)';
+  box.style.borderRadius = '8px';
+  box.style.padding = '18px';
+  box.style.border = '1px solid #4a5568';
+
+  const heading = document.createElement('div');
+  heading.innerText = title;
+  heading.style.fontSize = '16px';
+  heading.style.fontWeight = 'bold';
+  heading.style.color = '#60a5fa';
+  heading.style.marginBottom = '16px';
+  heading.style.textAlign = 'center';
+  heading.style.borderBottom = '1px solid #4a5568';
+  heading.style.paddingBottom = '10px';
+  box.appendChild(heading);
+
+  if (!periodData) {
+    const noData = document.createElement('div');
+    noData.innerText = 'No games yet';
+    noData.style.color = '#6b7280';
+    noData.style.fontSize = '14px';
+    noData.style.fontStyle = 'italic';
+    noData.style.textAlign = 'center';
+    noData.style.padding = '20px 0';
+    box.appendChild(noData);
+    return box;
+  }
+
+  box.appendChild(createRecordEntry('Highest Score', '#4ade80', periodData.highestScore, 'score'));
+  box.appendChild(createRecordEntry('Lowest Score', '#f87171', periodData.lowestScore, 'score'));
+  box.appendChild(createRecordEntry('Biggest Win', '#fbbf24', periodData.biggestWin, 'win'));
+
+  return box;
+}
+
+/**
+ * Show the records page.
+ *
+ * @param {Object} records - Records data with allTime, thisYear, thisMonth
+ */
+export function showRecordsPage(records) {
+  // Remove any existing records page
+  removeRecordsPage();
+
+  // Create overlay
+  const overlay = document.createElement('div');
+  overlay.id = 'recordsPageOverlay';
+  overlay.style.position = 'fixed';
+  overlay.style.top = '0';
+  overlay.style.left = '0';
+  overlay.style.right = '0';
+  overlay.style.bottom = '0';
+  overlay.style.background = 'rgba(0, 0, 0, 0.7)';
+  overlay.style.zIndex = '2000';
+  overlay.style.display = 'flex';
+  overlay.style.alignItems = 'center';
+  overlay.style.justifyContent = 'center';
+
+  // Close on overlay click
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) removeRecordsPage();
+  });
+
+  // Create modal container
+  const modal = document.createElement('div');
+  modal.id = 'recordsPageModal';
+  modal.style.background = '#1a1a2e';
+  modal.style.color = '#fff';
+  modal.style.padding = '25px';
+  modal.style.borderRadius = '12px';
+  modal.style.border = '2px solid #4a5568';
+  modal.style.width = '960px';
+  modal.style.maxWidth = '95vw';
+  modal.style.maxHeight = '90vh';
+  modal.style.boxSizing = 'border-box';
+  modal.style.fontFamily = 'Arial, sans-serif';
+  modal.style.display = 'flex';
+  modal.style.flexDirection = 'column';
+  modal.style.overflowY = 'auto';
+
+  // Header
+  const headerRow = document.createElement('div');
+  headerRow.style.display = 'flex';
+  headerRow.style.justifyContent = 'space-between';
+  headerRow.style.alignItems = 'center';
+  headerRow.style.marginBottom = '20px';
+  headerRow.style.flexShrink = '0';
+
+  const title = document.createElement('div');
+  title.innerText = 'Records';
+  title.style.fontSize = '24px';
+  title.style.fontWeight = 'bold';
+  title.style.color = '#4ade80';
+  headerRow.appendChild(title);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.innerText = 'X';
+  closeBtn.style.background = '#ef4444';
+  closeBtn.style.border = 'none';
+  closeBtn.style.borderRadius = '50%';
+  closeBtn.style.width = '32px';
+  closeBtn.style.height = '32px';
+  closeBtn.style.color = '#fff';
+  closeBtn.style.fontSize = '16px';
+  closeBtn.style.fontWeight = 'bold';
+  closeBtn.style.cursor = 'pointer';
+  closeBtn.style.lineHeight = '32px';
+  closeBtn.style.textAlign = 'center';
+  closeBtn.addEventListener('click', removeRecordsPage);
+  closeBtn.addEventListener('mouseenter', () => { closeBtn.style.background = '#dc2626'; });
+  closeBtn.addEventListener('mouseleave', () => { closeBtn.style.background = '#ef4444'; });
+  headerRow.appendChild(closeBtn);
+
+  modal.appendChild(headerRow);
+
+  // Three boxes row
+  const boxesRow = document.createElement('div');
+  boxesRow.style.display = 'flex';
+  boxesRow.style.gap = '16px';
+  boxesRow.style.flexWrap = 'wrap';
+
+  boxesRow.appendChild(createPeriodBox('All Time', records.allTime));
+  boxesRow.appendChild(createPeriodBox('This Year', records.thisYear));
+  boxesRow.appendChild(createPeriodBox('This Month', records.thisMonth));
+
+  modal.appendChild(boxesRow);
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+}
+
+/**
+ * Remove the records page.
+ */
+export function removeRecordsPage() {
+  const overlay = document.getElementById('recordsPageOverlay');
+  if (overlay) overlay.remove();
+}

--- a/server/database.js
+++ b/server/database.js
@@ -5,7 +5,7 @@ const { dbLogger } = require("./utils/logger");
 const mongoURI = process.env.MONGO_URI || 'mongodb://localhost:27017/babonline';
 const dbName = "babonline";
 
-let db, usersCollection;
+let db, usersCollection, gameRecordsCollection;
 
 /**
  * Connect to MongoDB
@@ -17,10 +17,12 @@ async function connectDB() {
         dbLogger.info("Connected to MongoDB");
         db = client.db(dbName);
         usersCollection = db.collection("users");
+        gameRecordsCollection = db.collection("gameRecords");
+        await gameRecordsCollection.createIndex({ completedAt: -1 });
     } catch (error) {
         dbLogger.error("MongoDB connection failed", { error: error.message });
     }
 }
 
 // ✅ Export database and collection references
-module.exports = { connectDB, getDB: () => db, getUsersCollection: () => usersCollection };
+module.exports = { connectDB, getDB: () => db, getUsersCollection: () => usersCollection, getGameRecordsCollection: () => gameRecordsCollection };

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -116,6 +116,9 @@ function setupSocketHandlers(io) {
         socket.on('getLeaderboard', () =>
             safeHandler(profileHandlers.getLeaderboard)(socket, io, {})
         );
+        socket.on('getRecords', () =>
+            safeHandler(profileHandlers.getRecords)(socket, io, {})
+        );
         socket.on('searchPlayers', (data) =>
             asyncHandler('searchPlayers', profileHandlers.searchPlayers)(socket, io, data)
         );

--- a/server/socket/profileHandlers.js
+++ b/server/socket/profileHandlers.js
@@ -3,7 +3,7 @@
  * Handles fetching and updating user profiles
  */
 
-const { getUsersCollection } = require('../database');
+const { getUsersCollection, getGameRecordsCollection } = require('../database');
 const gameManager = require('../game/GameManager');
 const { authLogger } = require('../utils/logger');
 
@@ -195,6 +195,37 @@ async function uploadProfilePic(socket, io, data) {
 }
 
 /**
+ * Record a completed game's results into the gameRecords collection
+ * @param {Object} game - The completed game object
+ */
+async function recordGameResult(game) {
+    const gameRecordsCollection = getGameRecordsCollection();
+    if (!gameRecordsCollection) return;
+
+    try {
+        const team1Players = [game.getOriginalPlayer(1), game.getOriginalPlayer(3)]
+            .filter(p => p && p.username)
+            .map(p => p.username);
+        const team2Players = [game.getOriginalPlayer(2), game.getOriginalPlayer(4)]
+            .filter(p => p && p.username)
+            .map(p => p.username);
+
+        await gameRecordsCollection.insertOne({
+            gameId: game.gameId,
+            team1Score: game.score.team1,
+            team2Score: game.score.team2,
+            team1Players,
+            team2Players,
+            completedAt: new Date()
+        });
+
+        authLogger.info('Game result recorded', { gameId: game.gameId });
+    } catch (error) {
+        authLogger.error('Error recording game result', { gameId: game.gameId, error: error.message });
+    }
+}
+
+/**
  * Record game statistics for all players after a game ends
  * @param {Object} game - The completed game object
  * @param {boolean} team1Won - Whether team 1 won (positions 1 & 3)
@@ -208,6 +239,9 @@ async function recordGameStats(game) {
         authLogger.info('Skipping stat recording — game contains bots', { gameId: game.gameId });
         return;
     }
+
+    // Record the game result for records page
+    await recordGameResult(game);
 
     // Determine winner based on final scores
     const team1Won = game.score.team1 > game.score.team2;
@@ -489,6 +523,85 @@ async function getPlayerProfile(socket, io, data) {
     }
 }
 
+/**
+ * Get game records (highest score, lowest score, biggest win) for 3 time periods
+ * @param {Socket} socket - Socket instance
+ * @param {Server} io - Socket.IO server instance
+ */
+async function getRecords(socket, io) {
+    const gameRecordsCollection = getGameRecordsCollection();
+
+    if (!gameRecordsCollection) {
+        socket.emit('recordsResponse', { success: false, message: 'Database not available' });
+        return;
+    }
+
+    try {
+        const now = new Date();
+        const startOfYear = new Date(now.getFullYear(), 0, 1);
+        const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+        const filters = {
+            allTime: {},
+            thisYear: { completedAt: { $gte: startOfYear } },
+            thisMonth: { completedAt: { $gte: startOfMonth } }
+        };
+
+        const records = {};
+
+        for (const [period, filter] of Object.entries(filters)) {
+            const games = await gameRecordsCollection.find(filter).toArray();
+
+            if (games.length === 0) {
+                records[period] = null;
+                continue;
+            }
+
+            let highestScore = null;
+            let lowestScore = null;
+            let biggestWin = null;
+
+            for (const game of games) {
+                // Check both teams for highest/lowest individual team score
+                const entries = [
+                    { score: game.team1Score, players: game.team1Players },
+                    { score: game.team2Score, players: game.team2Players }
+                ];
+
+                for (const entry of entries) {
+                    if (!highestScore || entry.score > highestScore.score) {
+                        highestScore = { score: entry.score, players: entry.players };
+                    }
+                    if (!lowestScore || entry.score < lowestScore.score) {
+                        lowestScore = { score: entry.score, players: entry.players };
+                    }
+                }
+
+                // Biggest win margin
+                const margin = Math.abs(game.team1Score - game.team2Score);
+                if (!biggestWin || margin > biggestWin.margin) {
+                    const winnerIsTeam1 = game.team1Score > game.team2Score;
+                    biggestWin = {
+                        margin,
+                        winnerScore: winnerIsTeam1 ? game.team1Score : game.team2Score,
+                        loserScore: winnerIsTeam1 ? game.team2Score : game.team1Score,
+                        winnerPlayers: winnerIsTeam1 ? game.team1Players : game.team2Players,
+                        loserPlayers: winnerIsTeam1 ? game.team2Players : game.team1Players
+                    };
+                }
+            }
+
+            records[period] = { highestScore, lowestScore, biggestWin };
+        }
+
+        socket.emit('recordsResponse', { success: true, records });
+        authLogger.debug('Records fetched');
+    } catch (error) {
+        authLogger.error('Error fetching records', { error: error.message });
+        socket.emit('recordsResponse', { success: false, message: 'Database error' });
+    }
+}
+
 module.exports = {
     getProfile,
     updateProfilePic,
@@ -497,5 +610,6 @@ module.exports = {
     getUserProfilePic,
     getLeaderboard,
     searchPlayers,
-    getPlayerProfile
+    getPlayerProfile,
+    getRecords
 };


### PR DESCRIPTION
## Summary
- Player avatars (all 4 positions) are now clickable during gameplay to view that player's profile page
- Username labels styled with gray background box and light gray text to match HSI label styling
- Added player records page with game history

## Test plan
- [ ] Start a game with bots
- [ ] Click on any opponent's avatar → profile modal should appear
- [ ] Click on your own avatar → your profile should appear
- [ ] Close profile modal → game continues normally
- [ ] Verify card play and bidding still work after closing profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)