### PR TITLE
Add trick indicator to bid UI and game log

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -191,6 +191,10 @@ export function setGameScene(scene) {
       if (window.updateBoreButtons) {
         window.updateBoreButtons();
       }
+      // Update game log trick indicator
+      if (gameLogInstance && gameLogInstance.updateTrickIndicator) {
+        gameLogInstance.updateTrickIndicator();
+      }
     };
   }
 
@@ -204,6 +208,7 @@ export function setGameScene(scene) {
       if (this.bidManager) {
         this.bidManager.hideBidUI();
       }
+      // Keep game log trick indicator visible through playing phase
     };
   }
 
@@ -1823,8 +1828,22 @@ function initializeApp() {
         scene.cardManager.updateCardLegality(legalityChecker, canPlay);
       }
 
+      // Show game log trick indicator on reconnect (persists through entire hand)
+      if (gameLogInstance && gameLogInstance.showTrickIndicator) {
+        const handSize = data.hand?.length || data.currentHand;
+        if (handSize) {
+          gameLogInstance.showTrickIndicator(handSize);
+        }
+      }
+
+      // Re-apply bidding state (scene creation may have reset it)
+      if (isBiddingOnRejoin) {
+        gameState.isBidding = true;
+        gameState.phase = PHASE.BIDDING;
+      }
+
       // Create bid UI via BidManager (only if still in bidding phase)
-      if (scene && scene.bidManager && data.hand && gameState.isBidding && !gameState.isSpectator) {
+      if (scene && scene.bidManager && data.hand && isBiddingOnRejoin && !gameState.isSpectator) {
         scene.bidManager.showBidUI(data.hand.length, (bid) => {
           if (window.socket) {
             window.socket.emit('playerBid', { position: gameState.position, bid });
@@ -2437,6 +2456,11 @@ function initializeApp() {
             scene.opponentManager.displayOpponentCards(cardCount);
           }
         }
+
+        // Show game log trick indicator as cards are dealt
+        if (gameLogInstance && gameLogInstance.showTrickIndicator && data.hand) {
+          gameLogInstance.showTrickIndicator(data.hand.length);
+        }
       };
 
       // Function to show bid UI (delayed until trump flip complete)
@@ -2598,6 +2622,10 @@ function initializeApp() {
       if (scene && scene.handleBidReceived) {
         scene.handleBidReceived(data);
       }
+      // Update game log trick indicator
+      if (gameLogInstance && gameLogInstance.updateTrickIndicator) {
+        gameLogInstance.updateTrickIndicator();
+      }
       // Note: Legacy code in displayCards() also handles bidReceived for bubbles/impact events
     },
     onDoneBidding: (data) => {
@@ -2665,9 +2693,16 @@ function initializeApp() {
       if (scene && scene.handleHandComplete) {
         scene.handleHandComplete(data);
       }
+      // Hide game log trick indicator at end of hand
+      if (gameLogInstance && gameLogInstance.hideTrickIndicator) {
+        gameLogInstance.hideTrickIndicator();
+      }
     },
     onGameEnd: (data) => {
       const scene = getGameScene();
+      if (gameLogInstance && gameLogInstance.hideTrickIndicator) {
+        gameLogInstance.hideTrickIndicator();
+      }
 
       // Determine which team the player is on (positions 1,3 = Team 1, positions 2,4 = Team 2)
       // Spectators view from position 1 but aren't on either team

--- a/client/src/phaser/managers/BidManager.js
+++ b/client/src/phaser/managers/BidManager.js
@@ -28,6 +28,11 @@ export class BidManager {
 
     // Currently selected bid
     this.selectedBid = null;
+
+    // Trick indicator
+    this.trickIndicators = [];
+    this.indicatorRow = null;
+    this.handSize = 0;
   }
 
   /**
@@ -97,8 +102,24 @@ export class BidManager {
     header.style.fontWeight = 'bold';
     header.style.textAlign = 'center';
     header.style.marginBottom = '4px';
-    header.innerText = 'Your Bid:';
+    header.innerText = 'Bid!';
     this.bidContainer.appendChild(header);
+
+    // Trick indicator
+    this.handSize = handSize;
+    this.indicatorRow = document.createElement('div');
+    this.indicatorRow.style.display = 'flex';
+    this.indicatorRow.style.gap = '3px';
+    this.indicatorRow.style.justifyContent = 'center';
+    this.indicatorRow.style.marginBottom = '4px';
+    this.trickIndicators = [];
+    for (let i = 0; i < handSize; i++) {
+      const rect = this.createIndicatorRect();
+      this.trickIndicators.push(rect);
+      this.indicatorRow.appendChild(rect);
+    }
+    this.bidContainer.appendChild(this.indicatorRow);
+    this.updateTrickIndicator();
 
     // Reset selection tracking
     this.allBidButtons = [];
@@ -247,6 +268,84 @@ export class BidManager {
         btn.style.background = '#c53030';
       }
     });
+
+    this.updateTrickIndicator();
+  }
+
+  /**
+   * Create a single indicator rectangle element.
+   */
+  createIndicatorRect() {
+    const rect = document.createElement('div');
+    rect.style.width = '18px';
+    rect.style.height = '26px';
+    rect.style.borderRadius = '3px';
+    rect.style.background = '#555';
+    rect.style.transition = 'background 150ms ease';
+    rect.style.boxSizing = 'border-box';
+    return rect;
+  }
+
+  /**
+   * Update trick indicator colors based on current bids.
+   * Adds extra pulsing rectangles for overbids (capped at 16 total).
+   */
+  updateTrickIndicator() {
+    if (!this.indicatorRow) return;
+
+    const bids = this.state.bids;
+    const myTeam = this.state.position % 2;
+
+    let teamBidCount = 0;
+    let oppBidCount = 0;
+
+    for (const [pos, bid] of Object.entries(bids)) {
+      const bidStr = String(bid).toUpperCase();
+      if (['B', '2B', '3B', '4B'].includes(bidStr)) continue;
+      const numBid = parseInt(bidStr, 10);
+      if (isNaN(numBid)) continue;
+
+      if (Number(pos) % 2 === myTeam) {
+        teamBidCount += numBid;
+      } else {
+        oppBidCount += numBid;
+      }
+    }
+
+    const totalBid = teamBidCount + oppBidCount;
+    const totalNeeded = Math.min(Math.max(totalBid, this.handSize), 16);
+
+    // Add or remove extra rectangles to match totalNeeded
+    while (this.trickIndicators.length < totalNeeded) {
+      const rect = this.createIndicatorRect();
+      this.trickIndicators.push(rect);
+      this.indicatorRow.appendChild(rect);
+    }
+    while (this.trickIndicators.length > totalNeeded) {
+      const rect = this.trickIndicators.pop();
+      rect.remove();
+    }
+
+    // Color the rectangles
+    for (let i = 0; i < this.trickIndicators.length; i++) {
+      const rect = this.trickIndicators[i];
+      const isOverbid = i >= this.handSize;
+
+      if (i < teamBidCount) {
+        rect.style.background = '#68d391';
+      } else if (i < totalBid) {
+        rect.style.background = '#fc8181';
+      } else {
+        rect.style.background = '#555';
+      }
+
+      if (isOverbid) {
+        rect.style.animation = 'trickOverbidPulse 1s ease-in-out infinite';
+      } else {
+        rect.style.animation = '';
+        rect.style.outline = '';
+      }
+    }
   }
 
   /**
@@ -300,6 +399,9 @@ export class BidManager {
     this.boreButtons = {};
     this.allBidButtons = [];
     this.selectedBid = null;
+    this.trickIndicators = [];
+    this.indicatorRow = null;
+    this.handSize = 0;
   }
 
   /**

--- a/client/src/ui/components/GameLog.js
+++ b/client/src/ui/components/GameLog.js
@@ -84,11 +84,131 @@ export function createGameLog({ onChatSubmit } = {}) {
   scoreSection.appendChild(oppScoreDiv);
   container.appendChild(scoreSection);
 
+  // Trick indicator (shown during bidding, below score section)
+  const trickIndicatorSection = document.createElement('div');
+  trickIndicatorSection.style.cssText = `
+    display: none;
+    padding: 6px 10px;
+    border-bottom: 1px solid #333;
+    background: rgba(0, 0, 0, 0.3);
+    flex-shrink: 0;
+  `;
+  const trickIndicatorRow = document.createElement('div');
+  trickIndicatorRow.style.cssText = `
+    display: flex;
+    gap: 2px;
+    justify-content: center;
+    flex-wrap: wrap;
+  `;
+  trickIndicatorSection.appendChild(trickIndicatorRow);
+  container.appendChild(trickIndicatorSection);
+
   // Message area
   const messageArea = document.createElement('div');
   messageArea.id = 'gameFeedMessages';  // Legacy ID for compatibility
   messageArea.classList.add('chat-messages');  // Legacy class
   container.appendChild(messageArea);
+
+  let trickRects = [];
+  let trickHandSize = 0;
+
+  const createTrickRect = () => {
+    const rect = document.createElement('div');
+    rect.style.cssText = `
+      width: 14px;
+      height: 20px;
+      border-radius: 2px;
+      background: #555;
+      transition: background 150ms ease;
+      box-sizing: border-box;
+    `;
+    return rect;
+  };
+
+  const showTrickIndicator = (handSize) => {
+    trickHandSize = handSize;
+    trickIndicatorRow.innerHTML = '';
+    trickRects = [];
+    for (let i = 0; i < handSize; i++) {
+      const rect = createTrickRect();
+      trickRects.push(rect);
+      trickIndicatorRow.appendChild(rect);
+    }
+    trickIndicatorSection.style.display = 'block';
+    updateTrickIndicator();
+  };
+
+  const hideTrickIndicator = () => {
+    trickIndicatorSection.style.display = 'none';
+    trickIndicatorRow.innerHTML = '';
+    trickRects = [];
+    trickHandSize = 0;
+  };
+
+  const updateTrickIndicator = () => {
+    if (trickRects.length === 0) return;
+
+    const state = getGameState();
+    const bids = state.bids;
+    const myTeam = state.position % 2;
+
+    let teamBidCount = 0;
+    let oppBidCount = 0;
+
+    // After bidding completes, bids changes to { team1: N, team2: N }
+    if (bids.team1 !== undefined) {
+      const isTeam1 = state.position === 1 || state.position === 3;
+      teamBidCount = isTeam1 ? bids.team1 : bids.team2;
+      oppBidCount = isTeam1 ? bids.team2 : bids.team1;
+    } else {
+      for (const [pos, bid] of Object.entries(bids)) {
+        const bidStr = String(bid).toUpperCase();
+        if (['B', '2B', '3B', '4B'].includes(bidStr)) continue;
+        const numBid = parseInt(bidStr, 10);
+        if (isNaN(numBid)) continue;
+
+        if (Number(pos) % 2 === myTeam) {
+          teamBidCount += numBid;
+        } else {
+          oppBidCount += numBid;
+        }
+      }
+    }
+
+    const totalBid = teamBidCount + oppBidCount;
+    const totalNeeded = Math.min(Math.max(totalBid, trickHandSize), 16);
+
+    // Add or remove extra rectangles
+    while (trickRects.length < totalNeeded) {
+      const rect = createTrickRect();
+      trickRects.push(rect);
+      trickIndicatorRow.appendChild(rect);
+    }
+    while (trickRects.length > totalNeeded) {
+      const rect = trickRects.pop();
+      rect.remove();
+    }
+
+    for (let i = 0; i < trickRects.length; i++) {
+      const rect = trickRects[i];
+      const isOverbid = i >= trickHandSize;
+
+      if (i < teamBidCount) {
+        rect.style.background = '#68d391';
+      } else if (i < totalBid) {
+        rect.style.background = '#fc8181';
+      } else {
+        rect.style.background = '#555';
+      }
+
+      if (isOverbid) {
+        rect.style.animation = 'trickOverbidPulse 1s ease-in-out infinite';
+      } else {
+        rect.style.animation = '';
+        rect.style.outline = '';
+      }
+    }
+  };
 
   // Chat input section
   const chatSection = document.createElement('div');
@@ -426,6 +546,9 @@ export function createGameLog({ onChatSubmit } = {}) {
     updateTricks,
     updateFullScore,
     updateHandIndicator,
+    showTrickIndicator,
+    hideTrickIndicator,
+    updateTrickIndicator,
     clearMessages,
     destroy,
     chatInput,

--- a/client/styles.css
+++ b/client/styles.css
@@ -76,6 +76,17 @@ h1 {
     }
 }
 
+@keyframes trickOverbidPulse {
+    0%, 100% {
+        outline: 2px solid transparent;
+        box-shadow: none;
+    }
+    50% {
+        outline: 2px solid #ff3333;
+        box-shadow: 0 0 6px #ff3333;
+    }
+}
+
 /* Warning toast (yellow) */
 .warning-toast {
     background: #f59e0b;


### PR DESCRIPTION
## Summary
- Add visual trick indicator (row of card-shaped rectangles) to both the bid panel and game log showing bid distribution: green for your team, red for opponents, gray for unclaimed
- Overbid tricks beyond hand size pulse with bright red glow, capped at 16 total rectangles
- Game log indicator appears when cards are dealt and persists through the entire hand
- Handles reconnect/refresh correctly, including the server's post-bidding `{ team1, team2 }` bid format
- Rename bid panel header from "Your Bid:" to "Bid!"

## Test plan
- [ ] Start a game with bots and verify indicator shows correct number of rectangles per hand size
- [ ] During bidding, verify green/red rectangles update as each player bids (including bore bids counting as 0)
- [ ] Verify overbid rectangles appear with pulsing red glow when total bids exceed hand size
- [ ] Verify game log indicator appears when cards are dealt and persists through playing phase
- [ ] Refresh during bidding and playing phases — indicator should restore with correct counts
- [ ] Verify indicator hides at end of hand and reappears for next hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)