### PR TITLE
Fix voice relay not triggering on connectionState failure

### DIFF
--- a/client/src/voice/VoiceChatManager.js
+++ b/client/src/voice/VoiceChatManager.js
@@ -494,6 +494,10 @@ export class VoiceChatManager {
     // Connection state monitoring
     pc.onconnectionstatechange = () => {
       console.log(`[Voice] peer ${socketId} connection: ${pc.connectionState}`);
+      if (pc.connectionState === 'failed') {
+        console.log(`[Voice] P2P connection failed for ${socketId}, switching to relay`);
+        this._startRelay(socketId);
+      }
     };
 
     pc.oniceconnectionstatechange = () => {


### PR DESCRIPTION
## Summary
- ICE can stop at `disconnected` while `connectionState` goes to `failed`, bypassing the relay fallback
- Now `onconnectionstatechange` also triggers `_startRelay()` when state is `failed`

## Test plan
- [ ] Join game with player behind symmetric NAT — relay should now activate when connection fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)