### PR TITLE
Fix reconnection state restore and draw-phase disconnects

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1800,6 +1800,14 @@ function initializeApp() {
         scene.trickManager._teamTrickCount = gameState.teamTricks || 0;
         scene.trickManager._oppTrickCount = gameState.oppTricks || 0;
         scene.trickManager.createTrickBackgrounds(false);
+
+        // Restore visual trick stacks (card-back placeholders for won tricks)
+        if (gameState.teamTricks > 0 || gameState.oppTricks > 0) {
+          // Reset counts before restoreTrickPlaceholders (it increments them)
+          scene.trickManager._teamTrickCount = 0;
+          scene.trickManager._oppTrickCount = 0;
+          scene.trickManager.restoreTrickPlaceholders(gameState.teamTricks, gameState.oppTricks);
+        }
       }
 
       // Restore played cards in current trick via TrickManager
@@ -1915,25 +1923,33 @@ function initializeApp() {
     if (data.currentTurn !== undefined) gameState.setCurrentTurn(data.currentTurn);
 
     const bidding = data.isBidding !== undefined ? data.isBidding : data.bidding;
+    const isBiddingOnRejoin = !!bidding;
     if (bidding !== undefined) {
       gameState.isBidding = bidding;
       gameState.phase = bidding ? PHASE.BIDDING : PHASE.PLAYING;
     }
 
     if (data.playedCards && Array.isArray(data.playedCards)) {
-      let foundLead = false;
       let playedCount = 0;
-      data.playedCards.forEach((card, index) => {
-        if (card) {
-          playedCount++;
-          if (!foundLead) {
-            gameState.leadCard = card;
-            gameState.leadPosition = index + 1;
-            foundLead = true;
-          }
-        }
+      data.playedCards.forEach((card) => {
+        if (card) playedCount++;
       });
       gameState.playedCardIndex = playedCount;
+
+      // Use server-provided leadPosition (position-indexed array can't reliably infer lead order)
+      if (data.leadPosition !== undefined) {
+        gameState.leadPosition = data.leadPosition;
+        const leadCard = data.playedCards[data.leadPosition - 1];
+        if (leadCard) gameState.leadCard = leadCard;
+      } else {
+        // Fallback: infer from first non-null card (legacy)
+        data.playedCards.forEach((card, index) => {
+          if (card && !gameState.leadCard) {
+            gameState.leadCard = card;
+            gameState.leadPosition = index + 1;
+          }
+        });
+      }
     } else {
       if (data.leadCard) gameState.leadCard = data.leadCard;
       if (data.leadPosition !== undefined) gameState.leadPosition = data.leadPosition;

--- a/client/src/state/GameState.js
+++ b/client/src/state/GameState.js
@@ -752,7 +752,7 @@ export class GameState {
     this.position = data.position;
     this.currentHand = data.currentHand;
     this.trump = data.trump;
-    this.trumpBroken = data.trumpBroken || false;
+    this.trumpBroken = data.trumpBroken || data.isTrumpBroken || false;
     this.dealer = data.dealer;
     this.isBidding = data.isBidding !== undefined ? data.isBidding : (data.bidding || false);
     this.currentTurn = data.currentTurn;
@@ -769,6 +769,14 @@ export class GameState {
     if (data.teamTricks !== undefined) {
       this.teamTricks = data.teamTricks;
       this.oppTricks = data.oppTricks;
+    } else if (data.tricks) {
+      if (this.position % 2 !== 0) {
+        this.teamTricks = data.tricks.team1;
+        this.oppTricks = data.tricks.team2;
+      } else {
+        this.teamTricks = data.tricks.team2;
+        this.oppTricks = data.tricks.team1;
+      }
     }
 
     if (data.teamScore !== undefined) {
@@ -797,9 +805,17 @@ export class GameState {
       this.leadCard = null;
       this.leadPosition = null;
 
+      // Use server-provided leadPosition when available
+      if (data.leadPosition !== undefined) {
+        this.leadPosition = data.leadPosition;
+        const leadCard = data.playedCards[data.leadPosition - 1];
+        if (leadCard) this.leadCard = leadCard;
+      }
+
       data.playedCards.forEach((card, index) => {
         if (card) {
           const cardPosition = index + 1; // Convert to 1-4 position
+          // Fallback: infer lead from first non-null card if server didn't provide it
           if (!this.leadCard) {
             this.leadCard = card;
             this.leadPosition = cardPosition;

--- a/client/src/ui/screens/SignIn.js
+++ b/client/src/ui/screens/SignIn.js
@@ -76,6 +76,8 @@ export function createSignInScreen({ onSignIn, onCreateAccount }) {
     "this is a man's game!",
     'you should be dealing already!',
     "i did it frank's way, that bastard!",
+    'alls we gotta do...',
+    'coulda bored!',
   ];
   const splash = document.createElement('span');
   splash.textContent = splashPhrases[Math.floor(Math.random() * splashPhrases.length)];

--- a/server/game/GameState.js
+++ b/server/game/GameState.js
@@ -269,6 +269,7 @@ class GameState {
             tricks: this.tricks,
             score: this.score,
             playedCards: this.playedCards,
+            leadPosition: this.leadPosition,
             isTrumpBroken: this.isTrumpBroken,
             players: playerInfo,
             gameLog: this.getGameLog(),

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -331,7 +331,7 @@ async function handleDrawComplete(io, game) {
             username = bot?.username || 'Bot';
         } else {
             const user = gameManager.getUserBySocketId(playerId);
-            username = user?.username || 'Player';
+            username = user?.username || game._pendingUsernames?.[playerId] || 'Player';
         }
 
         game.addPlayer(playerId, username, position, pics[i], isBot);
@@ -349,6 +349,18 @@ async function handleDrawComplete(io, game) {
         if (!isBot) {
             io.to(playerId).emit('playerAssigned', { playerId, position });
         }
+    }
+
+    // Handle players who disconnected during draw phase
+    if (game._drawPhaseDisconnects) {
+        for (const [socketId, info] of Object.entries(game._drawPhaseDisconnects)) {
+            const pos = game.getPositionBySocketId(socketId);
+            if (pos) {
+                game.markPlayerDisconnected(pos);
+            }
+        }
+        delete game._drawPhaseDisconnects;
+        delete game._pendingUsernames;
     }
 
     // Build all arrays in position order (1, 2, 3, 4) for consistency

--- a/server/socket/queueHandlers.js
+++ b/server/socket/queueHandlers.js
@@ -129,6 +129,59 @@ async function handleDisconnect(socket, io) {
     // If player was in an active game, give them time to reconnect
     if (result.wasInGame && result.game) {
         const position = result.game.getPositionBySocketId(socket.id);
+
+        // Handle disconnect during draw phase (player has no position yet)
+        if (!position && result.game.phase === 'drawing') {
+            const user = gameManager.getUserBySocketId(socket.id);
+            const username = user?.username || 'Player';
+
+            // Check if this player already drew
+            const alreadyDrew = result.game.drawIDs.includes(socket.id);
+
+            if (!alreadyDrew) {
+                // Auto-draw for the disconnected player (random card)
+                const remaining = result.game.deck.cards.length;
+                if (remaining > 0) {
+                    const drawIndex = Math.floor(Math.random() * remaining);
+                    const card = result.game.deck.cards[drawIndex];
+                    result.game.drawCards.push(card);
+                    result.game.drawIDs.push(socket.id);
+                    result.game.deck.cards.splice(drawIndex, 1);
+
+                    result.game.broadcast(io, 'playerDrew', {
+                        username,
+                        card,
+                        drawOrder: result.game.drawIndex + 1,
+                        socketId: socket.id
+                    });
+
+                    result.game.drawIndex++;
+
+                    // If all 4 have now drawn, complete the draw phase
+                    if (result.game.drawIndex === 4) {
+                        const { handleDrawComplete } = require('./gameHandlers');
+                        handleDrawComplete(io, result.game);
+                    }
+                }
+            }
+
+            // Store username for lookup during handleDrawComplete
+            if (!result.game._pendingUsernames) result.game._pendingUsernames = {};
+            result.game._pendingUsernames[socket.id] = username;
+
+            // Mark this socket as needing replacement after draw completes
+            if (!result.game._drawPhaseDisconnects) result.game._drawPhaseDisconnects = {};
+            result.game._drawPhaseDisconnects[socket.id] = { username };
+
+            // Log disconnect
+            result.game.broadcast(io, 'playerDisconnected', { position: null, username });
+            const dcMessage = `${username} disconnected during card draw.`;
+            result.game.addLogEntry(dcMessage, null, 'system');
+            result.game.broadcast(io, 'gameLogEntry', { message: dcMessage, type: 'system' });
+
+            return;
+        }
+
         const player = result.game.getPlayerByPosition(position);
         const username = player?.username || `Player ${position}`;
 


### PR DESCRIPTION
## Summary
- Restore visual trick stacks and use server-provided `leadPosition` on rejoin
- Support `isTrumpBroken` alias and `tricks` object format in client GameState restore
- Auto-draw for players who disconnect during draw phase so the game continues
- Include `leadPosition` in server reconnect payload
- Add new splash phrases to sign-in screen

## Test plan
- [ ] Disconnect and rejoin mid-game — trick counts, lead position, and trump broken state should restore correctly
- [ ] Disconnect during draw phase — game should auto-draw and continue
- [ ] Run `npm test` and `npm run test:client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)