### PR TITLE
Fix mic selector audio loss and add speaker test button

### DIFF
--- a/client/src/ui/components/VoiceChatUI.js
+++ b/client/src/ui/components/VoiceChatUI.js
@@ -214,6 +214,31 @@ async function toggleDevicePopover() {
     popover.appendChild(item);
   }
 
+  // Divider
+  const divider = document.createElement('div');
+  divider.style.cssText = 'height: 1px; background: rgba(255, 255, 255, 0.1); margin: 4px 0;';
+  popover.appendChild(divider);
+
+  // Speaker test button
+  const testBtn = document.createElement('div');
+  testBtn.style.cssText = `
+    padding: 8px 14px;
+    color: #aaa;
+    font-size: 13px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  `;
+  testBtn.innerHTML = `<span style="flex-shrink:0">${getSpeakerIcon()}</span><span>Test Speakers</span>`;
+  testBtn.addEventListener('mouseenter', () => { testBtn.style.background = 'rgba(255,255,255,0.1)'; });
+  testBtn.addEventListener('mouseleave', () => { testBtn.style.background = 'none'; });
+  testBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    voiceManager.playTestTone();
+  });
+  popover.appendChild(testBtn);
+
   // Position above the device button, right-aligned so it doesn't overflow left
   const btn = document.getElementById('voice-device-btn');
   if (btn) {
@@ -245,6 +270,13 @@ function getGearIcon() {
   return `<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="12" r="3"></circle>
     <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+  </svg>`;
+}
+
+function getSpeakerIcon() {
+  return `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+    <path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"></path>
   </svg>`;
 }
 

--- a/client/src/voice/VoiceChatManager.js
+++ b/client/src/voice/VoiceChatManager.js
@@ -354,29 +354,55 @@ export class VoiceChatManager {
   async switchAudioDevice(deviceId) {
     if (!this.active) return;
 
+    const oldStream = this.localStream;
+
     // Get new stream from selected device
-    const newStream = await navigator.mediaDevices.getUserMedia({
-      audio: { deviceId: { exact: deviceId } }
-    });
+    let newStream;
+    try {
+      newStream = await navigator.mediaDevices.getUserMedia({
+        audio: { deviceId: { exact: deviceId } }
+      });
+    } catch (err) {
+      console.warn('[Voice] Failed to get new audio device:', err.message);
+      throw err;
+    }
+
     const newTrack = newStream.getAudioTracks()[0];
 
-    // Stop old tracks
-    if (this.localStream) {
-      this.localStream.getAudioTracks().forEach(t => t.stop());
+    // Re-apply mute state to the new track before connecting
+    if (this.selfMuted) {
+      newTrack.enabled = false;
     }
-    this.localStream = newStream;
 
-    // Replace track on all peer connections (no renegotiation needed)
-    for (const [, peer] of this.peers) {
-      const senders = peer.connection.getSenders();
-      const audioSender = senders.find(s => s.track?.kind === 'audio' || s.track === null);
-      if (audioSender) {
-        await audioSender.replaceTrack(newTrack);
+    try {
+      // Replace track on all peer connections BEFORE stopping old tracks
+      for (const [, peer] of this.peers) {
+        const senders = peer.connection.getSenders();
+        const audioSender = senders.find(s => s.track?.kind === 'audio' || s.track === null);
+        if (audioSender) {
+          await audioSender.replaceTrack(newTrack);
+        }
       }
+    } catch (err) {
+      // Rollback: stop the new stream and leave old one intact
+      console.warn('[Voice] replaceTrack failed, rolling back:', err.message);
+      newStream.getTracks().forEach(t => t.stop());
+      throw err;
     }
 
-    // Recreate self analyser with new stream
-    this._analysers.delete('self');
+    // All replacements succeeded — now safe to stop old tracks
+    this.localStream = newStream;
+    if (oldStream) {
+      oldStream.getAudioTracks().forEach(t => t.stop());
+    }
+
+    // Resume AudioContext if suspended (some browsers suspend after getUserMedia)
+    if (this._audioContext?.state === 'suspended') {
+      await this._audioContext.resume().catch(() => {});
+    }
+
+    // Properly disconnect old analyser source node, then create new one
+    this._cleanupAnalyser('self');
     this._addAnalyser('self', newStream);
 
     // Reconnect relay processor to new stream if relay is active
@@ -387,11 +413,42 @@ export class VoiceChatManager {
       this._relaySource = this._audioContext.createMediaStreamSource(newStream);
       this._relaySource.connect(this._relayProcessor);
     }
+  }
 
-    // Re-apply mute state
-    if (this.selfMuted) {
-      newTrack.enabled = false;
-    }
+  /**
+   * Play a short test tone (~300ms, 440Hz) through the speakers.
+   * @returns {Promise<void>} Resolves when the tone finishes.
+   */
+  playTestTone() {
+    this._setupAudioContext();
+    const ctx = this._audioContext;
+    if (!ctx) return Promise.resolve();
+
+    // Resume if suspended (user gesture requirement)
+    const ready = ctx.state === 'suspended' ? ctx.resume() : Promise.resolve();
+
+    return ready.then(() => {
+      const duration = 0.3;
+      const oscillator = ctx.createOscillator();
+      const gain = ctx.createGain();
+
+      oscillator.type = 'sine';
+      oscillator.frequency.value = 440;
+
+      gain.gain.setValueAtTime(0.15, ctx.currentTime);
+      // Ramp down for a clean end
+      gain.gain.linearRampToValueAtTime(0, ctx.currentTime + duration);
+
+      oscillator.connect(gain);
+      gain.connect(ctx.destination);
+
+      oscillator.start(ctx.currentTime);
+      oscillator.stop(ctx.currentTime + duration);
+
+      return new Promise(resolve => {
+        oscillator.onended = resolve;
+      });
+    });
   }
 
   /**
@@ -524,7 +581,7 @@ export class VoiceChatManager {
     }
 
     this._gainNodes.delete(socketId);
-    this._analysers.delete(socketId);
+    this._cleanupAnalyser(socketId);
     this._speakingStates.delete(socketId);
     this._speakingLastActive.delete(socketId);
 
@@ -563,7 +620,7 @@ export class VoiceChatManager {
     }
 
     // Remove P2P analyser — speaking detection for relay uses RMS from received PCM
-    this._analysers.delete(socketId);
+    this._cleanupAnalyser(socketId);
 
     this._relayedPeers.add(socketId);
     this._ensureRelayCapture();
@@ -720,10 +777,22 @@ export class VoiceChatManager {
       source.connect(analyser);
 
       const dataArray = new Float32Array(analyser.fftSize);
-      this._analysers.set(id, { analyser, dataArray });
+      this._analysers.set(id, { analyser, dataArray, source });
     } catch (err) {
       console.warn('Failed to create analyser for', id, err.message);
     }
+  }
+
+  /**
+   * Properly clean up an analyser entry by disconnecting its Web Audio source node.
+   */
+  _cleanupAnalyser(id) {
+    const entry = this._analysers.get(id);
+    if (!entry) return;
+    try {
+      entry.source?.disconnect();
+    } catch (e) { /* already disconnected */ }
+    this._analysers.delete(id);
   }
 
   _startSpeakingDetection() {


### PR DESCRIPTION
## Summary
- **Fix mic selector bug**: Rewrote `switchAudioDevice()` to replace tracks on all peers *before* stopping the old stream, with full rollback on failure. Previously, the old stream was destroyed first, so any `replaceTrack()` failure left audio permanently broken.
- **Fix Web Audio leak**: Added `_cleanupAnalyser()` helper that properly disconnects the `MediaStreamSource` node before removing analyser entries. Previously only the map entry was deleted, leaving orphaned nodes attached to stopped streams.
- **Resume AudioContext**: After `getUserMedia`, some browsers suspend the AudioContext — now explicitly resumed during device switch.
- **Add speaker test**: New `playTestTone()` method (440Hz, 300ms ping) and a "Test Speakers" button in the mic selector popover so users can verify audio output.

## Test plan
- [ ] Join a voice-enabled lobby with multiple players
- [ ] Open mic selector (gear button) and switch to a different mic — verify audio continues working for all peers
- [ ] Switch back to the original mic — verify audio is restored
- [ ] Click "Test Speakers" in the popover — verify a short ping tone is audible
- [ ] Verify mute state persists correctly across device switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)