### PR TITLE
Add bags records, population row, and total games count

### DIFF
--- a/client/src/handlers/recordsHandlers.js
+++ b/client/src/handlers/recordsHandlers.js
@@ -22,7 +22,7 @@ export function registerRecordsHandlers(socketManager, callbacks = {}) {
   socketManager.on('recordsResponse', (data) => {
     if (data.success) {
       console.log('Records received');
-      onRecordsReceived?.(data.records);
+      onRecordsReceived?.(data.records, data.totalGames);
     } else {
       console.warn('Records fetch failed:', data.message);
       onRecordsError?.(data.message || 'Failed to fetch records');

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -3167,8 +3167,8 @@ function initializeApp() {
       showError(message || 'Failed to load leaderboard');
     },
     // Records callbacks
-    onRecordsReceived: (records) => {
-      showRecordsPage(records);
+    onRecordsReceived: (records, totalGames) => {
+      showRecordsPage(records, totalGames);
     },
     onRecordsError: (message) => {
       showError(message || 'Failed to load records');

--- a/client/src/ui/screens/LeaderboardPage.js
+++ b/client/src/ui/screens/LeaderboardPage.js
@@ -207,21 +207,34 @@ function renderTableBody(tbody, data) {
 
   const sortedData = sortLeaderboard(data);
 
-  sortedData.forEach((player, index) => {
+  let rank = 0;
+  sortedData.forEach((player) => {
+    const isPopulation = player.isPopulation;
+    if (!isPopulation) rank++;
+
     const tr = document.createElement('tr');
     tr.style.transition = 'background 0.2s';
+    const defaultBg = isPopulation ? 'rgba(96, 165, 250, 0.1)' : 'transparent';
+    tr.style.background = defaultBg;
     tr.addEventListener('mouseenter', () => {
-      tr.style.background = 'rgba(255, 255, 255, 0.05)';
+      tr.style.background = isPopulation ? 'rgba(96, 165, 250, 0.18)' : 'rgba(255, 255, 255, 0.05)';
     });
     tr.addEventListener('mouseleave', () => {
-      tr.style.background = 'transparent';
+      tr.style.background = defaultBg;
     });
 
     // Rank
-    tr.appendChild(createDataCell(index + 1));
+    tr.appendChild(createDataCell(isPopulation ? '\u2014' : rank));
 
-    // Player (avatar + username)
-    tr.appendChild(createDataCell(createPlayerCell(player), 'left'));
+    // Player (avatar + username, or "Population" label)
+    if (isPopulation) {
+      const popLabel = document.createElement('span');
+      popLabel.innerText = 'Population';
+      popLabel.style.fontWeight = 'bold';
+      tr.appendChild(createDataCell(popLabel, 'left'));
+    } else {
+      tr.appendChild(createDataCell(createPlayerCell(player), 'left'));
+    }
 
     // Stats columns
     tr.appendChild(createDataCell(formatStatValue(player.gamesPlayed, 'integer')));
@@ -232,6 +245,13 @@ function renderTableBody(tbody, data) {
     tr.appendChild(createDataCell(formatStatValue(player.setRate, 'percent')));
     tr.appendChild(createDataCell(formatStatValue(player.drag, 'decimal')));
     tr.appendChild(createDataCell(formatStatValue(player.avgHSI, 'decimal')));
+
+    // Bold all cells in population row
+    if (isPopulation) {
+      for (const td of tr.children) {
+        td.style.fontWeight = 'bold';
+      }
+    }
 
     tbody.appendChild(tr);
   });

--- a/client/src/ui/screens/RecordsPage.js
+++ b/client/src/ui/screens/RecordsPage.js
@@ -49,6 +49,19 @@ function createRecordEntry(label, color, data, type) {
     playersEl.style.fontSize = '12px';
     playersEl.style.color = '#9ca3af';
     entry.appendChild(playersEl);
+  } else if (type === 'bags') {
+    const bagsEl = document.createElement('div');
+    bagsEl.innerText = `${data.bags} bags`;
+    bagsEl.style.fontSize = '20px';
+    bagsEl.style.fontWeight = 'bold';
+    bagsEl.style.color = '#fff';
+    entry.appendChild(bagsEl);
+
+    const playersEl = document.createElement('div');
+    playersEl.innerText = data.players.join(' & ');
+    playersEl.style.fontSize = '12px';
+    playersEl.style.color = '#9ca3af';
+    entry.appendChild(playersEl);
   } else if (type === 'win') {
     const marginEl = document.createElement('div');
     marginEl.innerText = `${data.margin} pt margin`;
@@ -122,6 +135,8 @@ function createPeriodBox(title, periodData) {
   box.appendChild(createRecordEntry('Highest Score', '#4ade80', periodData.highestScore, 'score'));
   box.appendChild(createRecordEntry('Lowest Score', '#f87171', periodData.lowestScore, 'score'));
   box.appendChild(createRecordEntry('Biggest Win', '#fbbf24', periodData.biggestWin, 'win'));
+  box.appendChild(createRecordEntry('Most Bags', '#fb923c', periodData.mostBags, 'bags'));
+  box.appendChild(createRecordEntry('Least Bags', '#a78bfa', periodData.leastBags, 'bags'));
 
   return box;
 }
@@ -131,7 +146,7 @@ function createPeriodBox(title, periodData) {
  *
  * @param {Object} records - Records data with allTime, thisYear, thisMonth
  */
-export function showRecordsPage(records) {
+export function showRecordsPage(records, totalGames) {
   // Remove any existing records page
   removeRecordsPage();
 
@@ -205,6 +220,24 @@ export function showRecordsPage(records) {
   headerRow.appendChild(closeBtn);
 
   modal.appendChild(headerRow);
+
+  // Total games played
+  if (totalGames != null) {
+    const totalRow = document.createElement('div');
+    totalRow.style.textAlign = 'center';
+    totalRow.style.marginBottom = '16px';
+    totalRow.style.fontSize = '14px';
+    totalRow.style.color = '#9ca3af';
+
+    const countSpan = document.createElement('span');
+    countSpan.innerText = totalGames.toLocaleString();
+    countSpan.style.color = '#e5e7eb';
+    countSpan.style.fontWeight = 'bold';
+
+    totalRow.appendChild(countSpan);
+    totalRow.appendChild(document.createTextNode(' games played'));
+    modal.appendChild(totalRow);
+  }
 
   // Three boxes row
   const boxesRow = document.createElement('div');

--- a/server/socket/profileHandlers.js
+++ b/server/socket/profileHandlers.js
@@ -210,12 +210,21 @@ async function recordGameResult(game) {
             .filter(p => p && p.username)
             .map(p => p.username);
 
+        // Calculate team-level bags (total tricks taken minus total tricks bid)
+        const ps = game.playerStats || {};
+        const team1Bags = ((ps[1]?.totalTricks || 0) + (ps[3]?.totalTricks || 0))
+            - ((ps[1]?.totalBids || 0) + (ps[3]?.totalBids || 0));
+        const team2Bags = ((ps[2]?.totalTricks || 0) + (ps[4]?.totalTricks || 0))
+            - ((ps[2]?.totalBids || 0) + (ps[4]?.totalBids || 0));
+
         await gameRecordsCollection.insertOne({
             gameId: game.gameId,
             team1Score: game.score.team1,
             team2Score: game.score.team2,
             team1Players,
             team2Players,
+            team1Bags,
+            team2Bags,
             completedAt: new Date()
         });
 
@@ -404,6 +413,25 @@ async function getLeaderboard(socket, io) {
             };
         });
 
+        // Compute population averages
+        if (leaderboard.length > 0) {
+            const n = leaderboard.length;
+            const sum = (key) => leaderboard.reduce((acc, p) => acc + p[key], 0);
+            leaderboard.push({
+                username: 'Population',
+                isPopulation: true,
+                gamesPlayed: Math.round(sum('gamesPlayed') / n),
+                winRate: sum('winRate') / n,
+                pointsPerGame: sum('pointsPerGame') / n,
+                bidsPerGame: sum('bidsPerGame') / n,
+                tricksPerBid: sum('tricksPerBid') / n,
+                setRate: sum('setRate') / n,
+                drag: sum('drag') / n,
+                faultsPerGame: sum('faultsPerGame') / n,
+                avgHSI: sum('avgHSI') / n
+            });
+        }
+
         // Sort by win rate descending by default
         leaderboard.sort((a, b) => b.winRate - a.winRate);
 
@@ -560,6 +588,8 @@ async function getRecords(socket, io) {
             let highestScore = null;
             let lowestScore = null;
             let biggestWin = null;
+            let mostBags = null;
+            let leastBags = null;
 
             for (const game of games) {
                 // Check both teams for highest/lowest individual team score
@@ -589,12 +619,32 @@ async function getRecords(socket, io) {
                         loserPlayers: winnerIsTeam1 ? game.team2Players : game.team1Players
                     };
                 }
+
+                // Most/least bags — skip legacy records without bags data
+                if (game.team1Bags != null && game.team2Bags != null) {
+                    const bagsEntries = [
+                        { bags: game.team1Bags, players: game.team1Players },
+                        { bags: game.team2Bags, players: game.team2Players }
+                    ];
+
+                    for (const entry of bagsEntries) {
+                        if (!mostBags || entry.bags > mostBags.bags) {
+                            mostBags = { bags: entry.bags, players: entry.players };
+                        }
+                        if (!leastBags || entry.bags < leastBags.bags) {
+                            leastBags = { bags: entry.bags, players: entry.players };
+                        }
+                    }
+                }
             }
 
-            records[period] = { highestScore, lowestScore, biggestWin };
+            records[period] = { highestScore, lowestScore, biggestWin, mostBags, leastBags };
         }
 
-        socket.emit('recordsResponse', { success: true, records });
+        // Total games played (all time count)
+        const totalGames = (await gameRecordsCollection.countDocuments({}));
+
+        socket.emit('recordsResponse', { success: true, records, totalGames });
         authLogger.debug('Records fetched');
     } catch (error) {
         authLogger.error('Error fetching records', { error: error.message });


### PR DESCRIPTION
## Summary
- Add **Most Bags / Least Bags** records to the Records page across all three time periods (All Time, This Year, This Month), with team players shown
- Add a bolded **Population** row to the Leaderboard showing average stats across all players, sorting alongside regular entries
- Show **total games played** count at the top of the Records page

## Test plan
- [x] Server tests pass (`npm test` — 214/214)
- [ ] Open Records page and verify Most Bags / Least Bags entries appear (will show "No games yet" for legacy records without bags data)
- [ ] Open Records page and verify total games count displays in the header
- [ ] Open Leaderboard and verify Population row appears with bolded text, blue-tinted background, and dash for rank
- [ ] Sort leaderboard columns and verify Population row sorts correctly with other entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)