### PR TITLE
Fix tournament mode and add App Store compliance features

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -1,269 +1,134 @@
-# BAB Online
+# BAB Online - Claude Context Document
 
-A 4-player online multiplayer trick-taking card game (Back Alley Bridge). Players bid on tricks, with special scoring for "rainbow" hands (all 4 suits). Hand progression: 12→10→8→6→4→2→1→3→5→7→9→11→13, then game ends. Teams: Positions 1 & 3 vs Positions 2 & 4.
+This document helps Claude understand the project quickly in new sessions.
 
-> **Complete game rules**: See [docs/RULES.md](docs/RULES.md) for detailed rules including bidding, bore mechanics, trump, and scoring.
+## What is this?
 
-## Technology Stack
+BAB Online is a 4-player online multiplayer trick-taking card game ("Back Alley Bridge"). Players form 2 teams (positions 1&3 vs 2&4) and compete across 13 hands with varying card counts.
 
-- **Web Frontend**: Phaser 3.55.2 (game engine), ES6 Modules, Socket.io 4.0.1, Vite (build)
-- **iOS Client**: SwiftUI + SpriteKit, Socket.IO-Client-Swift 16, Combine, iOS 17+
-- **Backend**: Node.js 18+, Express.js 4.21.2, Socket.IO 4.8.1
-- **Database**: MongoDB with Mongoose 8.12.1
-- **Security**: Helmet, bcryptjs for password hashing
-- **Testing**: Vitest (client), Jest (server)
-- **Deployment**: Railway.app
+**See `docs/RULES.md` for complete game rules.**
 
-## Project Structure
+## Tech Stack
+
+- **Frontend**: Phaser 3 (game engine), ES6 modules, Socket.IO client, Vite bundler
+- **Backend**: Node.js 18+, Express.js, Socket.IO server
+- **Database**: MongoDB (native client, no ORM)
+- **Testing**: Jest (server), Vitest (client)
+- **Deployment**: Railway.app via GitHub Actions
+
+## Directory Structure
 
 ```
 bab-online/
-├── client/                             # Web client (Phaser + Vite)
+├── client/                     # Frontend
 │   ├── src/
-│   │   ├── main.js                     # Entry point, wires callbacks to GameScene
-│   │   ├── constants/                  # events.js, ranks.js
-│   │   ├── utils/                      # positions.js, cards.js, colors.js
-│   │   ├── rules/                      # legality.js - card play validation
-│   │   ├── state/                      # GameState.js - client state singleton
-│   │   ├── socket/                     # SocketManager.js - connection management
-│   │   ├── handlers/                   # Socket event handlers (auth, game, chat, lobby, profile, leaderboard, tournament)
-│   │   ├── phaser/
-│   │   │   ├── PhaserGame.js           # Game instance wrapper
-│   │   │   ├── scenes/GameScene.js     # Main game scene
-│   │   │   └── managers/               # Card, Trick, Opponent, Effects, Draw, Bid, Layout
-│   │   └── ui/
-│   │       ├── UIManager.js            # DOM lifecycle management
-│   │       ├── components/             # Modal, Toast, BidUI, GameLog, ChatBubble, ScoreModal, TournamentScoreboard
-│   │       └── screens/               # SignIn, Register, MainRoom, GameLobby, TournamentLobby, ProfilePage, LeaderboardPage
-│   ├── styles/components.css           # All UI styles
-│   └── assets/                         # Card images, backgrounds
-├── iOSClient/BABOnline/                # iOS client (SwiftUI + SpriteKit)
-│   ├── BABOnlineApp.swift              # App entry, environment objects, scene phase handling
-│   ├── AppState.swift                  # Screen navigation state
-│   ├── ContentView.swift               # Root view switch + session restore
-│   ├── Constants/                      # CardConstants, LayoutConstants, SocketEvents
-│   ├── Extensions/                     # Color+Theme, View+Haptics
-│   ├── Models/                         # Card, ChatMessage, Lobby, Player, ScoreData, Tournament
-│   ├── Networking/
-│   │   ├── SocketService.swift         # Socket.IO connection, forceReconnect on foreground
-│   │   ├── SocketEventRouter.swift     # Routes incoming events to handlers
-│   │   ├── Emitters/                   # Auth, Chat, Game, Lobby, Tournament emitters
-│   │   └── Handlers/                   # Auth, Chat, Game, Lobby, Tournament socket handlers
-│   ├── Rules/CardLegality.swift        # Card play validation (mirrors server rules.js)
-│   ├── State/                          # AuthState, GameState, LobbyState, MainRoomState, TournamentState
-│   ├── SpriteKit/
-│   │   ├── GameSKScene.swift           # Main scene, Combine subscriptions to GameState
-│   │   ├── CardTextureGenerator.swift  # Programmatic card rendering
-│   │   ├── Managers/                   # SKCard, SKTrick, SKBid, SKDraw, SKOpponent, SKEffects managers
-│   │   ├── Nodes/                      # CardSprite, HandNode, TrickArea, BidBubble, Avatar, OpponentHand, TrickHistory
-│   │   └── Actions/CardAnimations.swift
-│   ├── Utils/                          # CardUtils, Positions, HapticManager, UsernameColor
-│   └── Views/
-│       ├── Auth/                       # SignInView, RegisterView
-│       ├── Components/                 # ConnectionStatusToast
-│       ├── Game/                       # GameContainerView, BidOverlayView, DrawPhaseView, GameEndView, GameLogView, ScoreBarView, DisconnectBannerView
-│       ├── GameLobby/                  # GameLobbyView, LobbyChatView, LobbyPlayerRow
-│       ├── MainRoom/                   # MainRoomView, MainRoomChatView, LobbyListView
-│       └── Tournament/                 # TournamentLobbyView, PlayerList, Chat, Scoreboard, ActiveGames, Results
-├── server/
-│   ├── index.js                        # Entry point
-│   ├── game/
-│   │   ├── Deck.js                     # Card deck with shuffle
-│   │   ├── GameState.js                # Per-game state + room management
-│   │   ├── GameManager.js              # Queue, lobby, game coordination, in-progress listing
-│   │   ├── TournamentState.js          # Per-tournament state + round management
-│   │   ├── rules.js                    # Pure game logic functions
-│   │   └── bot/                        # Bot player system
-│   │       ├── BotPlayer.js            # Bot player class with card memory
-│   │       ├── BotController.js        # Singleton managing bot lifecycle
-│   │       ├── BotStrategy.js          # Pure strategy functions
-│   │       └── personalities.js        # Bot personality definitions
-│   ├── socket/
-│   │   ├── index.js                    # Socket event routing
-│   │   ├── authHandlers.js             # signIn, signUp
-│   │   ├── mainRoomHandlers.js         # Main room, lobby browser, spectator join
-│   │   ├── queueHandlers.js            # joinQueue, disconnect grace period
-│   │   ├── lobbyHandlers.js            # playerReady, lobbyChat, leaveLobby
-│   │   ├── gameHandlers.js             # playCard, playerBid, draw, forceResign
-│   │   ├── reconnectHandlers.js        # rejoinGame for mid-game reconnection
-│   │   ├── chatHandlers.js             # chatMessage, slash commands (/lazy, /active, /leave)
-│   │   ├── profileHandlers.js          # Profile and leaderboard events
-│   │   ├── tournamentHandlers.js       # Tournament lifecycle events
-│   │   ├── validators.js               # Joi validation schemas
-│   │   ├── errorHandler.js             # Handler wrappers with rate limiting
-│   │   └── rateLimiter.js              # Per-socket rate limiting
-│   ├── routes/index.js                 # Express routes, /health
-│   ├── utils/                          # timing.js, logger.js, errors.js, shutdown.js
-│   └── database.js                     # MongoDB connection
-├── docs/
-│   ├── RULES.md                        # Complete game rules
-│   ├── bot-strategy-guide.md           # Bot strategy reference
-│   └── todos/                          # Improvement roadmap
-└── scripts/build-atlas.js              # Sprite atlas builder
+│   │   ├── constants/         # Event names, card ranks, hand progression
+│   │   ├── utils/             # Position math, card helpers
+│   │   ├── rules/             # Card legality (mirrors server)
+│   │   ├── state/             # GameState singleton
+│   │   ├── socket/            # SocketManager (connection + listener cleanup)
+│   │   ├── handlers/          # Socket event handlers by domain
+│   │   ├── phaser/            # Game rendering
+│   │   │   ├── scenes/        # GameScene (main Phaser scene)
+│   │   │   └── managers/      # CardManager, TrickManager, BidManager, etc.
+│   │   └── ui/                # DOM-based UI (screens, components)
+│   └── assets/                # Card images, sprites
+│
+├── server/                     # Backend
+│   ├── game/                  # Core game logic
+│   │   ├── rules.js           # Pure functions: card comparison, legality, scoring
+│   │   ├── Deck.js            # Card deck with Fisher-Yates shuffle
+│   │   ├── GameState.js       # Game state encapsulation
+│   │   ├── GameManager.js     # Singleton: manages games, queue, lobbies
+│   │   └── bot/               # AI player system
+│   ├── socket/                # Socket.IO handlers by domain
+│   │   ├── gameHandlers.js    # Core gameplay (draw, bid, play)
+│   │   ├── lobbyHandlers.js   # Pre-game lobby
+│   │   ├── authHandlers.js    # Sign-in/up
+│   │   └── validators.js      # Joi validation schemas
+│   └── __tests__/             # Jest tests
+│
+└── docs/
+    └── RULES.md               # Complete game rules
 ```
 
-## Architecture Patterns
+## Key Architecture Patterns
 
-### Web Client
-- **Event Callbacks**: Socket events → `handlers/*.js` → `main.js` callbacks → `GameScene.handleX()` → Phaser managers
-- **Client State**: `GameState` singleton with event emitter (`handChanged`, `bidChanged`)
-- **Optimistic Updates**: Client updates UI immediately, rolls back on server rejection
-- **Socket Cleanup**: `SocketManager` tracks listeners via `onGame()`, cleaned up between games
-- **UI**: Phaser for game canvas, `UIManager` for DOM lifecycle
+**Server:**
+- `GameManager` singleton manages all active games and queue
+- `GameState` encapsulates all state for a single game
+- `rules.js` contains pure, stateless game logic functions (highly testable)
+- Socket handlers wrapped with validation, rate limiting, error handling
 
-### iOS Client
-- **Architecture**: SwiftUI views + SpriteKit game scene, MVVM-ish with `@Published` state objects
-- **State**: `@EnvironmentObject` for AuthState, AppState, LobbyState, MainRoomState, GameState, TournamentState, SocketService
-- **Reactive**: `GameState` uses `@Published` properties + Combine subjects; `GameSKScene` subscribes via `.sink`
-- **Socket Pattern**: `SocketEventRouter` dispatches to domain handlers → handlers update `@Published` state → SwiftUI/SpriteKit react
-- **Emitter Pattern**: Static methods on `AuthEmitter`, `GameEmitter`, `LobbyEmitter`, `ChatEmitter`, `TournamentEmitter` — access `SocketService.shared`
-- **Game Rendering**: SpriteKit scene with managers (SKCardManager, SKTrickManager, etc.) matching web client manager pattern
-- **Reconnection**: `BABOnlineApp` calls `forceReconnect()` on `scenePhase` change to `.active`; `ConnectionStatusToast` shows reconnecting/connected state
-- **Theme**: `Color.Theme.*` extension (background, surface, primary, warning, success, etc.)
+**Client:**
+- `GameState` singleton replaces global variables
+- `SocketManager` tracks listeners for cleanup (prevents memory leaks)
+- Manager pattern: specialized managers (CardManager, TrickManager, etc.)
+- Client-side validation mirrors server for immediate UI feedback
 
-### Shared
-- **Communication**: Socket.io bidirectional WebSocket (same server events for both clients)
-- **State**: Server-authoritative, `GameState` class per game instance
-- **Validation**: Server validates all actions; Joi schemas validate all socket event data
-- **Socket Rooms**: Game events broadcast only to game participants + spectators via `game.broadcast()`
-- **Game Logic**: Pure functions in `rules.js` for testability
+## Key Data Structures
 
-## Game Flow
-
-1. Authentication (signIn/signUp) → MongoDB users collection
-2. Main Room → Global chat, browse game lobbies, spectate in-progress games
-3. Game Lobby → 4 players chat and ready up; can add bot players (5 personalities)
-4. Draw phase → Players draw cards to determine positions; teams announced (1&3 vs 2&4)
-5. Hand progression (12→10→8→6→4→2→1→3→5→7→9→11→13) with bidding then playing
-6. Game end → Final scores, return to main room
-
-## Key Socket Events
-
-**Client → Server**: `signIn`, `signUp`, `joinMainRoom`, `mainRoomChat`, `createLobby`, `joinLobby`, `playerReady`, `lobbyChat`, `leaveLobby`, `addBot`, `removeBot`, `draw`, `playerBid`, `playCard`, `chatMessage`, `rejoinGame`, `forceResign`, `joinAsSpectator`, `getProfile`, `updateProfilePic`, `getLeaderboard`, `createTournament`, `joinTournament`, `leaveTournament`, `tournamentReady`, `beginTournament`, `beginNextRound`, `returnToTournament`
-
-**Server → Client**: `mainRoomJoined`, `mainRoomMessage`, `lobbiesUpdated`, `lobbyCreated`, `lobbyJoined`, `playerReadyUpdate`, `lobbyMessage`, `lobbyPlayerLeft`, `allPlayersReady`, `startDraw`, `playerDrew`, `youDrew`, `teamsAnnounced`, `positionUpdate`, `createUI`, `gameStart`, `bidReceived`, `doneBidding`, `cardPlayed`, `updateTurn`, `trickComplete`, `handComplete`, `gameEnd`, `rainbow`, `rejoinSuccess`, `rejoinFailed`, `playerDisconnected`, `playerReconnected`, `activeGameFound`, `resignationAvailable`, `playerResigned`, `playerLazyMode`, `playerActiveMode`, `gameLogEntry`, `leftGame`, `spectatorJoined`, `profileResponse`, `leaderboardResponse`, `restorePlayerState`, `tournamentCreated`, `tournamentJoined`, `tournamentRoundStart`, `tournamentGameAssignment`, `tournamentGameComplete`, `tournamentRoundComplete`, `tournamentComplete`
-
-## Disconnection, Resignation & Bot Takeover
-
-When a player disconnects mid-game:
-1. Server marks player as disconnected, starts **60-second** grace period
-2. Other players see "[username] disconnected - waiting for reconnection..."
-3. If player reconnects within 60 seconds: normal rejoin via `rejoinGame`
-4. If grace period expires: remaining players see a prompt to replace with a bot (`resignationAvailable`)
-5. Any player clicks "Replace with bot" → `forceResign` → bot takes over the hand
-6. Game stats are attributed to the original human player, not the bot
-7. Game only aborts if ALL human players disconnect
-
-### Cross-Browser/Device Reconnection
-Server stores `activeGameId` in MongoDB user document. On sign-in, checks for active game and emits `activeGameFound`. iOS client also restores session via stored credentials on app launch.
-
-## Slash Commands (In-Game)
-
-Players type these in the game log chat input (autocomplete appears when typing `/`):
-
-| Command | Behavior |
-|---------|----------|
-| `/lazy` | Bot takes over temporarily. Player stays as spectator (can see hand/chat, bot plays). Avatar switches to bot. |
-| `/active` | Take back control from bot. Avatar switches back. Only works for original players, not spectators. |
-| `/leave` | Bot takes over + player exits to main lobby. Can rejoin later and `/active` to resume. |
-
-Slash commands are intercepted in `chatHandlers.js` on the server. The `GameLog.js` component provides autocomplete with single-match auto-submit on Enter.
-
-### Lazy Mode State
-- `GameState.lazyPlayers`: tracks `position → { botSocketId, botUsername, originalUsername, ... }`
-- `triggerBotIfNeeded()` checks both `isBot()` and `isLazy()` to schedule bot actions
-- Same bot personality persists across lazy/active cycles per position
-
-## Spectator System
-
-Players can join in-progress games from the main room lobby panel:
-- `MainRoom.js` / `MainRoomView.swift` shows in-progress games with "Spectate" button
-- `joinAsSpectator` event → server sends full game state (no hand data) → client sets up read-only view
-- Spectators see tricks, bids, scores, game log; can chat (marked as spectator)
-- Pure spectators only see `/leave` in autocomplete; `/lazy` and `/active` are silently ignored
-- Lazy-mode players who used `/leave` and rejoined as spectators still see `/active` and `/leave`
-
-## Server Game State (`server/game/GameState.js`)
-
-Key fields beyond core game state:
-- `resignedPlayers`: `position → { username, pic, resignedAt }` — original human info for stats
-- `lazyPlayers`: `position → { botSocketId, botUsername, originalUsername, originalSocketId, ... }`
-- `spectators`: Map of `socketId → { username, pic }`
-- Key methods: `resignPlayer()`, `enableLazyMode()`, `disableLazyMode()`, `addSpectator()`, `removeSpectator()`, `isLazy()`, `isSpectator()`, `getOriginalPlayer()`
-
-## Card Data Structure
-
+**Card:**
 ```javascript
-{ suit: "spades|hearts|diamonds|clubs|joker", rank: "2"-"K"|"A"|"HI"|"LO" }
+{ suit: 'spades'|'hearts'|'diamonds'|'clubs'|'joker', rank: '2'-'A'|'HI'|'LO' }
 ```
 
-Deck: 52 standard cards + 2 jokers (HI and LO). iOS uses `Card` struct with `Suit` and `Rank` enums.
+**Server GameState:**
+- `players`: Map<socketId → {username, position, pic, isBot}>
+- `hands`: {socketId → card[]}, `bids`: {position → bid_value}
+- `phase`: 'waiting'|'drawing'|'bidding'|'playing'
+- `trump`: card, `isTrumpBroken`: boolean
+- `playedCards`: [pos1Card, pos2Card, pos3Card, pos4Card]
+- `tricks`: {team1: count, team2: count}
 
-## Scoring Rules
+**Bid Values:** '0'-'12' for numbers, 'B'/'2B'/'3B'/'4B' for bores (2x/4x/8x/16x multipliers)
 
-- Made bid: `+(bid × 10 × multiplier) + (tricks - bid) + (rainbows × 10)`
-- Missed bid: `-(bid × 10 × multiplier) + (rainbows × 10)`
-- Rainbow = 4-card hand containing all 4 suits (+10 points bonus)
-- Bore multipliers: B (2x), 2B (4x), 3B (8x), 4B (16x)
+## Game Flow (Socket Events)
 
-## Bot System
+1. **Auth**: `signIn`/`signUp` → `signInResponse`
+2. **Lobby**: `joinQueue` → `lobbyCreated` → `playerReadyUpdate` → `allPlayersReady`
+3. **Draw**: `startDraw` → `draw` → `playerDrew` → `teamsAnnounced`
+4. **Bidding**: `gameStart` → `updateTurn` → `playerBid` → `bidReceived` → `doneBidding`
+5. **Play**: `updateTurn` → `playCard` → `cardPlayed` → `trickComplete` → `handComplete`
+6. **End**: `gameEnd`
 
-5 personalities: Mary (balanced), Sharon (conservative), Danny (calculated risk-taker), Mike (overconfident), Zach (adaptive). Defined in `server/game/bot/personalities.js`.
+## Quick Game Rules Reference
 
-- Bots use `isBot: true` flag, identified by `socketId.startsWith('bot:')`
-- Auto-ready when lobby fills to 4 players
-- Partner-aware play: positions 1&3 and 2&4 are partners
-- Card memory tracking for strategic play
-- Random delays simulate human thinking time (500-1500ms)
-- Used for lobby fill, resignation replacement, and lazy mode
+- 54 cards (52 + HI/LO jokers), jokers are always trump
+- Hand sizes: 12→10→8→6→4→2→1→3→5→7→9→11→13
+- Must follow suit; trump can't lead until broken (unless hand is all trump)
+- HI joker forces opponents to play highest trump, partner plays lowest
+- Scoring: Made bid = (bid × 10 × multiplier) + overtricks; Set = -(bid × 10 × multiplier)
+- Rainbow bonus: +10 on 4-card hand if hand has all 4 suits
 
-## Tournament System
-
-4-round tournament with cumulative scoring. Managed by `TournamentState.js` on server and `tournamentHandlers.js`.
-
-- Creator creates tournament from main room → tournament lobby (unbounded player count)
-- Players join and ready up → creator begins tournament
-- Each round: players shuffled into games of 4 (bots fill remaining slots)
-- Round score = team's final game score; cumulative across 4 rounds
-- Highest total score wins
-
-## Development Commands
+## Commands
 
 ```bash
-npm run dev           # Development server with hot reload (port 3000)
-npm start             # Production server
-npm test              # Run server tests (Jest)
-npm run test:client   # Run client tests (Vitest)
-npm run build:client  # Build client modules (Vite)
-npm run build:atlas   # Generate sprite atlas
-npm run dev:client    # Vite dev server (port 5173, proxies to :3000)
+npm run dev          # Start server + client (hot reload)
+npm start            # Server only (port 3000)
+npm run dev:client   # Client Vite dev server (port 5173)
+npm run build:client # Production build
+
+npm test             # Server tests (Jest)
+npm run test:client  # Client tests (Vitest)
 ```
 
-Server runs on port 3000. Requires Node.js 18+.
+## Important Implementation Details
 
-iOS client: open `iOSClient/BABOnline.xcodeproj` in Xcode 15+, build for iOS 17+ device/simulator.
+- Bots have socketIds like `bot:{username}:{uuid}`, use `BotStrategy.js` for AI
+- Reconnection uses session tokens stored in MongoDB
+- Socket rooms: players join `game:{gameId}` for broadcasts
+- Event constants in `client/src/constants/events.js` prevent typos
+- Card legality logic duplicated in `server/game/rules.js` and `client/src/rules/legality.js`
 
-## Common Tasks
+## Common Files to Check
 
-### Adding Socket Events
-1. Add handler in appropriate `server/socket/*.js` file
-2. Register in `server/socket/index.js`
-3. **Web client**: Add listener in `client/src/handlers/*.js`, wire callback through `client/src/handlers/index.js` — destructure from callbacks AND pass to the correct `register*Handlers()` call. Add cleanup in `cleanupGameListeners()` for game-specific events.
-4. **iOS client**: Add handler in appropriate `iOSClient/BABOnline/Networking/Handlers/*SocketHandler.swift`, add emitter method in `Emitters/*.swift` if needed, update relevant `State/*.swift` `@Published` properties
-
-### Game Logic Changes
-- **Rules**: `server/game/rules.js` — pure functions
-- **State**: `server/game/GameState.js` — game state management
-- **Flow**: `server/socket/gameHandlers.js` — `playCard()`, `playerBid()`
-
-### Web UI Changes
-- **Styles**: `client/styles/components.css`
-- **Components**: `client/src/ui/components/`
-- **Screens**: `client/src/ui/screens/`
-- **Cards**: `client/src/phaser/managers/CardManager.js`
-
-### iOS UI Changes
-- **Views**: `iOSClient/BABOnline/Views/` — SwiftUI views organized by screen
-- **Theme**: `iOSClient/BABOnline/Extensions/Color+Theme.swift` — all colors
-- **Game visuals**: `iOSClient/BABOnline/SpriteKit/Managers/` — SK managers mirror web Phaser managers
-- **Game scene subscriptions**: `iOSClient/BABOnline/SpriteKit/GameSKScene.swift` — `subscribeToState()` wires Combine to managers
+| Task | Files |
+|------|-------|
+| Game rules/logic | `server/game/rules.js`, `docs/RULES.md` |
+| Card play handling | `server/socket/gameHandlers.js` |
+| Client card legality | `client/src/rules/legality.js` |
+| UI screens | `client/src/ui/screens/` |
+| Visual card display | `client/src/phaser/managers/CardManager.js` |
+| State management | `server/game/GameState.js`, `client/src/state/GameState.js` |
+| Socket events list | `client/src/constants/events.js` |

--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -62,6 +62,14 @@ export const CLIENT_EVENTS = {
   VOICE_ANSWER: 'voiceAnswer',
   VOICE_ICE_CANDIDATE: 'voiceIceCandidate',
   VOICE_RELAY_AUDIO: 'voiceRelayAudio',
+
+  // Account management
+  DELETE_ACCOUNT: 'deleteAccount',
+
+  // Safety / moderation
+  REPORT_USER: 'reportUser',
+  BLOCK_USER: 'blockUser',
+  UNBLOCK_USER: 'unblockUser',
 };
 
 // Server -> Client Events
@@ -71,6 +79,11 @@ export const SERVER_EVENTS = {
   SIGN_UP_RESPONSE: 'signUpResponse',
   FORCE_LOGOUT: 'forceLogout',
   ACTIVE_GAME_FOUND: 'activeGameFound',
+  DELETE_ACCOUNT_RESPONSE: 'deleteAccountResponse',
+
+  // Safety / moderation
+  REPORT_USER_RESPONSE: 'reportUserResponse',
+  BLOCK_LIST_UPDATED: 'blockListUpdated',
 
   // Main Room
   MAIN_ROOM_JOINED: 'mainRoomJoined',

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -30,7 +30,7 @@ import { createSignInScreen, showSignInScreen } from './ui/screens/SignIn.js';
 import { createRegisterScreen, showRegisterScreen } from './ui/screens/Register.js';
 import { showMainRoom, addMainRoomChatMessage, updateLobbyList, removeMainRoom, updateMainRoomOnlineCount, getMainRoomUserColors } from './ui/screens/MainRoom.js';
 import { showGameLobby, updateLobbyPlayersList, addLobbyChatMessage, removeGameLobby, getCurrentLobbyId, getIsPlayerReady, getLobbyUserColors } from './ui/screens/GameLobby.js';
-import { showProfilePage, updateProfilePicDisplay, updateCustomProfilePicDisplay, removeProfilePage, isProfilePageVisible, showPlayerProfilePage } from './ui/screens/ProfilePage.js';
+import { showProfilePage, updateProfilePicDisplay, updateCustomProfilePicDisplay, removeProfilePage, isProfilePageVisible, showPlayerProfilePage, showDeleteAccountError } from './ui/screens/ProfilePage.js';
 import { showLeaderboardPage, removeLeaderboardPage, isLeaderboardPageVisible } from './ui/screens/LeaderboardPage.js';
 import { showRecordsPage, removeRecordsPage } from './ui/screens/RecordsPage.js';
 import { updatePlayerSearchResults } from './ui/screens/PlayerSearchPage.js';
@@ -1414,7 +1414,56 @@ socket.on('rejoinSuccess', (data) => {
   // Also remove main room and lobby if present
   removeMainRoom();
   removeGameLobby();
+
+  // Restore tournament context (server includes it when the rejoined game
+  // belongs to a tournament) so the game-end screen offers 'Return to Tournament'
+  if (data.tournamentId !== undefined) {
+    getGameState().tournamentId = data.tournamentId;
+  }
   // Note: State restoration and UI rebuild handled by gameHandlers onRejoinSuccess callback
+});
+
+// Blocked users — chat from these usernames is hidden locally. Populated from
+// signInResponse/restoreSessionResponse and kept in sync via blockListUpdated.
+const blockedUsers = new Set();
+
+export function isUserBlocked(username) {
+  return blockedUsers.has(username);
+}
+
+export function setBlockedUsers(list) {
+  blockedUsers.clear();
+  (list || []).forEach(u => blockedUsers.add(u));
+}
+
+socket.on('blockListUpdated', (data) => {
+  if (data.success) {
+    setBlockedUsers(data.blockedUsers);
+    showInfo('Block list updated');
+  } else {
+    showError(data.message || 'Failed to update block list');
+  }
+});
+
+socket.on('reportUserResponse', (data) => {
+  if (data.success) {
+    showSuccess('Report submitted. Thank you — we review all reports.');
+  } else {
+    showError(data.message || 'Failed to submit report');
+  }
+});
+
+// Account deletion (in-app, required by App Store Guideline 5.1.1(v))
+socket.on('deleteAccountResponse', (data) => {
+  if (data.success) {
+    sessionStorage.removeItem('username');
+    sessionStorage.removeItem('sessionToken');
+    sessionStorage.removeItem('gameId');
+    sessionStorage.removeItem('spectatingGameId');
+    window.location.reload();
+  } else {
+    showDeleteAccountError(data.message || 'Account deletion failed');
+  }
 });
 
 socket.on('rejoinFailed', (data) => {
@@ -2002,6 +2051,7 @@ function initializeApp() {
       console.log('Sign in success, going to main room');
       gameState.username = data.username;
       uiManager.setUsername(data.username);
+      setBlockedUsers(data.blockedUsers);
       // Reset rejoin flags for fresh session
       rejoinAttempted = false;
       rejoinSucceeded = false;
@@ -2029,6 +2079,8 @@ function initializeApp() {
         console.log(`Registration & auto-login successful: ${data.username}`);
         gameState.username = data.username;
         uiManager.setUsername(data.username);
+        // Fresh account, fresh block list (don't inherit a prior session's)
+        setBlockedUsers([]);
         socket.emit('joinMainRoom');
       } else {
         showSuccess('Registration successful! Please sign in.');
@@ -2073,6 +2125,7 @@ function initializeApp() {
       sessionStorage.removeItem('gameId');
       sessionStorage.removeItem('spectatingGameId');
       gameState.reset();
+      setBlockedUsers([]);
 
       // Show sign-in screen
       displaySignInScreen();
@@ -2095,6 +2148,10 @@ function initializeApp() {
         return;
       }
       console.log('Joined main room, showing UI');
+      // Hide replayed chat history from blocked users
+      if (data.messages) {
+        data.messages = data.messages.filter(m => !isUserBlocked(m.username));
+      }
       // Clear modular sign-in/register screens (with dashes)
       const signInContainer = document.getElementById('sign-in-container');
       if (signInContainer) signInContainer.remove();
@@ -2113,6 +2170,7 @@ function initializeApp() {
       showMainRoom(data, socket);
     },
     onMainRoomMessage: (data) => {
+      if (isUserBlocked(data.username)) return;
       addMainRoomChatMessage(data.username, data.message, data.timestamp);
     },
     onLobbiesUpdated: (data) => {
@@ -2132,7 +2190,11 @@ function initializeApp() {
       console.log('Lobby created, showing lobby UI');
       removeMainRoom();
       showGameLobby(
-        { lobbyId: data.lobbyId, players: data.players, messages: data.messages || [] },
+        {
+          lobbyId: data.lobbyId,
+          players: data.players,
+          messages: (data.messages || []).filter(m => !isUserBlocked(m.username))
+        },
         socket,
         gameState.username
       );
@@ -2148,7 +2210,11 @@ function initializeApp() {
       console.log('Joined lobby, showing lobby UI');
       removeMainRoom();
       showGameLobby(
-        { lobbyId: data.lobbyId, players: data.players, messages: data.messages || [] },
+        {
+          lobbyId: data.lobbyId,
+          players: data.players,
+          messages: (data.messages || []).filter(m => !isUserBlocked(m.username))
+        },
         socket,
         gameState.username
       );
@@ -2157,6 +2223,7 @@ function initializeApp() {
       updateLobbyPlayersList(null, data.players, gameState.username);
     },
     onLobbyMessage: (data) => {
+      if (isUserBlocked(data.username)) return;
       addLobbyChatMessage(data.username, data.message);
     },
     onLobbyPlayerLeft: (data) => {
@@ -2748,9 +2815,16 @@ function initializeApp() {
       const { teamName, oppName } = getTeamNames(position, playerData);
       window.updateGameLogScoreFromLegacy(teamName, oppName, teamScore, oppScore);
 
-      // Determine return flow: tournament game returns to tournament, normal game to main room
-      const isTournamentGame = !!data.tournamentId || !!gameState.tournamentId;
-      const savedTournamentId = data.tournamentId || gameState.tournamentId;
+      // Determine return flow: tournament game returns to tournament, normal game to main room.
+      // The server always includes tournamentId in gameEnd (null for casual
+      // games), so prefer it — a stale local tournamentId from a previous
+      // tournament must not hijack a casual game's end screen.
+      const isTournamentGame = data.tournamentId !== undefined
+        ? !!data.tournamentId
+        : !!gameState.tournamentId;
+      const savedTournamentId = data.tournamentId !== undefined
+        ? data.tournamentId
+        : gameState.tournamentId;
 
       // Show final score overlay
       showFinalScoreOverlay({
@@ -3112,6 +3186,8 @@ function initializeApp() {
 
     // Chat callback - add to game feed and show bubble
     onChatMessage: (data) => {
+      if (data.username && isUserBlocked(data.username)) return;
+
       const scene = getGameScene();
       const state = getGameState();
 
@@ -3157,7 +3233,7 @@ function initializeApp() {
       updatePlayerSearchResults(players);
     },
     onPlayerProfileReceived: (profile) => {
-      showPlayerProfilePage(profile);
+      showPlayerProfilePage(profile, socket, { isBlocked: isUserBlocked(profile.username) });
     },
     // Leaderboard callbacks
     onLeaderboardReceived: (leaderboard) => {
@@ -3183,8 +3259,36 @@ function initializeApp() {
 
     onTournamentJoined: (data) => {
       gameState.tournamentId = data.tournamentId;
+      if (data.messages) {
+        data.messages = data.messages.filter(m => !isUserBlocked(m.username));
+      }
       removeMainRoom();
       uiManager.showScreen(SCREENS.TOURNAMENT_LOBBY, data);
+
+      // Returning to a finished tournament (e.g. from the game-end screen):
+      // show the final results on top of the lobby
+      if (data.phase === 'complete') {
+        const pending = gameState.pendingTournamentResults;
+        const scoreboard = data.scoreboard || pending?.scoreboard || [];
+        // Fresh server data first (getClientState now includes winners for
+        // completed tournaments); pending is only a same-session fallback
+        let winners = data.winners;
+        if (!winners || winners.length === 0) winners = pending?.winners;
+        if (!winners || winners.length === 0) {
+          const top = scoreboard.length > 0 ? scoreboard[0].totalScore : null;
+          winners = top === null ? [] : scoreboard.filter(e => e.totalScore === top).map(e => e.username);
+        }
+        showTournamentResultsOverlay({
+          scoreboard,
+          winners,
+          onReturn: () => {
+            gameState.tournamentId = null;
+            gameState.pendingTournamentResults = null;
+            removeTournamentLobby();
+            socket.emit('joinMainRoom');
+          }
+        });
+      }
     },
 
     onTournamentPlayerJoined: (data) => {
@@ -3203,6 +3307,7 @@ function initializeApp() {
     },
 
     onTournamentMessage: (data) => {
+      if (isUserBlocked(data.username)) return;
       addTournamentChatMessage(data.username, data.message, data.isSpectator);
     },
 
@@ -3236,13 +3341,24 @@ function initializeApp() {
     },
 
     onTournamentComplete: (data) => {
-      const winner = data.scoreboard && data.scoreboard.length > 0
-        ? data.scoreboard[0].username : null;
+      const winners = data.winners && data.winners.length > 0
+        ? data.winners
+        : (data.scoreboard && data.scoreboard.length > 0 ? [data.scoreboard[0].username] : []);
+
+      // If the player is still on the game-end screen, don't stack the results
+      // on top of the score modal — they'll see them after clicking 'Return to
+      // Tournament' (the server keeps the tournament alive for this)
+      if (document.getElementById('finalScoreOverlay')) {
+        gameState.pendingTournamentResults = { scoreboard: data.scoreboard, winners };
+        return;
+      }
+
       showTournamentResultsOverlay({
         scoreboard: data.scoreboard,
-        winner,
+        winners,
         onReturn: () => {
           gameState.tournamentId = null;
+          gameState.pendingTournamentResults = null;
           removeTournamentLobby();
           socket.emit('joinMainRoom');
         }
@@ -3251,11 +3367,13 @@ function initializeApp() {
 
     onTournamentLeft: () => {
       gameState.tournamentId = null;
+      gameState.pendingTournamentResults = null;
       removeTournamentLobby();
     },
 
     onTournamentCancelled: () => {
       gameState.tournamentId = null;
+      gameState.pendingTournamentResults = null;
       removeTournamentLobby();
       showInfo('Tournament has been cancelled by the host');
       socket.emit('joinMainRoom');
@@ -3379,6 +3497,7 @@ socket.on('restoreSessionResponse', (data) => {
     console.log('Session restored successfully');
     const gameState = getGameState();
     gameState.username = data.username;
+    setBlockedUsers(data.blockedUsers);
 
     // Check if user has an active game to rejoin
     if (data.activeGameId) {

--- a/client/src/ui/components/TournamentScoreboard.js
+++ b/client/src/ui/components/TournamentScoreboard.js
@@ -96,7 +96,7 @@ export function createTournamentScoreboard(scoreboard, currentRound, totalRounds
     for (let r = 0; r < totalRounds; r++) {
       const td = document.createElement('td');
       td.style.cssText = 'padding: 8px 6px; text-align: center; color: #e5e7eb;';
-      if (entry.roundScores && entry.roundScores[r] !== undefined) {
+      if (entry.roundScores && typeof entry.roundScores[r] === 'number') {
         td.textContent = entry.roundScores[r];
       } else {
         td.textContent = '-';
@@ -124,10 +124,11 @@ export function createTournamentScoreboard(scoreboard, currentRound, totalRounds
  *
  * @param {Object} options
  * @param {Array} options.scoreboard - Final sorted scoreboard
- * @param {string} options.winner - Winner's username
+ * @param {string} [options.winner] - Winner's username (single-winner fallback)
+ * @param {string[]} [options.winners] - All winners (ties produce co-winners)
  * @param {Function} options.onReturn - Called when user clicks return
  */
-export function showTournamentResultsOverlay({ scoreboard, winner, onReturn }) {
+export function showTournamentResultsOverlay({ scoreboard, winner, winners, onReturn }) {
   removeTournamentResultsOverlay();
 
   const overlay = document.createElement('div');
@@ -158,10 +159,13 @@ export function showTournamentResultsOverlay({ scoreboard, winner, onReturn }) {
   `;
   overlay.appendChild(title);
 
-  // Winner
-  if (winner) {
+  // Winner(s) — ties are announced as co-winners
+  const winnerList = (winners && winners.length > 0) ? winners : (winner ? [winner] : []);
+  if (winnerList.length > 0) {
     const winnerDiv = document.createElement('div');
-    winnerDiv.textContent = `Winner: ${winner}`;
+    winnerDiv.textContent = winnerList.length > 1
+      ? `Winners (tie): ${winnerList.join(' & ')}`
+      : `Winner: ${winnerList[0]}`;
     winnerDiv.style.cssText = `
       font-size: 24px;
       color: #4ade80;

--- a/client/src/ui/screens/MainRoom.js
+++ b/client/src/ui/screens/MainRoom.js
@@ -291,7 +291,9 @@ function updateLobbyListContent(container, lobbies, socket, inProgressGames = []
       card.appendChild(detail);
 
       const joinBtn = document.createElement('button');
-      if (tournament.phase === 'lobby' || tournament.phase === 'between_rounds') {
+      if (tournament.phase === 'lobby') {
+        // New entrants can only join before the tournament starts; returning
+        // members are re-attached automatically at sign-in
         joinBtn.innerText = 'Join';
         joinBtn.style.background = '#fbbf24';
         joinBtn.style.color = '#000';
@@ -301,7 +303,7 @@ function updateLobbyListContent(container, lobbies, socket, inProgressGames = []
         });
         joinBtn.addEventListener('mouseenter', () => { joinBtn.style.background = '#f59e0b'; });
         joinBtn.addEventListener('mouseleave', () => { joinBtn.style.background = '#fbbf24'; });
-      } else if (tournament.phase === 'round_active') {
+      } else if (tournament.phase === 'round_active' || tournament.phase === 'between_rounds') {
         joinBtn.innerText = 'Spectate';
         joinBtn.style.background = '#60a5fa';
         joinBtn.style.color = '#fff';

--- a/client/src/ui/screens/ProfilePage.js
+++ b/client/src/ui/screens/ProfilePage.js
@@ -535,6 +535,9 @@ export function showProfilePage(profile, socket) {
 
   modal.appendChild(statsGrid);
 
+  // Danger zone — account deletion (required by App Store Guideline 5.1.1(v))
+  modal.appendChild(createDangerZone(socket));
+
   overlay.appendChild(modal);
 
   // Close on overlay click (but not modal click)
@@ -545,6 +548,115 @@ export function showProfilePage(profile, socket) {
   });
 
   document.body.appendChild(overlay);
+}
+
+/**
+ * Create the account-deletion section: a Delete Account button that expands
+ * into a password-confirm form.
+ *
+ * @param {Object} socket - Socket instance
+ * @returns {HTMLElement}
+ */
+function createDangerZone(socket) {
+  const section = document.createElement('div');
+  section.style.marginTop = '25px';
+  section.style.padding = '15px';
+  section.style.background = 'rgba(127, 29, 29, 0.2)';
+  section.style.border = '1px solid #7f1d1d';
+  section.style.borderRadius = '8px';
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.innerText = 'Delete Account';
+  deleteBtn.style.padding = '10px 20px';
+  deleteBtn.style.borderRadius = '6px';
+  deleteBtn.style.border = 'none';
+  deleteBtn.style.background = '#991b1b';
+  deleteBtn.style.color = '#fff';
+  deleteBtn.style.fontSize = '14px';
+  deleteBtn.style.cursor = 'pointer';
+  deleteBtn.style.fontWeight = 'bold';
+  section.appendChild(deleteBtn);
+
+  const confirmArea = document.createElement('div');
+  confirmArea.style.display = 'none';
+  confirmArea.style.marginTop = '12px';
+
+  const warning = document.createElement('div');
+  warning.innerText = 'This permanently deletes your account, statistics, and profile. This cannot be undone. Enter your password to confirm.';
+  warning.style.fontSize = '13px';
+  warning.style.color = '#fca5a5';
+  warning.style.marginBottom = '10px';
+  confirmArea.appendChild(warning);
+
+  const passwordInput = document.createElement('input');
+  passwordInput.type = 'password';
+  passwordInput.placeholder = 'Password';
+  passwordInput.autocomplete = 'current-password';
+  passwordInput.style.padding = '8px 12px';
+  passwordInput.style.borderRadius = '6px';
+  passwordInput.style.border = '1px solid #4a5568';
+  passwordInput.style.background = '#1f2937';
+  passwordInput.style.color = '#fff';
+  passwordInput.style.fontSize = '14px';
+  passwordInput.style.marginRight = '8px';
+  confirmArea.appendChild(passwordInput);
+
+  const confirmBtn = document.createElement('button');
+  confirmBtn.innerText = 'Permanently Delete';
+  confirmBtn.style.padding = '8px 16px';
+  confirmBtn.style.borderRadius = '6px';
+  confirmBtn.style.border = 'none';
+  confirmBtn.style.background = '#dc2626';
+  confirmBtn.style.color = '#fff';
+  confirmBtn.style.fontSize = '14px';
+  confirmBtn.style.cursor = 'pointer';
+  confirmBtn.style.fontWeight = 'bold';
+  confirmBtn.addEventListener('click', () => {
+    const password = passwordInput.value;
+    if (!password) {
+      passwordInput.style.border = '1px solid #dc2626';
+      return;
+    }
+    confirmBtn.disabled = true;
+    confirmBtn.innerText = 'Deleting…';
+    socket.emit('deleteAccount', { password });
+  });
+  confirmArea.appendChild(confirmBtn);
+
+  const errorMsg = document.createElement('div');
+  errorMsg.id = 'deleteAccountError';
+  errorMsg.style.fontSize = '13px';
+  errorMsg.style.color = '#f87171';
+  errorMsg.style.marginTop = '8px';
+  confirmArea.appendChild(errorMsg);
+
+  section.appendChild(confirmArea);
+
+  deleteBtn.addEventListener('click', () => {
+    const visible = confirmArea.style.display !== 'none';
+    confirmArea.style.display = visible ? 'none' : 'block';
+  });
+
+  return section;
+}
+
+/**
+ * Re-enable the delete-account form after a failed attempt.
+ *
+ * @param {string} message - Error message to display
+ */
+export function showDeleteAccountError(message) {
+  const errorMsg = document.getElementById('deleteAccountError');
+  if (errorMsg) {
+    errorMsg.innerText = message;
+  }
+  const buttons = document.querySelectorAll('#profilePageModal button');
+  buttons.forEach(btn => {
+    if (btn.innerText === 'Deleting…') {
+      btn.disabled = false;
+      btn.innerText = 'Permanently Delete';
+    }
+  });
 }
 
 /**
@@ -604,8 +716,11 @@ export function isProfilePageVisible() {
  * Show a read-only profile page for viewing another player.
  *
  * @param {Object} profile - Profile data (username, profilePic, stats)
+ * @param {Object} [socket] - Socket instance (enables report/block actions)
+ * @param {Object} [options] - { isBlocked } current block state for the toggle
  */
-export function showPlayerProfilePage(profile) {
+export function showPlayerProfilePage(profile, socket, options = {}) {
+  socket = socket || currentSocket;
   // Remove any existing player profile page
   removePlayerProfilePage();
 
@@ -703,6 +818,43 @@ export function showPlayerProfilePage(profile) {
   picSection.appendChild(picLabel);
 
   modal.appendChild(picSection);
+
+  // Report / Block actions (App Store Guideline 1.2 — UGC safety)
+  if (socket) {
+    const safetyRow = document.createElement('div');
+    safetyRow.style.display = 'flex';
+    safetyRow.style.gap = '10px';
+    safetyRow.style.marginBottom = '25px';
+
+    const reportBtn = document.createElement('button');
+    reportBtn.innerText = 'Report';
+    reportBtn.style.cssText = 'padding: 8px 16px; border-radius: 6px; border: 1px solid #b45309; background: transparent; color: #f59e0b; font-size: 13px; cursor: pointer;';
+    reportBtn.addEventListener('click', () => {
+      const reason = window.prompt(`Report ${profile.username} — what happened?`);
+      if (reason && reason.trim()) {
+        socket.emit('reportUser', { username: profile.username, reason: reason.trim().slice(0, 500), context: '' });
+      }
+    });
+    safetyRow.appendChild(reportBtn);
+
+    const blockBtn = document.createElement('button');
+    let isBlocked = !!options.isBlocked;
+    const renderBlockBtn = () => {
+      blockBtn.innerText = isBlocked ? 'Unblock' : 'Block';
+      blockBtn.style.cssText = isBlocked
+        ? 'padding: 8px 16px; border-radius: 6px; border: 1px solid #4a5568; background: transparent; color: #9ca3af; font-size: 13px; cursor: pointer;'
+        : 'padding: 8px 16px; border-radius: 6px; border: 1px solid #991b1b; background: transparent; color: #f87171; font-size: 13px; cursor: pointer;';
+    };
+    renderBlockBtn();
+    blockBtn.addEventListener('click', () => {
+      socket.emit(isBlocked ? 'unblockUser' : 'blockUser', { username: profile.username });
+      isBlocked = !isBlocked;
+      renderBlockBtn();
+    });
+    safetyRow.appendChild(blockBtn);
+
+    modal.appendChild(safetyRow);
+  }
 
   // Stats section
   const statsHeader = document.createElement('div');

--- a/client/src/ui/screens/Register.js
+++ b/client/src/ui/screens/Register.js
@@ -124,6 +124,19 @@ export function createRegisterScreen({ onRegister, onBackToSignIn, prefill = {} 
   `;
   container.appendChild(registerButton);
 
+  // Terms acceptance notice (UGC apps must require agreement to terms)
+  const termsNote = document.createElement('div');
+  termsNote.style.cssText = 'font-size: 11px; color: #888; margin-bottom: 10px; max-width: 260px; text-align: center;';
+  termsNote.append('By creating an account you agree to the ');
+  const termsLink = document.createElement('a');
+  termsLink.textContent = 'Terms of Use';
+  termsLink.href = '/terms';
+  termsLink.target = '_blank';
+  termsLink.style.color = '#4dcc73';
+  termsNote.appendChild(termsLink);
+  termsNote.append(', including zero tolerance for abusive content.');
+  container.appendChild(termsNote);
+
   // Back to sign in link
   const backLink = document.createElement('button');
   backLink.textContent = 'Back to Sign In';

--- a/client/src/ui/screens/TournamentLobby.js
+++ b/client/src/ui/screens/TournamentLobby.js
@@ -24,11 +24,15 @@ let isPlayerReady = false;
  */
 export function showTournamentLobby(data, socket, username) {
   console.log('Showing tournament lobby...', data);
+
+  // Remove any existing tournament lobby (this resets module state, so the
+  // server-provided phase must be applied afterwards — otherwise the Begin
+  // button emits beginTournament instead of beginNextRound after round 1)
+  removeTournamentLobby();
+
   currentTournamentId = data.tournamentId;
   isPlayerReady = false;
-
-  // Remove any existing tournament lobby
-  removeTournamentLobby();
+  currentPhase = data.phase || 'lobby';
 
   const isSpectator = data.isSpectator || false;
   const isCreator = data.creatorUsername === username;
@@ -280,8 +284,8 @@ export function showTournamentLobby(data, socket, username) {
       readyBtn.style.background = '#22c55e';
     }
 
-    // Hide ready button during active rounds
-    if (data.phase === 'round_active') {
+    // Hide ready button during active rounds and once the tournament is over
+    if (data.phase === 'round_active' || data.phase === 'complete') {
       readyBtn.style.display = 'none';
     }
 
@@ -327,10 +331,13 @@ export function showTournamentLobby(data, socket, username) {
 
       beginBtn.addEventListener('click', () => {
         if (beginBtn.disabled) return;
-        if (data.phase === 'lobby' || currentPhase === 'lobby') {
-          socket.emit('beginTournament');
-        } else {
+        // currentPhase tracks the latest server state (set on lobby render
+        // and by setTournamentPhase) — round 1 starts from 'lobby', later
+        // rounds from 'between_rounds'
+        if (currentPhase === 'between_rounds') {
           socket.emit('beginNextRound');
+        } else {
+          socket.emit('beginTournament');
         }
         beginBtn.disabled = true;
         beginBtn.style.background = '#6b7280';
@@ -594,7 +601,10 @@ function updateBeginButton(players) {
   const beginBtn = document.getElementById('tournamentBeginBtn');
   if (!beginBtn) return;
 
-  const allReady = players && players.length > 0 && players.every(p => p.ready);
+  // Disconnected members sit out rounds and never ready up — they must not
+  // gate the Begin button (the server's allPlayersReady ignores them too)
+  const connectedPlayers = (players || []).filter(p => p.connected !== false);
+  const allReady = connectedPlayers.length > 0 && connectedPlayers.every(p => p.ready);
 
   if (allReady) {
     beginBtn.disabled = false;

--- a/iOSClient/BABOnline.xcodeproj/project.pbxproj
+++ b/iOSClient/BABOnline.xcodeproj/project.pbxproj
@@ -78,6 +78,11 @@
 		FDB5445E7BEE26B8943D8770 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8790511FF395019A12A1F429 /* Assets.xcassets */; };
 		CC0000000000000000000001 /* ConnectionStatusToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000000000000000000002 /* ConnectionStatusToast.swift */; };
 		BB1234567890ABCDEF000001 /* Tournament.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000001 /* Tournament.swift */; };
+		CD0000000000000000000002 /* SafetyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0000000000000000000001 /* SafetyState.swift */; };
+		CD0000000000000000000004 /* SafetyEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0000000000000000000003 /* SafetyEmitter.swift */; };
+		CD0000000000000000000006 /* SafetySocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0000000000000000000005 /* SafetySocketHandler.swift */; };
+		CD0000000000000000000008 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0000000000000000000007 /* AccountSettingsView.swift */; };
+		CD000000000000000000000A /* SafetyMenus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0000000000000000000009 /* SafetyMenus.swift */; };
 		BB1234567890ABCDEF000002 /* TournamentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000002 /* TournamentState.swift */; };
 		BB1234567890ABCDEF000003 /* TournamentEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000003 /* TournamentEmitter.swift */; };
 		BB1234567890ABCDEF000004 /* TournamentSocketHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1234567890ABCDEF000004 /* TournamentSocketHandler.swift */; };
@@ -171,6 +176,11 @@
 		FA8B8AB7C156EE02DB4AA5EC /* SKOpponentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKOpponentManager.swift; sourceTree = "<group>"; };
 		FD7736BF05FE6B17925F5B58 /* AvatarNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarNode.swift; sourceTree = "<group>"; };
 		CC0000000000000000000002 /* ConnectionStatusToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatusToast.swift; sourceTree = "<group>"; };
+		CD0000000000000000000001 /* SafetyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyState.swift; sourceTree = "<group>"; };
+		CD0000000000000000000003 /* SafetyEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyEmitter.swift; sourceTree = "<group>"; };
+		CD0000000000000000000005 /* SafetySocketHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetySocketHandler.swift; sourceTree = "<group>"; };
+		CD0000000000000000000007 /* AccountSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
+		CD0000000000000000000009 /* SafetyMenus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetyMenus.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF000001 /* Tournament.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tournament.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF000002 /* TournamentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentState.swift; sourceTree = "<group>"; };
 		AA1234567890ABCDEF000003 /* TournamentEmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TournamentEmitter.swift; sourceTree = "<group>"; };
@@ -225,6 +235,7 @@
 				97217006DFD0797BEBAF6836 /* GameEmitter.swift */,
 				AA1234567890ABCDEF00000D /* LeaderboardEmitter.swift */,
 				ABFB49C1B9B998424D06A9B7 /* LobbyEmitter.swift */,
+				CD0000000000000000000003 /* SafetyEmitter.swift */,
 				AA1234567890ABCDEF000003 /* TournamentEmitter.swift */,
 				DD0000000000000000000004 /* VoiceEmitter.swift */,
 			);
@@ -244,6 +255,7 @@
 			children = (
 				F28474CFED18B3E46768C988 /* AuthSocketHandler.swift */,
 				1CC5887542913E6A913FA11E /* ChatSocketHandler.swift */,
+				CD0000000000000000000005 /* SafetySocketHandler.swift */,
 				7AA293C5CC063A9C3A5D35F2 /* GameSocketHandler.swift */,
 				AA1234567890ABCDEF00000E /* LeaderboardSocketHandler.swift */,
 				7FD14869A6FDEFEF8A26EB44 /* LobbySocketHandler.swift */,
@@ -284,6 +296,7 @@
 			isa = PBXGroup;
 			children = (
 				CC0000000000000000000002 /* ConnectionStatusToast.swift */,
+				CD0000000000000000000009 /* SafetyMenus.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -403,6 +416,7 @@
 		D5AAEA07E9E0D4E83C6DED04 /* MainRoom */ = {
 			isa = PBXGroup;
 			children = (
+				CD0000000000000000000007 /* AccountSettingsView.swift */,
 				AA1234567890ABCDEF00000F /* LeaderboardView.swift */,
 				C53AAE255FBF334AD3AEC34F /* LobbyListView.swift */,
 				07ED0716768E28CCCDE8A731 /* MainRoomChatView.swift */,
@@ -451,6 +465,7 @@
 				AA1234567890ABCDEF00000C /* LeaderboardState.swift */,
 				E9B310B890DA152FC2DC27BB /* LobbyState.swift */,
 				D8BFDA96358A6BEB484A42FB /* MainRoomState.swift */,
+				CD0000000000000000000001 /* SafetyState.swift */,
 				AA1234567890ABCDEF000002 /* TournamentState.swift */,
 			);
 			path = State;
@@ -658,6 +673,11 @@
 				DD0000000000000000000007 /* VoiceSocketHandler.swift in Sources */,
 				DD0000000000000000000009 /* VoiceMuteButton.swift in Sources */,
 				DD000000000000000000000B /* VoicePanelSheet.swift in Sources */,
+				CD0000000000000000000002 /* SafetyState.swift in Sources */,
+				CD0000000000000000000004 /* SafetyEmitter.swift in Sources */,
+				CD0000000000000000000006 /* SafetySocketHandler.swift in Sources */,
+				CD0000000000000000000008 /* AccountSettingsView.swift in Sources */,
+				CD000000000000000000000A /* SafetyMenus.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSClient/BABOnline/BABOnlineApp.swift
+++ b/iOSClient/BABOnline/BABOnlineApp.swift
@@ -9,6 +9,7 @@ struct BABOnlineApp: App {
     @StateObject private var gameState = GameState()
     @StateObject private var tournamentState = TournamentState()
     @StateObject private var leaderboardState = LeaderboardState()
+    @StateObject private var safetyState = SafetyState()
     @Environment(\.scenePhase) private var scenePhase
 
     private let socketService = SocketService.shared
@@ -23,6 +24,7 @@ struct BABOnlineApp: App {
                 .environmentObject(gameState)
                 .environmentObject(tournamentState)
                 .environmentObject(leaderboardState)
+                .environmentObject(safetyState)
                 .environmentObject(socketService)
                 .onAppear {
                     setupSocket()
@@ -46,7 +48,8 @@ struct BABOnlineApp: App {
             gameState: gameState,
             appState: appState,
             tournamentState: tournamentState,
-            leaderboardState: leaderboardState
+            leaderboardState: leaderboardState,
+            safetyState: safetyState
         )
         router.registerAll()
         socketService.eventRouter = router

--- a/iOSClient/BABOnline/Constants/SocketEvents.swift
+++ b/iOSClient/BABOnline/Constants/SocketEvents.swift
@@ -8,6 +8,12 @@ enum SocketEvents {
         // Auth
         static let signIn = "signIn"
         static let signUp = "signUp"
+        static let deleteAccount = "deleteAccount"
+
+        // Safety / moderation
+        static let reportUser = "reportUser"
+        static let blockUser = "blockUser"
+        static let unblockUser = "unblockUser"
 
         // Main Room
         static let joinMainRoom = "joinMainRoom"
@@ -71,6 +77,11 @@ enum SocketEvents {
         static let restoreSessionResponse = "restoreSessionResponse"
         static let forceLogout = "forceLogout"
         static let activeGameFound = "activeGameFound"
+        static let deleteAccountResponse = "deleteAccountResponse"
+
+        // Safety / moderation
+        static let reportUserResponse = "reportUserResponse"
+        static let blockListUpdated = "blockListUpdated"
 
         // Main Room
         static let mainRoomJoined = "mainRoomJoined"

--- a/iOSClient/BABOnline/Models/Tournament.swift
+++ b/iOSClient/BABOnline/Models/Tournament.swift
@@ -6,6 +6,7 @@ struct TournamentPlayer: Identifiable, Equatable {
     var pic: String?
     var isReady: Bool
     var isCreator: Bool
+    var connected: Bool
 
     static func from(_ dict: [String: Any]) -> TournamentPlayer? {
         guard let username = dict["username"] as? String else { return nil }
@@ -16,7 +17,8 @@ struct TournamentPlayer: Identifiable, Equatable {
         else { pic = nil }
         let isReady = dict["ready"] as? Bool ?? dict["isReady"] as? Bool ?? false
         let isCreator = dict["isCreator"] as? Bool ?? false
-        return TournamentPlayer(id: id, username: username, pic: pic, isReady: isReady, isCreator: isCreator)
+        let connected = dict["connected"] as? Bool ?? true
+        return TournamentPlayer(id: id, username: username, pic: pic, isReady: isReady, isCreator: isCreator, connected: connected)
     }
 }
 

--- a/iOSClient/BABOnline/Networking/Emitters/AuthEmitter.swift
+++ b/iOSClient/BABOnline/Networking/Emitters/AuthEmitter.swift
@@ -18,4 +18,8 @@ enum AuthEmitter {
     static func rejoinGame(gameId: String, username: String) {
         socket.emit(SocketEvents.Client.rejoinGame, ["gameId": gameId, "username": username])
     }
+
+    static func deleteAccount(password: String) {
+        socket.emit(SocketEvents.Client.deleteAccount, ["password": password])
+    }
 }

--- a/iOSClient/BABOnline/Networking/Emitters/SafetyEmitter.swift
+++ b/iOSClient/BABOnline/Networking/Emitters/SafetyEmitter.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Report/block emitters (App Store Guideline 1.2).
+enum SafetyEmitter {
+    private static var socket: SocketService { .shared }
+
+    static func reportUser(username: String, reason: String, context: String? = nil) {
+        var payload: [String: Any] = ["username": username, "reason": reason]
+        if let context {
+            payload["context"] = context
+        }
+        socket.emit(SocketEvents.Client.reportUser, payload)
+    }
+
+    static func blockUser(username: String) {
+        socket.emit(SocketEvents.Client.blockUser, ["username": username])
+    }
+
+    static func unblockUser(username: String) {
+        socket.emit(SocketEvents.Client.unblockUser, ["username": username])
+    }
+}

--- a/iOSClient/BABOnline/Networking/Handlers/AuthSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/AuthSocketHandler.swift
@@ -1,17 +1,19 @@
 import Foundation
 
-/// Handles auth-related socket events: signInResponse, signUpResponse, forceLogout, activeGameFound
+/// Handles auth-related socket events: signInResponse, signUpResponse, forceLogout, activeGameFound, deleteAccountResponse
 final class AuthSocketHandler {
     private let socket: SocketService
     private let authState: AuthState
     private let appState: AppState
     private let gameState: GameState
+    private let safetyState: SafetyState
 
-    init(socket: SocketService, authState: AuthState, appState: AppState, gameState: GameState) {
+    init(socket: SocketService, authState: AuthState, appState: AppState, gameState: GameState, safetyState: SafetyState) {
         self.socket = socket
         self.authState = authState
         self.appState = appState
         self.gameState = gameState
+        self.safetyState = safetyState
     }
 
     func register() {
@@ -40,6 +42,11 @@ final class AuthSocketHandler {
             guard let self, let dict = data.first as? [String: Any] else { return }
             self.handleActiveGameFound(dict)
         }
+
+        socket.on(SocketEvents.Server.deleteAccountResponse) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            self.handleDeleteAccountResponse(dict)
+        }
     }
 
     private func handleSignInResponse(_ data: [String: Any]) {
@@ -57,6 +64,10 @@ final class AuthSocketHandler {
 
                 self.gameState.username = username
                 self.gameState.playerId = self.socket.socketId
+
+                if let blocked = data["blockedUsers"] as? [String] {
+                    self.safetyState.setBlockedUsers(blocked)
+                }
 
                 // Check if there's an active game to rejoin (e.g. force-killed app)
                 if let gameId = data["activeGameId"] as? String, !gameId.isEmpty {
@@ -109,6 +120,7 @@ final class AuthSocketHandler {
             print("[Auth] Force logout: \(reason)")
             self.authState.clearCredentials()
             self.gameState.reset()
+            self.safetyState.reset()
             self.appState.screen = .signIn
         }
     }
@@ -125,6 +137,10 @@ final class AuthSocketHandler {
 
                 self.gameState.username = username
                 self.gameState.playerId = self.socket.socketId
+
+                if let blocked = data["blockedUsers"] as? [String] {
+                    self.safetyState.setBlockedUsers(blocked)
+                }
 
                 // Check if there's an active game to rejoin
                 if let gameId = data["activeGameId"] as? String, !gameId.isEmpty {
@@ -156,6 +172,27 @@ final class AuthSocketHandler {
 
             // Auto-rejoin the active game
             AuthEmitter.rejoinGame(gameId: gameId, username: self.authState.username)
+        }
+    }
+
+    private func handleDeleteAccountResponse(_ data: [String: Any]) {
+        let success = data["success"] as? Bool ?? false
+
+        DispatchQueue.main.async {
+            if success {
+                // Mirror forceLogout cleanup — the server force-disconnects this
+                // socket shortly after the response; with credentials cleared, the
+                // auto-reconnect won't restore a session.
+                print("[Auth] Account deleted")
+                self.authState.clearCredentials()
+                self.gameState.reset()
+                self.safetyState.reset()
+                self.appState.screen = .signIn
+            } else {
+                let message = data["message"] as? String ?? "Account deletion failed"
+                self.authState.deleteAccountError = message
+                print("[Auth] Account deletion failed: \(message)")
+            }
         }
     }
 }

--- a/iOSClient/BABOnline/Networking/Handlers/ChatSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/ChatSocketHandler.swift
@@ -4,10 +4,12 @@ import Foundation
 final class ChatSocketHandler {
     private let socket: SocketService
     private let gameState: GameState
+    private let safetyState: SafetyState
 
-    init(socket: SocketService, gameState: GameState) {
+    init(socket: SocketService, gameState: GameState, safetyState: SafetyState) {
         self.socket = socket
         self.gameState = gameState
+        self.safetyState = safetyState
     }
 
     func register() {
@@ -15,6 +17,7 @@ final class ChatSocketHandler {
             guard let self, let dict = data.first as? [String: Any] else { return }
             DispatchQueue.main.async {
                 let username = dict["username"] as? String ?? ""
+                guard !self.safetyState.isBlocked(username) else { return }
                 let message = dict["message"] as? String ?? ""
                 let position = dict["position"] as? Int
                 let type: ChatMessage.MessageType = (dict["type"] as? String) == "spectator" ? .spectator : .player

--- a/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/GameSocketHandler.swift
@@ -227,6 +227,10 @@ final class GameSocketHandler {
             DispatchQueue.main.async {
                 self.gameState.phase = .ended
                 self.gameState.gameEndData = GameEndData.from(dict)
+                // Always present (null for casual games) — keeps the
+                // "Return to Tournament" branch correct after reconnects and
+                // prevents stale tournament state on casual games.
+                self.gameState.tournamentId = dict["tournamentId"] as? String
             }
         }
     }

--- a/iOSClient/BABOnline/Networking/Handlers/LobbySocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/LobbySocketHandler.swift
@@ -7,13 +7,15 @@ final class LobbySocketHandler {
     private let lobbyState: LobbyState
     private let appState: AppState
     private let gameState: GameState
+    private let safetyState: SafetyState
 
-    init(socket: SocketService, mainRoomState: MainRoomState, lobbyState: LobbyState, appState: AppState, gameState: GameState) {
+    init(socket: SocketService, mainRoomState: MainRoomState, lobbyState: LobbyState, appState: AppState, gameState: GameState, safetyState: SafetyState) {
         self.socket = socket
         self.mainRoomState = mainRoomState
         self.lobbyState = lobbyState
         self.appState = appState
         self.gameState = gameState
+        self.safetyState = safetyState
     }
 
     func register() {
@@ -27,7 +29,9 @@ final class LobbySocketHandler {
                     self.mainRoomState.onlineUsers = users
                 }
                 if let messages = dict["recentMessages"] as? [[String: Any]] {
-                    self.mainRoomState.messages = messages.compactMap { ChatMessage.from($0) }
+                    self.mainRoomState.messages = messages
+                        .compactMap { ChatMessage.from($0) }
+                        .filter { !self.safetyState.isBlocked($0.username) }
                 }
                 if let lobbies = dict["lobbies"] as? [[String: Any]] {
                     self.mainRoomState.lobbies = lobbies.compactMap { Lobby.from($0) }
@@ -46,7 +50,8 @@ final class LobbySocketHandler {
             guard let dict = data.first as? [String: Any],
                   let msg = ChatMessage.from(dict) else { return }
             DispatchQueue.main.async {
-                self?.mainRoomState.messages.append(msg)
+                guard let self, !self.safetyState.isBlocked(msg.username) else { return }
+                self.mainRoomState.messages.append(msg)
             }
         }
 
@@ -91,7 +96,9 @@ final class LobbySocketHandler {
                     self.lobbyState.players = players.compactMap { LobbyPlayer.from($0) }
                 }
                 if let messages = dict["messages"] as? [[String: Any]] {
-                    self.lobbyState.messages = messages.compactMap { ChatMessage.from($0) }
+                    self.lobbyState.messages = messages
+                        .compactMap { ChatMessage.from($0) }
+                        .filter { !self.safetyState.isBlocked($0.username) }
                 }
                 self.appState.screen = .gameLobby
                 print("[Lobby] Created lobby: \(lobbyId)")
@@ -110,7 +117,9 @@ final class LobbySocketHandler {
                     self.lobbyState.players = players.compactMap { LobbyPlayer.from($0) }
                 }
                 if let messages = dict["messages"] as? [[String: Any]] {
-                    self.lobbyState.messages = messages.compactMap { ChatMessage.from($0) }
+                    self.lobbyState.messages = messages
+                        .compactMap { ChatMessage.from($0) }
+                        .filter { !self.safetyState.isBlocked($0.username) }
                 }
                 self.appState.screen = .gameLobby
                 print("[Lobby] Joined lobby: \(lobbyId)")
@@ -153,7 +162,8 @@ final class LobbySocketHandler {
             guard let dict = data.first as? [String: Any],
                   let msg = ChatMessage.from(dict) else { return }
             DispatchQueue.main.async {
-                self?.lobbyState.messages.append(msg)
+                guard let self, !self.safetyState.isBlocked(msg.username) else { return }
+                self.lobbyState.messages.append(msg)
             }
         }
 

--- a/iOSClient/BABOnline/Networking/Handlers/SafetySocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/SafetySocketHandler.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Handles safety-related socket events: reportUserResponse, blockListUpdated.
+final class SafetySocketHandler {
+    private let socket: SocketService
+    private let safetyState: SafetyState
+
+    init(socket: SocketService, safetyState: SafetyState) {
+        self.socket = socket
+        self.safetyState = safetyState
+    }
+
+    func register() {
+        socket.on(SocketEvents.Server.reportUserResponse) { [weak self] data, _ in
+            guard let self else { return }
+            let dict = data.first as? [String: Any]
+            DispatchQueue.main.async {
+                let success = dict?["success"] as? Bool ?? false
+                if success {
+                    self.safetyState.feedbackMessage = "Report submitted. Thank you."
+                } else {
+                    self.safetyState.feedbackMessage = dict?["message"] as? String ?? "Failed to submit report. Try again."
+                }
+                print("[Safety] Report response: success=\(success)")
+            }
+        }
+
+        socket.on(SocketEvents.Server.blockListUpdated) { [weak self] data, _ in
+            guard let self, let dict = data.first as? [String: Any] else { return }
+            DispatchQueue.main.async {
+                let success = dict["success"] as? Bool ?? false
+                if success {
+                    self.safetyState.setBlockedUsers(dict["blockedUsers"] as? [String] ?? [])
+                    self.safetyState.feedbackMessage = "Block list updated."
+                } else {
+                    self.safetyState.feedbackMessage = dict["message"] as? String ?? "Failed to update block list. Try again."
+                }
+                print("[Safety] Block list updated: success=\(success)")
+            }
+        }
+    }
+}

--- a/iOSClient/BABOnline/Networking/Handlers/TournamentSocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/TournamentSocketHandler.swift
@@ -6,12 +6,14 @@ final class TournamentSocketHandler {
     private let tournamentState: TournamentState
     private let gameState: GameState
     private let appState: AppState
+    private let safetyState: SafetyState
 
-    init(socket: SocketService, tournamentState: TournamentState, gameState: GameState, appState: AppState) {
+    init(socket: SocketService, tournamentState: TournamentState, gameState: GameState, appState: AppState, safetyState: SafetyState) {
         self.socket = socket
         self.tournamentState = tournamentState
         self.gameState = gameState
         self.appState = appState
+        self.safetyState = safetyState
     }
 
     func register() {
@@ -21,6 +23,7 @@ final class TournamentSocketHandler {
             guard let self, let dict = data.first as? [String: Any] else { return }
             DispatchQueue.main.async {
                 self.tournamentState.loadFromServerState(dict)
+                self.tournamentState.messages.removeAll { self.safetyState.isBlocked($0.username) }
                 self.appState.screen = .tournamentLobby
                 print("[Tournament] Created tournament: \(self.tournamentState.tournamentId)")
             }
@@ -30,6 +33,7 @@ final class TournamentSocketHandler {
             guard let self, let dict = data.first as? [String: Any] else { return }
             DispatchQueue.main.async {
                 self.tournamentState.loadFromServerState(dict)
+                self.tournamentState.messages.removeAll { self.safetyState.isBlocked($0.username) }
                 self.appState.screen = .tournamentLobby
                 print("[Tournament] Joined tournament: \(self.tournamentState.tournamentId)")
             }
@@ -73,7 +77,7 @@ final class TournamentSocketHandler {
         socket.on(SocketEvents.Server.tournamentMessage) { [weak self] data, _ in
             guard let self, let dict = data.first as? [String: Any] else { return }
             DispatchQueue.main.async {
-                if let msg = ChatMessage.from(dict) {
+                if let msg = ChatMessage.from(dict), !self.safetyState.isBlocked(msg.username) {
                     self.tournamentState.messages.append(msg)
                 }
             }
@@ -147,6 +151,7 @@ final class TournamentSocketHandler {
                 if let scoreboardArr = dict["scoreboard"] as? [[String: Any]] {
                     self.tournamentState.scoreboard = scoreboardArr.compactMap { TournamentScoreEntry.from($0) }
                 }
+                self.tournamentState.winners = dict["winners"] as? [String] ?? []
                 print("[Tournament] Tournament complete")
             }
         }

--- a/iOSClient/BABOnline/Networking/SocketEventRouter.swift
+++ b/iOSClient/BABOnline/Networking/SocketEventRouter.swift
@@ -11,6 +11,7 @@ final class SocketEventRouter {
     private let tournamentHandler: TournamentSocketHandler
     private let leaderboardHandler: LeaderboardSocketHandler
     private let voiceHandler: VoiceSocketHandler
+    private let safetyHandler: SafetySocketHandler
 
     init(
         socket: SocketService,
@@ -20,16 +21,18 @@ final class SocketEventRouter {
         gameState: GameState,
         appState: AppState,
         tournamentState: TournamentState,
-        leaderboardState: LeaderboardState
+        leaderboardState: LeaderboardState,
+        safetyState: SafetyState
     ) {
         self.socket = socket
-        self.authHandler = AuthSocketHandler(socket: socket, authState: authState, appState: appState, gameState: gameState)
-        self.lobbyHandler = LobbySocketHandler(socket: socket, mainRoomState: mainRoomState, lobbyState: lobbyState, appState: appState, gameState: gameState)
+        self.authHandler = AuthSocketHandler(socket: socket, authState: authState, appState: appState, gameState: gameState, safetyState: safetyState)
+        self.lobbyHandler = LobbySocketHandler(socket: socket, mainRoomState: mainRoomState, lobbyState: lobbyState, appState: appState, gameState: gameState, safetyState: safetyState)
         self.gameHandler = GameSocketHandler(socket: socket, gameState: gameState, appState: appState)
-        self.chatHandler = ChatSocketHandler(socket: socket, gameState: gameState)
-        self.tournamentHandler = TournamentSocketHandler(socket: socket, tournamentState: tournamentState, gameState: gameState, appState: appState)
+        self.chatHandler = ChatSocketHandler(socket: socket, gameState: gameState, safetyState: safetyState)
+        self.tournamentHandler = TournamentSocketHandler(socket: socket, tournamentState: tournamentState, gameState: gameState, appState: appState, safetyState: safetyState)
         self.leaderboardHandler = LeaderboardSocketHandler(socket: socket, leaderboardState: leaderboardState)
         self.voiceHandler = VoiceSocketHandler(socket: socket)
+        self.safetyHandler = SafetySocketHandler(socket: socket, safetyState: safetyState)
     }
 
     func registerAll() {
@@ -40,5 +43,6 @@ final class SocketEventRouter {
         tournamentHandler.register()
         leaderboardHandler.register()
         voiceHandler.register()
+        safetyHandler.register()
     }
 }

--- a/iOSClient/BABOnline/State/AuthState.swift
+++ b/iOSClient/BABOnline/State/AuthState.swift
@@ -7,6 +7,7 @@ final class AuthState: ObservableObject {
     @Published var sessionToken: String = ""
     @Published var isAuthenticated: Bool = false
     @Published var error: String?
+    @Published var deleteAccountError: String?
 
     private let keychainService = "com.bab-online.auth"
     private let usernameKey = "username"
@@ -43,6 +44,7 @@ final class AuthState: ObservableObject {
         sessionToken = ""
         isAuthenticated = false
         error = nil
+        deleteAccountError = nil
     }
 
     // MARK: - Keychain Helpers

--- a/iOSClient/BABOnline/State/GameState.swift
+++ b/iOSClient/BABOnline/State/GameState.swift
@@ -413,6 +413,12 @@ final class GameState: ObservableObject {
 
     func restoreFromRejoin(_ data: [String: Any]) {
         gameId = data["gameId"] as? String
+        // rejoinSuccess always carries tournamentId (null for casual games) —
+        // assigning clears stale tournament context. restorePlayerState reuses
+        // this parser but omits the key, so only overwrite when it's present.
+        if data.keys.contains("tournamentId") {
+            tournamentId = data["tournamentId"] as? String
+        }
         position = data["position"] as? Int
         currentHand = data["currentHand"] as? Int ?? 0
         dealer = data["dealer"] as? Int

--- a/iOSClient/BABOnline/State/SafetyState.swift
+++ b/iOSClient/BABOnline/State/SafetyState.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Tracks the signed-in user's blocked users plus transient feedback from
+/// report/block requests (App Store Guideline 1.2).
+final class SafetyState: ObservableObject {
+    @Published var blockedUsers: Set<String> = []
+    @Published var feedbackMessage: String?
+
+    func isBlocked(_ username: String) -> Bool {
+        blockedUsers.contains(username)
+    }
+
+    func setBlockedUsers(_ usernames: [String]) {
+        blockedUsers = Set(usernames)
+    }
+
+    func reset() {
+        blockedUsers = []
+        feedbackMessage = nil
+    }
+}

--- a/iOSClient/BABOnline/State/TournamentState.swift
+++ b/iOSClient/BABOnline/State/TournamentState.swift
@@ -10,6 +10,7 @@ final class TournamentState: ObservableObject {
     @Published var players: [TournamentPlayer] = []
     @Published var messages: [ChatMessage] = []
     @Published var scoreboard: [TournamentScoreEntry] = []
+    @Published var winners: [String] = []
     @Published var activeGames: [TournamentActiveGame] = []
     @Published var creatorUsername: String = ""
     @Published var isSpectator: Bool = false
@@ -24,6 +25,7 @@ final class TournamentState: ObservableObject {
         players = []
         messages = []
         scoreboard = []
+        winners = []
         activeGames = []
         creatorUsername = ""
         isSpectator = false
@@ -50,6 +52,8 @@ final class TournamentState: ObservableObject {
         if let scoreboardArr = dict["scoreboard"] as? [[String: Any]] {
             scoreboard = scoreboardArr.compactMap { TournamentScoreEntry.from($0) }
         }
+
+        winners = dict["winners"] as? [String] ?? []
 
         if let gamesArr = dict["activeGames"] as? [[String: Any]] {
             activeGames = gamesArr.compactMap { TournamentActiveGame.from($0) }

--- a/iOSClient/BABOnline/Views/Auth/RegisterView.swift
+++ b/iOSClient/BABOnline/Views/Auth/RegisterView.swift
@@ -67,6 +67,13 @@ struct RegisterView: View {
                         .cornerRadius(10)
                     }
                     .disabled(!canRegister)
+
+                    Text(.init("By creating an account you agree to the [Terms of Use](https://babonline.io/terms) — zero tolerance for abusive content."))
+                        .font(.caption2)
+                        .foregroundColor(Color.Theme.textDim)
+                        .tint(Color.Theme.primary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
                 }
                 .padding(.horizontal, 32)
 

--- a/iOSClient/BABOnline/Views/Components/SafetyMenus.swift
+++ b/iOSClient/BABOnline/Views/Components/SafetyMenus.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// Shared report/block affordances for chat surfaces (App Store Guideline 1.2).
+extension View {
+    /// Long-press context menu offering Report / Block on chat rows from other users.
+    /// Shows nothing for system messages or the current user's own messages.
+    func reportBlockMenu(for message: ChatMessage, currentUsername: String, reportTarget: Binding<String?>) -> some View {
+        contextMenu {
+            if message.type != .system, !message.username.isEmpty, message.username != currentUsername {
+                Button {
+                    reportTarget.wrappedValue = message.username
+                } label: {
+                    Label("Report User", systemImage: "exclamationmark.bubble")
+                }
+                Button(role: .destructive) {
+                    SafetyEmitter.blockUser(username: message.username)
+                } label: {
+                    Label("Block User", systemImage: "hand.raised")
+                }
+            }
+        }
+    }
+
+    /// Report-reason prompt + safety feedback alerts. Attach once per chat surface.
+    func safetyAlerts(reportTarget: Binding<String?>, reportContext: String) -> some View {
+        modifier(SafetyAlertsModifier(reportTarget: reportTarget, reportContext: reportContext))
+    }
+}
+
+struct SafetyAlertsModifier: ViewModifier {
+    @EnvironmentObject var safetyState: SafetyState
+    @Binding var reportTarget: String?
+    let reportContext: String
+
+    // Copied from the binding when the alert opens so the username survives
+    // the alert's dismissal ordering.
+    @State private var pendingTarget = ""
+    @State private var reportReason = ""
+    @State private var showReportAlert = false
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: reportTarget) { _, newValue in
+                if let target = newValue {
+                    pendingTarget = target
+                    reportReason = ""
+                    showReportAlert = true
+                }
+            }
+            .alert("Report \(pendingTarget)", isPresented: $showReportAlert) {
+                TextField("Reason", text: $reportReason)
+                Button("Cancel", role: .cancel) {
+                    reportTarget = nil
+                }
+                Button("Submit Report", role: .destructive) {
+                    SafetyEmitter.reportUser(
+                        username: pendingTarget,
+                        reason: reportReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            ? "No reason given"
+                            : reportReason,
+                        context: reportContext
+                    )
+                    reportTarget = nil
+                }
+            } message: {
+                Text("Reports are reviewed and abusive accounts are removed.")
+            }
+            .alert(
+                "Safety",
+                isPresented: Binding(
+                    get: { safetyState.feedbackMessage != nil },
+                    set: { if !$0 { safetyState.feedbackMessage = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) {
+                    safetyState.feedbackMessage = nil
+                }
+            } message: {
+                Text(safetyState.feedbackMessage ?? "")
+            }
+    }
+}

--- a/iOSClient/BABOnline/Views/Game/GameContainerView.swift
+++ b/iOSClient/BABOnline/Views/Game/GameContainerView.swift
@@ -14,7 +14,12 @@ struct GameContainerView: View {
 
     @State private var showGameLog = false
     @State private var showVoicePanel = false
+    @State private var showLeaveConfirm = false
     @ObservedObject private var voiceManager = VoiceChatManager.shared
+
+    private var isPureSpectator: Bool {
+        gameState.isSpectator && !gameState.isLazy
+    }
 
     var body: some View {
         ZStack {
@@ -79,8 +84,32 @@ struct GameContainerView: View {
                 }
             }
 
+            // Leave/exit game button (always visible during play — Guideline 4)
+            if gameState.phase == .draw || gameState.phase == .bidding || gameState.phase == .playing {
+                VStack {
+                    HStack {
+                        Button(action: handleLeaveTapped) {
+                            HStack(spacing: 4) {
+                                Image(systemName: "rectangle.portrait.and.arrow.right")
+                                Text(isPureSpectator ? "Exit" : "Leave")
+                            }
+                            .font(.caption.bold())
+                            .foregroundColor(Color.Theme.textSecondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 10)
+                            .background(Color.Theme.surface.opacity(0.8))
+                            .clipShape(Capsule())
+                        }
+                        .padding(.leading, 12)
+                        .padding(.top, 80)
+                        Spacer()
+                    }
+                    Spacer()
+                }
+            }
+
             // Game log toggle button
-            if gameState.phase == .bidding || gameState.phase == .playing {
+            if gameState.phase == .draw || gameState.phase == .bidding || gameState.phase == .playing {
                 VStack {
                     HStack {
                         Spacer()
@@ -136,14 +165,25 @@ struct GameContainerView: View {
             if gameState.isSpectator && !gameState.isLazy {
                 VStack {
                     Spacer()
-                    Text("Spectating \u{2014} type /leave to exit")
-                        .font(.caption.bold())
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(Color(red: 0.376, green: 0.647, blue: 0.98).opacity(0.9))
-                        .cornerRadius(8)
-                        .padding(.bottom, 12)
+                    HStack(spacing: 10) {
+                        Text("Spectating")
+                            .font(.caption.bold())
+                            .foregroundColor(.white)
+                        Button(action: { ChatEmitter.sendMessage("/leave") }) {
+                            Text("Exit")
+                                .font(.caption.bold())
+                                .foregroundColor(Color(red: 0.376, green: 0.647, blue: 0.98))
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 4)
+                                .background(Color.white)
+                                .cornerRadius(6)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Color(red: 0.376, green: 0.647, blue: 0.98).opacity(0.9))
+                    .cornerRadius(8)
+                    .padding(.bottom, 12)
                 }
             } else if gameState.isLazy {
                 VStack {
@@ -173,6 +213,14 @@ struct GameContainerView: View {
         }
         .animation(.easeInOut(duration: 0.3), value: gameState.isBidding)
         .animation(.easeInOut(duration: 0.3), value: gameState.phase)
+        .alert("Leave game?", isPresented: $showLeaveConfirm) {
+            Button("Leave Game", role: .destructive) {
+                ChatEmitter.sendMessage("/leave")
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("A bot will finish your hand for you.")
+        }
         .onAppear {
             scene.configure(gameState: gameState)
         }
@@ -183,6 +231,15 @@ struct GameContainerView: View {
         .sheet(isPresented: $showVoicePanel) {
             VoicePanelSheet()
                 .presentationDetents([.medium])
+        }
+    }
+
+    private func handleLeaveTapped() {
+        if isPureSpectator {
+            // Spectators just exit — nothing to confirm
+            ChatEmitter.sendMessage("/leave")
+        } else {
+            showLeaveConfirm = true
         }
     }
 }

--- a/iOSClient/BABOnline/Views/Game/GameLogView.swift
+++ b/iOSClient/BABOnline/Views/Game/GameLogView.swift
@@ -12,6 +12,7 @@ struct GameLogView: View {
     @Binding var isShowing: Bool
     @State private var chatMessage = ""
     @State private var showAutocomplete = false
+    @State private var reportTarget: String?
 
     private static let allCommands: [SlashCommand] = [
         SlashCommand(command: "/lazy", description: "Bot plays for you"),
@@ -61,6 +62,7 @@ struct GameLogView: View {
                                 ForEach(gameState.gameLog) { entry in
                                     GameLogEntryView(entry: entry)
                                         .id(entry.id)
+                                        .reportBlockMenu(for: entry, currentUsername: gameState.username ?? "", reportTarget: $reportTarget)
                                 }
                             }
                             .padding(.horizontal, 12)
@@ -130,6 +132,7 @@ struct GameLogView: View {
                 .padding(.vertical, 60)
             }
         }
+        .safetyAlerts(reportTarget: $reportTarget, reportContext: "game chat")
     }
 
     private func sendChat() {

--- a/iOSClient/BABOnline/Views/Game/VoicePanelSheet.swift
+++ b/iOSClient/BABOnline/Views/Game/VoicePanelSheet.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Bottom sheet showing voice chat participants with mute controls.
 struct VoicePanelSheet: View {
     @ObservedObject var voiceManager = VoiceChatManager.shared
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationView {
@@ -57,6 +58,11 @@ struct VoicePanelSheet: View {
             .background(Color.Theme.background)
             .navigationTitle("Voice Chat")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
         }
     }
 

--- a/iOSClient/BABOnline/Views/GameLobby/LobbyChatView.swift
+++ b/iOSClient/BABOnline/Views/GameLobby/LobbyChatView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct LobbyChatView: View {
     @EnvironmentObject var lobbyState: LobbyState
+    @EnvironmentObject var authState: AuthState
     @State private var message = ""
+    @State private var reportTarget: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -15,6 +17,7 @@ struct LobbyChatView: View {
                         ForEach(lobbyState.messages) { msg in
                             ChatBubbleView(message: msg)
                                 .id(msg.id)
+                                .reportBlockMenu(for: msg, currentUsername: authState.username, reportTarget: $reportTarget)
                         }
                     }
                     .padding(.horizontal, 12)
@@ -47,6 +50,7 @@ struct LobbyChatView: View {
             }
             .padding(8)
         }
+        .safetyAlerts(reportTarget: $reportTarget, reportContext: "lobby chat")
     }
 
     private func sendMessage() {

--- a/iOSClient/BABOnline/Views/MainRoom/AccountSettingsView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/AccountSettingsView.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+
+/// Account management sheet: sign out, legal links, blocked users, and
+/// permanent account deletion (App Store Guideline 5.1.1(v)).
+struct AccountSettingsView: View {
+    @EnvironmentObject var appState: AppState
+    @EnvironmentObject var authState: AuthState
+    @EnvironmentObject var mainRoomState: MainRoomState
+    @EnvironmentObject var lobbyState: LobbyState
+    @EnvironmentObject var gameState: GameState
+    @EnvironmentObject var tournamentState: TournamentState
+    @EnvironmentObject var safetyState: SafetyState
+    @EnvironmentObject var socketService: SocketService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showDeleteConfirm = false
+    @State private var deletePassword = ""
+    @State private var isDeleting = false
+
+    var body: some View {
+        NavigationView {
+            List {
+                accountSection
+                blockedUsersSection
+                legalSection
+                deleteSection
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(Color.Theme.background)
+            .navigationTitle("Account")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .onChange(of: authState.deleteAccountError) { _, newValue in
+                if newValue != nil {
+                    isDeleting = false
+                }
+            }
+            // Present safety feedback (e.g. unblock confirmation/errors) here:
+            // the chat-surface alert hosts are covered while this sheet is up
+            // and can't present, which would defer the alert until dismissal
+            .alert(
+                "Safety",
+                isPresented: Binding(
+                    get: { safetyState.feedbackMessage != nil },
+                    set: { if !$0 { safetyState.feedbackMessage = nil } }
+                )
+            ) {
+                Button("OK", role: .cancel) {
+                    safetyState.feedbackMessage = nil
+                }
+            } message: {
+                Text(safetyState.feedbackMessage ?? "")
+            }
+        }
+        .onDisappear {
+            authState.deleteAccountError = nil
+            safetyState.feedbackMessage = nil
+        }
+    }
+
+    // MARK: - Sections
+
+    private var accountSection: some View {
+        Section {
+            HStack {
+                Text("Signed in as")
+                    .foregroundColor(Color.Theme.textSecondary)
+                Spacer()
+                Text(authState.username)
+                    .bold()
+                    .foregroundColor(Color.Theme.textPrimary)
+            }
+
+            Button(action: signOut) {
+                Text("Sign Out")
+                    .foregroundColor(Color.Theme.primary)
+            }
+        }
+        .listRowBackground(Color.Theme.surface)
+    }
+
+    private var blockedUsersSection: some View {
+        Section("Blocked Users") {
+            if safetyState.blockedUsers.isEmpty {
+                Text("No blocked users")
+                    .foregroundColor(Color.Theme.textDim)
+            } else {
+                ForEach(safetyState.blockedUsers.sorted(), id: \.self) { username in
+                    HStack {
+                        Text(username)
+                            .foregroundColor(Color.Theme.textPrimary)
+                        Spacer()
+                        Button("Unblock") {
+                            SafetyEmitter.unblockUser(username: username)
+                        }
+                        .font(.callout.bold())
+                        .foregroundColor(Color.Theme.primary)
+                        .buttonStyle(.borderless)
+                    }
+                }
+            }
+        }
+        .listRowBackground(Color.Theme.surface)
+    }
+
+    private var legalSection: some View {
+        Section {
+            Link("Privacy Policy", destination: URL(string: "https://babonline.io/privacy")!)
+                .foregroundColor(Color.Theme.primary)
+            Link("Terms of Use", destination: URL(string: "https://babonline.io/terms")!)
+                .foregroundColor(Color.Theme.primary)
+        }
+        .listRowBackground(Color.Theme.surface)
+    }
+
+    @ViewBuilder
+    private var deleteSection: some View {
+        Section {
+            if !showDeleteConfirm {
+                Button(role: .destructive, action: { showDeleteConfirm = true }) {
+                    Text("Delete Account")
+                }
+            } else {
+                Text("Permanently deletes your account, statistics, and profile. This cannot be undone.")
+                    .font(.caption)
+                    .foregroundColor(Color.Theme.textSecondary)
+
+                SecureField("Confirm password", text: $deletePassword)
+                    .textContentType(.password)
+                    .foregroundColor(Color.Theme.textPrimary)
+
+                if let error = authState.deleteAccountError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(Color.Theme.error)
+                }
+
+                Button(role: .destructive, action: deleteAccount) {
+                    HStack {
+                        if isDeleting {
+                            ProgressView()
+                                .tint(Color.Theme.error)
+                                .scaleEffect(0.8)
+                        }
+                        Text("Permanently Delete")
+                            .bold()
+                    }
+                }
+                .disabled(deletePassword.isEmpty || isDeleting)
+
+                Button("Cancel") {
+                    showDeleteConfirm = false
+                    deletePassword = ""
+                    authState.deleteAccountError = nil
+                }
+                .foregroundColor(Color.Theme.textSecondary)
+            }
+        }
+        .listRowBackground(Color.Theme.surface)
+    }
+
+    // MARK: - Actions
+
+    private func signOut() {
+        authState.clearCredentials()
+        gameState.reset()
+        mainRoomState.reset()
+        lobbyState.reset()
+        tournamentState.reset()
+        safetyState.reset()
+        appState.screen = .signIn
+        // Cycle the connection so the server-side session ends; the auto
+        // session restore won't run because credentials are cleared.
+        socketService.forceReconnect()
+        dismiss()
+    }
+
+    private func deleteAccount() {
+        isDeleting = true
+        authState.deleteAccountError = nil
+        AuthEmitter.deleteAccount(password: deletePassword)
+
+        // Fallback so the button doesn't spin forever if no response arrives
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            isDeleting = false
+        }
+    }
+}

--- a/iOSClient/BABOnline/Views/MainRoom/LeaderboardView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/LeaderboardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct LeaderboardView: View {
     @EnvironmentObject var leaderboardState: LeaderboardState
+    @Environment(\.dismiss) private var dismiss
 
     enum SortField: String, CaseIterable {
         case winRate = "Win %"
@@ -88,6 +89,11 @@ struct LeaderboardView: View {
             }
             .navigationTitle("Leaderboard")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
         }
         .onAppear {
             leaderboardState.isLoading = true

--- a/iOSClient/BABOnline/Views/MainRoom/LobbyListView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/LobbyListView.swift
@@ -130,11 +130,13 @@ struct TournamentRowView: View {
     }
 
     private var canJoin: Bool {
-        tournament.phase == "lobby" || tournament.phase == "between_rounds"
+        // New entrants can only join before the tournament starts; returning
+        // members are re-attached automatically at sign-in
+        tournament.phase == "lobby"
     }
 
     private var canSpectate: Bool {
-        tournament.phase == "round_active"
+        tournament.phase == "round_active" || tournament.phase == "between_rounds"
     }
 
     var body: some View {

--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomChatView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomChatView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct MainRoomChatView: View {
     @EnvironmentObject var mainRoomState: MainRoomState
+    @EnvironmentObject var authState: AuthState
     @State private var message = ""
+    @State private var reportTarget: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -25,6 +27,7 @@ struct MainRoomChatView: View {
                         ForEach(mainRoomState.messages) { msg in
                             ChatBubbleView(message: msg)
                                 .id(msg.id)
+                                .reportBlockMenu(for: msg, currentUsername: authState.username, reportTarget: $reportTarget)
                         }
                     }
                     .padding(.horizontal)
@@ -57,6 +60,7 @@ struct MainRoomChatView: View {
             }
             .padding(10)
         }
+        .safetyAlerts(reportTarget: $reportTarget, reportContext: "main room chat")
     }
 
     private func sendMessage() {

--- a/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
+++ b/iOSClient/BABOnline/Views/MainRoom/MainRoomView.swift
@@ -6,6 +6,7 @@ struct MainRoomView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var showLeaderboard = false
     @State private var showOnlineUsers = false
+    @State private var showAccountSettings = false
 
     var body: some View {
         ZStack {
@@ -51,6 +52,9 @@ struct MainRoomView: View {
         .sheet(isPresented: $showOnlineUsers) {
             OnlineUsersSheet(users: mainRoomState.onlineUsers)
         }
+        .sheet(isPresented: $showAccountSettings) {
+            AccountSettingsView()
+        }
     }
 
     // MARK: - Lobby Browser
@@ -82,6 +86,12 @@ struct MainRoomView: View {
                 Button(action: { showOnlineUsers = true }) {
                     Text("\(mainRoomState.onlineCount) online")
                         .font(.caption)
+                        .foregroundColor(Color.Theme.textSecondary)
+                }
+
+                Button(action: { showAccountSettings = true }) {
+                    Image(systemName: "gearshape.fill")
+                        .font(.callout)
                         .foregroundColor(Color.Theme.textSecondary)
                 }
             }

--- a/iOSClient/BABOnline/Views/Tournament/TournamentChatView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentChatView.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct TournamentChatView: View {
     @EnvironmentObject var tournamentState: TournamentState
+    @EnvironmentObject var authState: AuthState
     @State private var message = ""
+    @State private var reportTarget: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -15,6 +17,7 @@ struct TournamentChatView: View {
                         ForEach(tournamentState.messages) { msg in
                             ChatBubbleView(message: msg)
                                 .id(msg.id)
+                                .reportBlockMenu(for: msg, currentUsername: authState.username, reportTarget: $reportTarget)
                         }
                     }
                     .padding(.horizontal, 12)
@@ -47,6 +50,7 @@ struct TournamentChatView: View {
             }
             .padding(8)
         }
+        .safetyAlerts(reportTarget: $reportTarget, reportContext: "tournament chat")
     }
 
     private func sendMessage() {

--- a/iOSClient/BABOnline/Views/Tournament/TournamentLobbyView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentLobbyView.swift
@@ -124,21 +124,26 @@ struct TournamentLobbyView: View {
     }
 
     private var allReady: Bool {
-        !tournamentState.players.isEmpty && tournamentState.players.allSatisfy { $0.isReady }
+        // Disconnected members sit out rounds and never ready up — they must
+        // not gate the Begin button (the server ignores them too)
+        let connected = tournamentState.players.filter { $0.connected }
+        return !connected.isEmpty && connected.allSatisfy { $0.isReady }
     }
 
     private var bottomButtons: some View {
         VStack(spacing: 8) {
             if tournamentState.phase == "lobby" || tournamentState.phase == "between_rounds" {
-                // Ready / Unready
-                Button(action: toggleReady) {
-                    Text(tournamentState.isReady ? "Unready" : "Ready")
-                        .font(.title3.bold())
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 14)
-                        .background(tournamentState.isReady ? Color.Theme.oppColor : Color.Theme.buttonBackground)
-                        .foregroundColor(.white)
-                        .cornerRadius(10)
+                // Ready / Unready (spectators can't ready up)
+                if !tournamentState.isSpectator {
+                    Button(action: toggleReady) {
+                        Text(tournamentState.isReady ? "Unready" : "Ready")
+                            .font(.title3.bold())
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(tournamentState.isReady ? Color.Theme.oppColor : Color.Theme.buttonBackground)
+                            .foregroundColor(.white)
+                            .cornerRadius(10)
+                    }
                 }
 
                 // Begin button (creator only)

--- a/iOSClient/BABOnline/Views/Tournament/TournamentPlayerListView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentPlayerListView.swift
@@ -61,6 +61,13 @@ struct TournamentPlayerListView: View {
                             .cornerRadius(4)
                     }
                 }
+
+                if !player.connected {
+                    Text("reconnecting\u{2026}")
+                        .font(.caption2)
+                        .foregroundColor(Color.Theme.textDim)
+                        .italic()
+                }
             }
 
             Spacer()
@@ -80,5 +87,6 @@ struct TournamentPlayerListView: View {
         .padding(.vertical, 10)
         .background(Color.Theme.surface)
         .cornerRadius(10)
+        .opacity(player.connected ? 1.0 : 0.5)
     }
 }

--- a/iOSClient/BABOnline/Views/Tournament/TournamentResultsView.swift
+++ b/iOSClient/BABOnline/Views/Tournament/TournamentResultsView.swift
@@ -4,8 +4,19 @@ struct TournamentResultsView: View {
     @EnvironmentObject var tournamentState: TournamentState
     @EnvironmentObject var appState: AppState
 
-    private var winner: TournamentScoreEntry? {
-        tournamentState.scoreboard.first
+    private var winnerText: String? {
+        // Server-provided winners handle co-winners on tie; fall back to the
+        // scoreboard leader when winners is empty (e.g. rejoin after complete)
+        if !tournamentState.winners.isEmpty {
+            if tournamentState.winners.count == 1 {
+                return "\(tournamentState.winners[0]) wins!"
+            }
+            return "\(tournamentState.winners.joined(separator: " & ")) tie!"
+        }
+        if let first = tournamentState.scoreboard.first {
+            return "\(first.username) wins!"
+        }
+        return nil
     }
 
     var body: some View {
@@ -22,8 +33,8 @@ struct TournamentResultsView: View {
                     .font(.system(size: 28, weight: .bold, design: .rounded))
                     .foregroundColor(Color.Theme.warning)
 
-                if let winner = winner {
-                    Text("\(winner.username) wins!")
+                if let winnerText = winnerText {
+                    Text(winnerText)
                         .font(.title2.bold())
                         .foregroundColor(Color.Theme.textPrimary)
                 }

--- a/server/database.js
+++ b/server/database.js
@@ -5,7 +5,7 @@ const { dbLogger } = require("./utils/logger");
 const mongoURI = process.env.MONGO_URI || 'mongodb://localhost:27017/babonline';
 const dbName = "babonline";
 
-let db, usersCollection, gameRecordsCollection;
+let db, usersCollection, gameRecordsCollection, reportsCollection;
 
 /**
  * Connect to MongoDB
@@ -18,11 +18,19 @@ async function connectDB() {
         db = client.db(dbName);
         usersCollection = db.collection("users");
         gameRecordsCollection = db.collection("gameRecords");
+        reportsCollection = db.collection("reports");
         await gameRecordsCollection.createIndex({ completedAt: -1 });
+        await reportsCollection.createIndex({ createdAt: -1 });
     } catch (error) {
         dbLogger.error("MongoDB connection failed", { error: error.message });
     }
 }
 
 // ✅ Export database and collection references
-module.exports = { connectDB, getDB: () => db, getUsersCollection: () => usersCollection, getGameRecordsCollection: () => gameRecordsCollection };
+module.exports = {
+    connectDB,
+    getDB: () => db,
+    getUsersCollection: () => usersCollection,
+    getGameRecordsCollection: () => gameRecordsCollection,
+    getReportsCollection: () => reportsCollection
+};

--- a/server/game/GameManager.js
+++ b/server/game/GameManager.js
@@ -35,6 +35,10 @@ class GameManager {
         this.tournaments = new Map();       // tournamentId → TournamentState
         this.playerTournaments = new Map();  // socketId → tournamentId
         this.tournamentGames = new Map();    // gameId → tournamentId
+
+        // Usernames deleted this server lifetime — keeps an in-flight game
+        // from re-inserting a deleted username into new gameRecords
+        this.deletedUsernames = new Set();
     }
 
     // Constants
@@ -157,6 +161,10 @@ class GameManager {
         if (this.playerLobbies.has(socketId)) {
             this.leaveLobby(socketId);
         }
+
+        // Returning from a finished tournament's results screen releases that
+        // membership (active tournaments are left alone)
+        this.releaseCompletedTournamentMembership(socketId);
 
         this.mainRoomSocketIds.add(socketId);
 
@@ -741,14 +749,15 @@ class GameManager {
                     game.markPlayerDisconnected(position);
                 }
             }
-            // Also remove from tournament if in one (e.g. during round_active)
+            // Mark disconnected in tournament (keeps membership/scores so the
+            // player can reattach with a new socket)
             let wasInTournament = false;
             let tournamentResult = null;
             const tournamentId = this.playerTournaments.get(socketId);
             if (tournamentId) {
                 const tournament = this.tournaments.get(tournamentId);
                 if (tournament) {
-                    tournamentResult = this.leaveTournament(socketId);
+                    tournamentResult = this.handleTournamentDisconnect(socketId, tournament);
                     wasInTournament = true;
                 }
             }
@@ -774,7 +783,7 @@ class GameManager {
         if (tournamentId) {
             const tournament = this.tournaments.get(tournamentId);
             if (tournament) {
-                tournamentResult = this.leaveTournament(socketId);
+                tournamentResult = this.handleTournamentDisconnect(socketId, tournament);
                 wasInTournament = true;
             }
         }
@@ -970,6 +979,10 @@ class GameManager {
         const user = this.getUserBySocketId(socketId);
         if (!user) return { success: false, error: 'User not found' };
 
+        // A finished tournament lingering for its results window must not
+        // block new ones
+        this.releaseCompletedTournamentMembership(socketId);
+
         // Check if already in a tournament
         if (this.playerTournaments.has(socketId)) {
             return { success: false, error: 'Already in a tournament' };
@@ -995,6 +1008,12 @@ class GameManager {
         const user = this.getUserBySocketId(socketId);
         if (!user) return { success: false, error: 'User not found' };
 
+        // A finished tournament lingering for its results window must not
+        // block joining a new one (unless they're rejoining that same one)
+        if (this.playerTournaments.get(socketId) !== tournamentId) {
+            this.releaseCompletedTournamentMembership(socketId);
+        }
+
         if (this.playerTournaments.has(socketId)) {
             return { success: false, error: 'Already in a tournament' };
         }
@@ -1002,7 +1021,22 @@ class GameManager {
         const tournament = this.tournaments.get(tournamentId);
         if (!tournament) return { success: false, error: 'Tournament not found' };
 
-        if (tournament.phase !== 'lobby' && tournament.phase !== 'between_rounds') {
+        // Returning member (e.g. reconnecting with a new socket): reattach in
+        // any phase so a dropped connection doesn't forfeit the tournament.
+        const reattach = tournament.reattachPlayerByUsername(user.username, socketId);
+        if (reattach) {
+            if (reattach.oldSocketId !== socketId) {
+                this.playerTournaments.delete(reattach.oldSocketId);
+            }
+            this.playerTournaments.set(socketId, tournamentId);
+            this.leaveMainRoom(socketId);
+            return { success: true, tournament, reattached: true };
+        }
+
+        // New entrants can only join before the tournament starts — joining
+        // mid-tournament would let anyone block the next round by never
+        // readying, and their scoreboard would be missing earlier rounds.
+        if (tournament.phase !== 'lobby') {
             return { success: false, error: 'Tournament is not accepting players' };
         }
 
@@ -1033,9 +1067,9 @@ class GameManager {
         tournament.removePlayer(socketId);
         this.playerTournaments.delete(socketId);
 
-        // If no players left, delete tournament
-        if (tournament.players.size === 0) {
-            this.tournaments.delete(tournamentId);
+        // Delete when empty — or when only disconnected ghosts remain, so a
+        // tournament can't sit in everyone's lobby list forever
+        if (this.deleteTournamentIfAbandoned(tournament)) {
             return { success: true, deleted: true, tournament };
         }
 
@@ -1046,6 +1080,99 @@ class GameManager {
         }
 
         return { success: true, tournament, newCreator };
+    }
+
+    /**
+     * Delete a tournament that has nobody left to play it: no players at all,
+     * or only disconnected ghosts with no round game still running (running
+     * games carry their own 60s reconnect grace).
+     * @returns {boolean} - true if deleted
+     */
+    deleteTournamentIfAbandoned(tournament) {
+        const round = tournament.getCurrentRound();
+        const hasRunningGames = round && round.completedGames.size < round.games.size;
+        if (tournament.players.size === 0 ||
+            (tournament.getConnectedPlayerCount() === 0 && !hasRunningGames)) {
+            this.deleteTournament(tournament.tournamentId);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Drop a socket's membership in a tournament that is already complete (or
+     * gone). Completed tournaments linger briefly so players can view results;
+     * that lingering membership must not block creating/joining new ones.
+     */
+    releaseCompletedTournamentMembership(socketId) {
+        const tournamentId = this.playerTournaments.get(socketId);
+        if (!tournamentId) return;
+
+        const tournament = this.tournaments.get(tournamentId);
+        if (!tournament) {
+            this.playerTournaments.delete(socketId);
+            return;
+        }
+        if (tournament.phase === 'complete') {
+            tournament.removePlayer(socketId);
+            this.playerTournaments.delete(socketId);
+            this.deleteTournamentIfAbandoned(tournament);
+        }
+    }
+
+    /**
+     * Handle a tournament member's socket disconnecting.
+     * In the lobby phase this is a plain leave (nothing to preserve). Once the
+     * tournament has started, the player is only marked disconnected so their
+     * scores survive and they can reattach with a new socket.
+     * @returns {{ success: boolean, tournament?: TournamentState, deleted?: boolean, newCreator?: Object, disconnected?: boolean }}
+     */
+    handleTournamentDisconnect(socketId, tournament) {
+        if (tournament.phase === 'lobby') {
+            return this.leaveTournament(socketId);
+        }
+
+        const wasCreator = tournament.createdBy === socketId;
+        tournament.markPlayerDisconnected(socketId);
+        this.playerTournaments.delete(socketId);
+
+        if (this.deleteTournamentIfAbandoned(tournament)) {
+            return { success: true, deleted: true, tournament, disconnected: true };
+        }
+
+        let newCreator = null;
+        if (wasCreator && tournament.getConnectedPlayerCount() > 0) {
+            newCreator = tournament.transferCreator();
+        }
+
+        return { success: true, tournament, newCreator, disconnected: true };
+    }
+
+    /**
+     * Reattach a reconnecting user (new socket) to the tournament that still
+     * holds a player entry for their username, in any phase.
+     * @param {string} [preferredTournamentId] - When known (e.g. resolved from
+     *   the game being rejoined), reattach only within that tournament — the
+     *   same username can linger as a ghost in an older tournament.
+     * @returns {TournamentState|null}
+     */
+    reattachTournamentPlayer(socketId, username, preferredTournamentId = null) {
+        const candidates = preferredTournamentId
+            ? [[preferredTournamentId, this.tournaments.get(preferredTournamentId)]]
+            : this.tournaments;
+
+        for (const [tournamentId, tournament] of candidates) {
+            if (!tournament) continue;
+            const result = tournament.reattachPlayerByUsername(username, socketId);
+            if (result) {
+                if (result.oldSocketId !== socketId) {
+                    this.playerTournaments.delete(result.oldSocketId);
+                }
+                this.playerTournaments.set(socketId, tournamentId);
+                return tournament;
+            }
+        }
+        return null;
     }
 
     /**

--- a/server/game/GameState.js
+++ b/server/game/GameState.js
@@ -438,6 +438,14 @@ class GameState {
         if (this.resignedPlayers[position]) {
             return this.resignedPlayers[position];
         }
+        // Lazy mode overwrites the player entry with the bot's name — return
+        // the original human for stat/score attribution
+        if (this.lazyPlayers[position]) {
+            return {
+                username: this.lazyPlayers[position].originalUsername,
+                pic: this.lazyPlayers[position].originalPic
+            };
+        }
         return this.getPlayerByPosition(position);
     }
 

--- a/server/game/TournamentState.js
+++ b/server/game/TournamentState.js
@@ -44,7 +44,7 @@ class TournamentState {
     // ========================================
 
     addPlayer(socketId, username, pic) {
-        this.players.set(socketId, { username, pic, ready: false });
+        this.players.set(socketId, { username, pic, ready: false, connected: true });
         // Initialize scoreboard entry
         if (!this.scoreboard[username]) {
             this.scoreboard[username] = {
@@ -54,6 +54,71 @@ class TournamentState {
             };
         }
         this.logAction('addPlayer', { socketId, username });
+    }
+
+    /**
+     * Mark a player disconnected without removing them — keeps their scores and
+     * lets them reattach with a new socket. Returns the player or null.
+     */
+    markPlayerDisconnected(socketId) {
+        const player = this.players.get(socketId);
+        if (!player) return null;
+
+        player.connected = false;
+        player.ready = false;
+        this.readyPlayers.delete(socketId);
+
+        this.logAction('markPlayerDisconnected', { socketId, username: player.username });
+        return player;
+    }
+
+    /**
+     * Re-key an existing player entry (matched by username) to a new socket.
+     * Used when a player reconnects mid-tournament.
+     * @returns {{ oldSocketId: string } | null}
+     */
+    reattachPlayerByUsername(username, newSocketId) {
+        for (const [oldSocketId, player] of this.players.entries()) {
+            if (player.username === username) {
+                if (oldSocketId === newSocketId) {
+                    player.connected = true;
+                    this.recoverCreatorIfDisconnected();
+                    return { oldSocketId };
+                }
+                this.players.delete(oldSocketId);
+                this.readyPlayers.delete(oldSocketId);
+                player.connected = true;
+                player.ready = false;
+                this.players.set(newSocketId, player);
+                if (this.createdBy === oldSocketId) {
+                    this.createdBy = newSocketId;
+                }
+                this.recoverCreatorIfDisconnected();
+                this.logAction('reattachPlayer', { username, oldSocketId, newSocketId });
+                return { oldSocketId };
+            }
+        }
+        return null;
+    }
+
+    /**
+     * If the creator role is stuck on a disconnected/missing socket (e.g.
+     * everyone dropped at once, so no transfer happened at disconnect time),
+     * hand it to a connected player so Begin/Cancel work again.
+     */
+    recoverCreatorIfDisconnected() {
+        const creatorEntry = this.players.get(this.createdBy);
+        if (!creatorEntry || creatorEntry.connected === false) {
+            this.transferCreator();
+        }
+    }
+
+    getConnectedPlayerCount() {
+        let count = 0;
+        for (const [, player] of this.players) {
+            if (player.connected !== false) count++;
+        }
+        return count;
     }
 
     removePlayer(socketId) {
@@ -101,8 +166,15 @@ class TournamentState {
     }
 
     allPlayersReady() {
-        if (this.players.size === 0) return false;
-        return this.readyPlayers.size === this.players.size;
+        // Disconnected players don't block readiness — they're excluded from
+        // round pairings until they reattach.
+        let connected = 0;
+        for (const [socketId, player] of this.players.entries()) {
+            if (player.connected === false) continue;
+            connected++;
+            if (!this.readyPlayers.has(socketId)) return false;
+        }
+        return connected > 0;
     }
 
     resetAllReady() {
@@ -117,7 +189,16 @@ class TournamentState {
      * @returns {{ socketId: string, username: string } | null} New creator, or null if no humans remain
      */
     transferCreator() {
-        // Find first player that isn't the current creator
+        // Prefer a connected player that isn't the current creator
+        for (const [socketId, player] of this.players.entries()) {
+            if (socketId !== this.createdBy && player.connected !== false) {
+                this.createdBy = socketId;
+                this.creatorUsername = player.username;
+                this.logAction('transferCreator', { newCreator: player.username });
+                return { socketId, username: player.username };
+            }
+        }
+        // Fall back to any other player
         for (const [socketId, player] of this.players.entries()) {
             if (socketId !== this.createdBy) {
                 this.createdBy = socketId;
@@ -186,7 +267,22 @@ class TournamentState {
 
         const entry = this.scoreboard[username];
         const roundScore = details.teamScore;
-        entry.roundScores.push(roundScore);
+        const roundIdx = (details.roundNumber || this.currentRound) - 1;
+
+        // Index by round number (padding missed rounds with 0) so scoreboard
+        // columns stay aligned for players who missed a round or joined late.
+        if (roundIdx >= 0) {
+            if (entry.roundScores[roundIdx] !== undefined) {
+                this.logAction('recordPlayerRoundScore:duplicate', { username, roundIdx });
+                return;
+            }
+            while (entry.roundScores.length < roundIdx) {
+                entry.roundScores.push(0);
+            }
+            entry.roundScores[roundIdx] = roundScore;
+        } else {
+            entry.roundScores.push(roundScore);
+        }
         entry.roundDetails.push(details);
         entry.totalScore += roundScore;
 
@@ -239,9 +335,30 @@ class TournamentState {
                 username,
                 ...data
             }))
-            .sort((a, b) => b.totalScore - a.totalScore);
+            .sort((a, b) => b.totalScore - a.totalScore || a.username.localeCompare(b.username));
 
         return entries;
+    }
+
+    /**
+     * All entrants tied for the top score (co-winners on a tie).
+     * @returns {string[]} usernames
+     */
+    getWinners() {
+        const scoreboard = this.getScoreboard();
+        if (scoreboard.length === 0) return [];
+
+        // Only current members can win — scoreboard entries persist for
+        // players who quit, and a no-show's 0 can beat real (negative) totals
+        const memberNames = new Set();
+        for (const [, player] of this.players) {
+            memberNames.add(player.username);
+        }
+        const eligible = scoreboard.filter(e => memberNames.has(e.username));
+        const pool = eligible.length > 0 ? eligible : scoreboard;
+
+        const top = pool[0].totalScore;
+        return pool.filter(e => e.totalScore === top).map(e => e.username);
     }
 
     // ========================================
@@ -332,11 +449,12 @@ class TournamentState {
                 username: player.username,
                 pic: player.pic,
                 ready: player.ready,
+                connected: player.connected !== false,
                 isCreator: socketId === this.createdBy
             });
         }
 
-        return {
+        const state = {
             tournamentId: this.tournamentId,
             name: this.name,
             phase: this.phase,
@@ -349,6 +467,14 @@ class TournamentState {
             creatorUsername: this.creatorUsername,
             creatorSocketId: this.createdBy
         };
+
+        // Returning to a finished tournament must show the same (co-)winners
+        // the tournamentComplete broadcast announced
+        if (this.phase === 'complete') {
+            state.winners = this.getWinners();
+        }
+
+        return state;
     }
 
     // ========================================

--- a/server/game/__tests__/GameManagerTournament.test.js
+++ b/server/game/__tests__/GameManagerTournament.test.js
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for GameManager tournament lifecycle: join/reattach rules,
+ * disconnect handling, and round completion via game end/abort.
+ */
+
+let gameManager;
+
+beforeEach(() => {
+    jest.resetModules();
+    gameManager = require('../GameManager');
+});
+
+function createTournamentWithPlayers(usernames) {
+    gameManager.registerUser('creatorSocket', usernames[0]);
+    const { tournament } = gameManager.createTournament('creatorSocket', 'Test');
+    for (let i = 1; i < usernames.length; i++) {
+        const socketId = `socket${i}`;
+        gameManager.registerUser(socketId, usernames[i]);
+        gameManager.joinTournament(socketId, tournament.tournamentId);
+    }
+    return tournament;
+}
+
+describe('GameManager tournaments', () => {
+    describe('joinTournament', () => {
+        test('new players can join in the lobby phase', () => {
+            const tournament = createTournamentWithPlayers(['alice']);
+            gameManager.registerUser('s2', 'bob');
+
+            const result = gameManager.joinTournament('s2', tournament.tournamentId);
+
+            expect(result.success).toBe(true);
+            expect(tournament.players.size).toBe(2);
+        });
+
+        test('new players cannot join once the tournament has started', () => {
+            const tournament = createTournamentWithPlayers(['alice']);
+            tournament.startRound(1);
+            tournament.completeRound(); // between_rounds
+
+            gameManager.registerUser('s2', 'bob');
+            const result = gameManager.joinTournament('s2', tournament.tournamentId);
+
+            expect(result.success).toBe(false);
+        });
+
+        test('a returning member reattaches in any phase', () => {
+            const tournament = createTournamentWithPlayers(['alice', 'bob']);
+            tournament.startRound(1); // round_active
+            gameManager.handleTournamentDisconnect('socket1', tournament);
+
+            gameManager.registerUser('newSocket', 'bob');
+            const result = gameManager.joinTournament('newSocket', tournament.tournamentId);
+
+            expect(result.success).toBe(true);
+            expect(result.reattached).toBe(true);
+            expect(tournament.getPlayerBySocketId('newSocket').username).toBe('bob');
+            expect(gameManager.getPlayerTournament('newSocket')).toBe(tournament);
+        });
+    });
+
+    describe('handleTournamentDisconnect', () => {
+        test('lobby-phase disconnects are plain leaves', () => {
+            const tournament = createTournamentWithPlayers(['alice', 'bob']);
+
+            const result = gameManager.handleTournamentDisconnect('socket1', tournament);
+
+            expect(result.success).toBe(true);
+            expect(tournament.players.size).toBe(1);
+            expect(tournament.getPlayerByUsername('bob')).toBeNull();
+        });
+
+        test('mid-tournament disconnects keep membership and scores', () => {
+            const tournament = createTournamentWithPlayers(['alice', 'bob']);
+            tournament.recordPlayerRoundScore('bob', { roundNumber: 1, teamScore: 100 });
+            tournament.startRound(1);
+
+            const result = gameManager.handleTournamentDisconnect('socket1', tournament);
+
+            expect(result.disconnected).toBe(true);
+            expect(tournament.getPlayerByUsername('bob')).not.toBeNull();
+            expect(tournament.getPlayerByUsername('bob').connected).toBe(false);
+            expect(tournament.scoreboard.bob.totalScore).toBe(100);
+        });
+
+        test('creator disconnect mid-tournament transfers creatorship', () => {
+            const tournament = createTournamentWithPlayers(['alice', 'bob']);
+            tournament.startRound(1);
+
+            const result = gameManager.handleTournamentDisconnect('creatorSocket', tournament);
+
+            expect(result.newCreator.username).toBe('bob');
+            expect(tournament.createdBy).toBe('socket1');
+        });
+
+        test('deletes the tournament when nobody is connected and no games are running', () => {
+            const tournament = createTournamentWithPlayers(['alice', 'bob']);
+            tournament.startRound(1);
+            tournament.addGameToRound('g1', ['alice', 'bob'], 2);
+            tournament.markGameComplete('g1');
+            tournament.completeRound(); // between_rounds, no running games
+
+            gameManager.handleTournamentDisconnect('socket1', tournament);
+            const result = gameManager.handleTournamentDisconnect('creatorSocket', tournament);
+
+            expect(result.deleted).toBe(true);
+            expect(gameManager.getTournamentById(tournament.tournamentId)).toBeNull();
+        });
+
+        test('keeps the tournament while a round game is still running', () => {
+            const tournament = createTournamentWithPlayers(['alice', 'bob']);
+            tournament.startRound(1);
+            tournament.addGameToRound('g1', ['alice', 'bob'], 2);
+
+            gameManager.handleTournamentDisconnect('socket1', tournament);
+            const result = gameManager.handleTournamentDisconnect('creatorSocket', tournament);
+
+            expect(result.deleted).toBeUndefined();
+            expect(gameManager.getTournamentById(tournament.tournamentId)).toBe(tournament);
+        });
+    });
+
+    describe('handleTournamentGameEnd', () => {
+        test('marks games complete and reports round completion', () => {
+            const tournament = createTournamentWithPlayers(['alice']);
+            tournament.startRound(1);
+            tournament.addGameToRound('g1', ['alice'], 3);
+            tournament.addGameToRound('g2', ['x'], 3);
+            gameManager.tournamentGames.set('g1', tournament.tournamentId);
+            gameManager.tournamentGames.set('g2', tournament.tournamentId);
+
+            const first = gameManager.handleTournamentGameEnd('g1');
+            expect(first.roundComplete).toBe(false);
+
+            const second = gameManager.handleTournamentGameEnd('g2');
+            expect(second.roundComplete).toBe(true);
+            expect(tournament.phase).toBe('between_rounds');
+            expect(gameManager.tournamentGames.has('g1')).toBe(false);
+            expect(gameManager.tournamentGames.has('g2')).toBe(false);
+        });
+
+        test('returns null for non-tournament games', () => {
+            expect(gameManager.handleTournamentGameEnd('not-a-game')).toBeNull();
+        });
+    });
+
+    describe('reattachTournamentPlayer', () => {
+        test('finds the tournament by username and re-keys membership', () => {
+            const tournament = createTournamentWithPlayers(['alice', 'bob']);
+            tournament.startRound(1);
+            gameManager.handleTournamentDisconnect('socket1', tournament);
+
+            const found = gameManager.reattachTournamentPlayer('freshSocket', 'bob');
+
+            expect(found).toBe(tournament);
+            expect(gameManager.getPlayerTournament('freshSocket')).toBe(tournament);
+            expect(tournament.getPlayerBySocketId('freshSocket').connected).toBe(true);
+        });
+
+        test('returns null when the user has no tournament', () => {
+            expect(gameManager.reattachTournamentPlayer('s1', 'ghost')).toBeNull();
+        });
+    });
+});

--- a/server/game/__tests__/TournamentState.test.js
+++ b/server/game/__tests__/TournamentState.test.js
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for TournamentState — lifecycle, player distribution, scoring
+ * alignment, disconnect/reattach handling, and winner determination.
+ */
+
+const TournamentState = require('../TournamentState');
+
+function makeTournament() {
+    return new TournamentState('tid-1234-5678', 'Test Tournament', 'creatorSocket', 'creator');
+}
+
+describe('TournamentState', () => {
+    describe('player management', () => {
+        test('addPlayer marks players connected and seeds scoreboard', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+
+            const player = t.getPlayerBySocketId('s1');
+            expect(player.connected).toBe(true);
+            expect(t.scoreboard.alice).toEqual({
+                totalScore: 0,
+                roundScores: [],
+                roundDetails: []
+            });
+        });
+
+        test('markPlayerDisconnected keeps the entry but clears ready', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+            t.setReady('s1');
+
+            const player = t.markPlayerDisconnected('s1');
+
+            expect(player.username).toBe('alice');
+            expect(player.connected).toBe(false);
+            expect(player.ready).toBe(false);
+            expect(t.readyPlayers.has('s1')).toBe(false);
+            expect(t.players.has('s1')).toBe(true);
+        });
+
+        test('reattachPlayerByUsername re-keys the entry to the new socket', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+            t.markPlayerDisconnected('s1');
+
+            const result = t.reattachPlayerByUsername('alice', 's2');
+
+            expect(result).toEqual({ oldSocketId: 's1' });
+            expect(t.players.has('s1')).toBe(false);
+            expect(t.getPlayerBySocketId('s2').username).toBe('alice');
+            expect(t.getPlayerBySocketId('s2').connected).toBe(true);
+        });
+
+        test('reattachPlayerByUsername transfers creatorship to the new socket', () => {
+            const t = makeTournament();
+            t.addPlayer('creatorSocket', 'creator', null);
+            t.markPlayerDisconnected('creatorSocket');
+
+            t.reattachPlayerByUsername('creator', 'newSocket');
+
+            expect(t.createdBy).toBe('newSocket');
+        });
+
+        test('reattachPlayerByUsername returns null for unknown usernames', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+            expect(t.reattachPlayerByUsername('mallory', 's9')).toBeNull();
+        });
+    });
+
+    describe('allPlayersReady', () => {
+        test('requires every connected player to be ready', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+            t.addPlayer('s2', 'bob', null);
+            t.setReady('s1');
+
+            expect(t.allPlayersReady()).toBe(false);
+            t.setReady('s2');
+            expect(t.allPlayersReady()).toBe(true);
+        });
+
+        test('disconnected players do not block readiness', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+            t.addPlayer('s2', 'bob', null);
+            t.setReady('s1');
+            t.markPlayerDisconnected('s2');
+
+            expect(t.allPlayersReady()).toBe(true);
+        });
+
+        test('false when nobody is connected', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+            t.markPlayerDisconnected('s1');
+            expect(t.allPlayersReady()).toBe(false);
+        });
+
+        test('false with no players', () => {
+            expect(makeTournament().allPlayersReady()).toBe(false);
+        });
+    });
+
+    describe('transferCreator', () => {
+        test('prefers a connected player over a disconnected one', () => {
+            const t = makeTournament();
+            t.addPlayer('creatorSocket', 'creator', null);
+            t.addPlayer('s2', 'bob', null);
+            t.addPlayer('s3', 'carol', null);
+            t.markPlayerDisconnected('s2');
+
+            const result = t.transferCreator();
+
+            expect(result.username).toBe('carol');
+            expect(t.createdBy).toBe('s3');
+        });
+    });
+
+    describe('round lifecycle', () => {
+        test('round completes only when every game is marked complete', () => {
+            const t = makeTournament();
+            t.startRound(1);
+            t.addGameToRound('g1', ['alice', 'bob'], 2);
+            t.addGameToRound('g2', ['carol', 'dave'], 2);
+
+            expect(t.isRoundComplete()).toBe(false);
+            t.markGameComplete('g1');
+            expect(t.isRoundComplete()).toBe(false);
+            t.markGameComplete('g2');
+            expect(t.isRoundComplete()).toBe(true);
+        });
+
+        test('completeRound moves to between_rounds before the final round', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+            t.setReady('s1');
+            t.startRound(1);
+            t.completeRound();
+
+            expect(t.phase).toBe('between_rounds');
+            expect(t.readyPlayers.size).toBe(0);
+        });
+
+        test('completeRound finishes the tournament after the last round', () => {
+            const t = makeTournament();
+            t.startRound(4);
+            t.completeRound();
+
+            expect(t.phase).toBe('complete');
+            expect(t.isTournamentComplete()).toBe(true);
+        });
+    });
+
+    describe('recordPlayerRoundScore', () => {
+        test('stores scores under the round index, not append order', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+            t.currentRound = 1;
+            t.recordPlayerRoundScore('alice', { roundNumber: 1, teamScore: 120 });
+            t.currentRound = 3;
+            t.recordPlayerRoundScore('alice', { roundNumber: 3, teamScore: 80 });
+
+            expect(t.scoreboard.alice.roundScores).toEqual([120, 0, 80]);
+            expect(t.scoreboard.alice.totalScore).toBe(200);
+        });
+
+        test('pads missed earlier rounds with 0 for late joiners', () => {
+            const t = makeTournament();
+            t.recordPlayerRoundScore('latecomer', { roundNumber: 3, teamScore: 50 });
+
+            expect(t.scoreboard.latecomer.roundScores).toEqual([0, 0, 50]);
+            expect(t.scoreboard.latecomer.totalScore).toBe(50);
+        });
+
+        test('ignores duplicate recordings for the same round', () => {
+            const t = makeTournament();
+            t.recordPlayerRoundScore('alice', { roundNumber: 1, teamScore: 100 });
+            t.recordPlayerRoundScore('alice', { roundNumber: 1, teamScore: 999 });
+
+            expect(t.scoreboard.alice.roundScores).toEqual([100]);
+            expect(t.scoreboard.alice.totalScore).toBe(100);
+        });
+    });
+
+    describe('scoreboard and winners', () => {
+        test('sorts by total score, then username for determinism', () => {
+            const t = makeTournament();
+            t.recordPlayerRoundScore('zed', { roundNumber: 1, teamScore: 100 });
+            t.recordPlayerRoundScore('amy', { roundNumber: 1, teamScore: 100 });
+            t.recordPlayerRoundScore('bob', { roundNumber: 1, teamScore: 200 });
+
+            const board = t.getScoreboard();
+            expect(board.map(e => e.username)).toEqual(['bob', 'amy', 'zed']);
+        });
+
+        test('getWinners returns all entrants tied at the top', () => {
+            const t = makeTournament();
+            t.recordPlayerRoundScore('zed', { roundNumber: 1, teamScore: 200 });
+            t.recordPlayerRoundScore('amy', { roundNumber: 1, teamScore: 200 });
+            t.recordPlayerRoundScore('bob', { roundNumber: 1, teamScore: 50 });
+
+            expect(t.getWinners()).toEqual(['amy', 'zed']);
+        });
+
+        test('getWinners is empty for an empty scoreboard', () => {
+            expect(makeTournament().getWinners()).toEqual([]);
+        });
+    });
+
+    describe('distributePlayersIntoGames', () => {
+        function totalHumans(games) {
+            return games.reduce((sum, g) => sum + g.humans.length, 0);
+        }
+
+        test.each([
+            [0, 0],
+            [1, 1],
+            [2, 1],
+            [3, 1],
+            [4, 1],
+            [5, 2],
+            [6, 2],
+            [7, 2],
+            [8, 2],
+            [9, 3],
+            [12, 3]
+        ])('%i players → %i games, every game has 4 seats', (n, expectedGames) => {
+            const usernames = Array.from({ length: n }, (_, i) => `p${i}`);
+            const games = TournamentState.distributePlayersIntoGames(usernames);
+
+            expect(games).toHaveLength(expectedGames);
+            expect(totalHumans(games)).toBe(n);
+            for (const game of games) {
+                expect(game.humans.length + game.botCount).toBe(4);
+            }
+        });
+    });
+
+    describe('getClientState', () => {
+        test('includes connected flags on players', () => {
+            const t = makeTournament();
+            t.addPlayer('s1', 'alice', null);
+            t.addPlayer('s2', 'bob', null);
+            t.markPlayerDisconnected('s2');
+
+            const state = t.getClientState();
+            const alice = state.players.find(p => p.username === 'alice');
+            const bob = state.players.find(p => p.username === 'bob');
+
+            expect(alice.connected).toBe(true);
+            expect(bob.connected).toBe(false);
+        });
+    });
+});

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -46,7 +46,8 @@ router.get('/privacy', (req, res) => {
     <p>Data is stored in a MongoDB database hosted on Railway. Passwords are hashed with bcrypt and are never stored in plain text.</p>
 
     <h2>Data Deletion</h2>
-    <p>To request deletion of your account and all associated data, contact us at the support link below.</p>
+    <p>You can permanently delete your account and all associated data directly in the app: open <strong>Settings → Delete Account</strong> (iOS) or your <strong>profile page → Delete Account</strong> (web), confirm with your password, and your account, statistics, and profile data are removed immediately. Your username is also anonymized in historical game records.</p>
+    <p>You may also email <a href="mailto:support@zalberico.com">support@zalberico.com</a> if you prefer; we will process the request within 48 hours.</p>
 
     <h2>Children's Privacy</h2>
     <p>BAB Online does not knowingly collect data from children under 13. The game contains no advertising, in-app purchases, or tracking.</p>
@@ -102,7 +103,8 @@ router.get('/support', (req, res) => {
 
     <details>
         <summary>How do I delete my account?</summary>
-        <p>To request deletion of your account and all associated data, email <a href="mailto:support@zalberico.com">support@zalberico.com</a> with your username. We will delete your account within 48 hours.</p>
+        <p>You can delete your account directly in the app. On iOS, open <strong>Settings</strong> (the gear icon in the main room) and tap <strong>Delete Account</strong>; on the web, open your <strong>profile page</strong> and click <strong>Delete Account</strong>. You'll confirm with your password, and your account, statistics, and profile data are deleted immediately. Your username is anonymized in historical game records.</p>
+        <p>You may also email <a href="mailto:support@zalberico.com">support@zalberico.com</a> with your username and we will delete your account within 48 hours.</p>
     </details>
 
     <details>
@@ -126,6 +128,55 @@ router.get('/support', (req, res) => {
 
     <h2>Links</h2>
     <p><a href="/privacy">Privacy Policy</a></p>
+</body>
+</html>`);
+});
+
+// Terms of Use — includes the zero-tolerance UGC policy required by App Store Guideline 1.2
+router.get('/terms', (req, res) => {
+    res.send(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BAB Online - Terms of Use</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 700px; margin: 40px auto; padding: 0 20px; color: #e0e0e0; background: #1a1a1a; line-height: 1.6; }
+        h1 { color: #4dcc73; }
+        h2 { color: #ccc; margin-top: 2em; }
+        p { margin: 0.8em 0; }
+        a { color: #4dcc73; }
+        ul { margin: 0.8em 0; }
+    </style>
+</head>
+<body>
+    <h1>BAB Online — Terms of Use</h1>
+    <p><strong>Last updated:</strong> June 9, 2026</p>
+
+    <h2>Acceptance</h2>
+    <p>By creating an account or playing BAB Online you agree to these terms. If you do not agree, do not use the service.</p>
+
+    <h2>User Conduct — Zero Tolerance for Objectionable Content</h2>
+    <p>BAB Online includes text chat and voice chat with other players. There is <strong>no tolerance for objectionable content or abusive behavior</strong>, including but not limited to:</p>
+    <ul>
+        <li>Harassment, threats, or hate speech</li>
+        <li>Obscene, sexual, or violent content</li>
+        <li>Offensive usernames, lobby names, or profile pictures</li>
+        <li>Spam or impersonation</li>
+    </ul>
+    <p>Violations may result in immediate account termination without notice.</p>
+
+    <h2>Moderation Tools</h2>
+    <p>You can <strong>report</strong> any player and <strong>block</strong> any player from within the app (block hides their chat messages from you immediately). Reports are reviewed within 24 hours, and offending users may be removed.</p>
+
+    <h2>Accounts</h2>
+    <p>You are responsible for your account. You may delete your account at any time in the app (Settings → Delete Account on iOS, profile page on web); see the <a href="/privacy">Privacy Policy</a> for what deletion removes.</p>
+
+    <h2>Service</h2>
+    <p>BAB Online is provided free of charge, as-is, with no warranty. We may modify or discontinue the service at any time.</p>
+
+    <h2>Contact</h2>
+    <p>Email: <a href="mailto:support@zalberico.com">support@zalberico.com</a></p>
 </body>
 </html>`);
 });

--- a/server/socket/authHandlers.js
+++ b/server/socket/authHandlers.js
@@ -4,7 +4,7 @@
 
 const bcrypt = require('bcryptjs');
 const { v4: uuidv4 } = require('uuid');
-const { getUsersCollection } = require('../database');
+const { getUsersCollection, getGameRecordsCollection } = require('../database');
 const gameManager = require('../game/GameManager');
 const { authLogger } = require('../utils/logger');
 
@@ -61,13 +61,16 @@ async function signIn(socket, io, data) {
         const activeGameId = user.activeGameId;
         const activeGame = activeGameId ? gameManager.getGameById(activeGameId) : null;
 
+        const blockedUsers = user.blockedUsers || [];
+
         if (activeGame) {
             // User has an active game - notify client
             socket.emit('signInResponse', {
                 success: true,
                 username,
                 sessionToken,
-                activeGameId: activeGameId
+                activeGameId: activeGameId,
+                blockedUsers
             });
             authLogger.info('User signed in with active game', { username, socketId: socket.id, gameId: activeGameId });
         } else {
@@ -85,14 +88,15 @@ async function signIn(socket, io, data) {
                     success: true,
                     username,
                     sessionToken,
-                    activeTournamentId
+                    activeTournamentId,
+                    blockedUsers
                 });
                 authLogger.info('User signed in with active tournament', { username, socketId: socket.id, tournamentId: activeTournamentId });
             } else {
                 if (activeTournamentId) {
                     await gameManager.clearActiveTournament(username);
                 }
-                socket.emit('signInResponse', { success: true, username, sessionToken });
+                socket.emit('signInResponse', { success: true, username, sessionToken, blockedUsers });
                 authLogger.info('User signed in', { username, socketId: socket.id });
             }
         }
@@ -119,6 +123,18 @@ async function signUp(socket, io, data) {
     }
 
     const { username, password } = data;
+
+    // Substring matching for usernames — embedded slurs in handles like
+    // "xX_slur_Xx" must be rejected, not just standalone words
+    const { containsProfanitySubstring } = require('../utils/profanityFilter');
+    if (containsProfanitySubstring(username)) {
+        socket.emit('signUpResponse', {
+            success: false,
+            message: 'That username is not allowed.'
+        });
+        authLogger.warn('Sign-up failed: username rejected by filter', { username });
+        return;
+    }
 
     try {
         const existingUser = await usersCollection.findOne({ username });
@@ -153,6 +169,10 @@ async function signUp(socket, io, data) {
                 totalTricksTaken: 0
             }
         });
+
+        // The name now belongs to a fresh account — stop anonymizing it in
+        // new game records (only relevant if a deleted name is re-registered)
+        gameManager.deletedUsernames.delete(username);
 
         // Auto-login: register with game manager (same as signIn)
         gameManager.registerUser(socket.id, username);
@@ -210,12 +230,14 @@ async function restoreSession(socket, io, data) {
         // Check if user has an active game they can rejoin
         const activeGameId = user.activeGameId;
         const activeGame = activeGameId ? gameManager.getGameById(activeGameId) : null;
+        const blockedUsers = user.blockedUsers || [];
 
         if (activeGame) {
             socket.emit('restoreSessionResponse', {
                 success: true,
                 username,
-                activeGameId: activeGameId
+                activeGameId: activeGameId,
+                blockedUsers
             });
             authLogger.info('Session restored with active game', { username, socketId: socket.id, gameId: activeGameId });
         } else {
@@ -232,14 +254,15 @@ async function restoreSession(socket, io, data) {
                 socket.emit('restoreSessionResponse', {
                     success: true,
                     username,
-                    activeTournamentId
+                    activeTournamentId,
+                    blockedUsers
                 });
                 authLogger.info('Session restored with active tournament', { username, socketId: socket.id, tournamentId: activeTournamentId });
             } else {
                 if (activeTournamentId) {
                     await gameManager.clearActiveTournament(username);
                 }
-                socket.emit('restoreSessionResponse', { success: true, username });
+                socket.emit('restoreSessionResponse', { success: true, username, blockedUsers });
                 authLogger.info('Session restored', { username, socketId: socket.id });
             }
         }
@@ -253,8 +276,107 @@ async function restoreSession(socket, io, data) {
     }
 }
 
+/**
+ * Permanently delete the signed-in user's account (App Store Guideline
+ * 5.1.1(v) requires in-app deletion). Requires password re-confirmation.
+ * Removes the user document and anonymizes the username in historical game
+ * records, which are shared documents describing other players' games too.
+ */
+async function deleteAccount(socket, io, data) {
+    const usersCollection = getUsersCollection();
+    const { password } = data;
+
+    if (!usersCollection) {
+        socket.emit('deleteAccountResponse', {
+            success: false,
+            message: 'Database not ready. Try again.'
+        });
+        return;
+    }
+
+    // Only the authenticated session may delete its own account — never
+    // accept a client-supplied username here
+    const sessionUser = gameManager.getUserBySocketId(socket.id);
+    if (!sessionUser) {
+        socket.emit('deleteAccountResponse', {
+            success: false,
+            message: 'Not signed in'
+        });
+        return;
+    }
+    const username = sessionUser.username;
+
+    try {
+        const user = await usersCollection.findOne({ username });
+        if (!user) {
+            socket.emit('deleteAccountResponse', {
+                success: false,
+                message: 'Account not found'
+            });
+            return;
+        }
+
+        const passwordMatch = await bcrypt.compare(password, user.password);
+        if (!passwordMatch) {
+            socket.emit('deleteAccountResponse', {
+                success: false,
+                message: 'Incorrect password'
+            });
+            authLogger.warn('Account deletion failed: incorrect password', { username });
+            return;
+        }
+
+        const gameRecords = getGameRecordsCollection();
+        if (gameRecords) {
+            await gameRecords.updateMany(
+                { team1Players: username },
+                { $set: { 'team1Players.$[p]': '[deleted]' } },
+                { arrayFilters: [{ p: username }] }
+            );
+            await gameRecords.updateMany(
+                { team2Players: username },
+                { $set: { 'team2Players.$[p]': '[deleted]' } },
+                { arrayFilters: [{ p: username }] }
+            );
+        }
+
+        // Removes password hash, session token, stats (and with them the
+        // leaderboard entry), profile pictures, and active game/tournament
+        // pointers in one shot — everything else is keyed by this document
+        await usersCollection.deleteOne({ username });
+
+        // Keep an in-flight game from re-inserting this username into a new
+        // game record after the anonymization above
+        gameManager.deletedUsernames.add(username);
+
+        // Force-logout any other device signed into this account
+        if (user.socketId && user.socketId !== socket.id) {
+            const otherSocket = io.sockets.sockets.get(user.socketId);
+            if (otherSocket) {
+                otherSocket.emit('forceLogout');
+                otherSocket.disconnect();
+            }
+        }
+
+        socket.emit('deleteAccountResponse', { success: true });
+        authLogger.info('Account deleted', { username, socketId: socket.id });
+
+        // Disconnect after the response flushes; the normal disconnect flow
+        // cleans up any lobby/queue/game/tournament state
+        setTimeout(() => socket.disconnect(true), 500);
+
+    } catch (error) {
+        authLogger.error('Database error during account deletion', { username, error: error.message });
+        socket.emit('deleteAccountResponse', {
+            success: false,
+            message: 'Database error. Try again.'
+        });
+    }
+}
+
 module.exports = {
     signIn,
     signUp,
-    restoreSession
+    restoreSession,
+    deleteAccount
 };

--- a/server/socket/chatHandlers.js
+++ b/server/socket/chatHandlers.js
@@ -198,6 +198,13 @@ function handleLeaveCommand(socket, io, game, position) {
         socketLogger.warn('All humans permanently left, aborting game', { gameId: game.gameId });
         game.broadcast(io, 'abortGame', { reason: 'All players left' });
         gameManager.clearActiveGameForAll(game.gameId);
+        // Tournament games must still count toward round completion
+        const { handleAbortedTournamentGame } = require('./tournamentHandlers');
+        handleAbortedTournamentGame(io, game.gameId).catch(err =>
+            socketLogger.error('Failed to resolve aborted tournament game', {
+                gameId: game.gameId, error: err.message
+            })
+        );
         game.leaveAllFromRoom(io);
         gameManager.abortGame(game.gameId);
         botController.cleanupGame(game.gameId);
@@ -209,6 +216,57 @@ function handleLeaveCommand(socket, io, game, position) {
     }
 
     return true;
+}
+
+/**
+ * Leave during the draw phase, before positions exist. Mirrors the
+ * disconnect-during-draw handling: auto-draw a card for the leaver so the
+ * phase can complete, mark their seat for bot replacement, and send them out.
+ */
+function handleDrawPhaseLeave(socket, io, game) {
+    const user = gameManager.getUserBySocketId(socket.id);
+    const username = user?.username || 'Player';
+
+    const alreadyDrew = game.drawIDs.includes(socket.id);
+    if (!alreadyDrew && game.deck && game.deck.cards.length > 0) {
+        const drawIndex = Math.floor(Math.random() * game.deck.cards.length);
+        const card = game.deck.cards[drawIndex];
+        game.drawCards.push(card);
+        game.drawIDs.push(socket.id);
+        game.deck.cards.splice(drawIndex, 1);
+
+        game.broadcast(io, 'playerDrew', {
+            username,
+            card,
+            drawOrder: game.drawIndex + 1,
+            socketId: socket.id
+        });
+        game.drawIndex++;
+    }
+
+    // Mark the seat for bot replacement once positions are assigned
+    if (!game._pendingUsernames) game._pendingUsernames = {};
+    game._pendingUsernames[socket.id] = username;
+    if (!game._drawPhaseDisconnects) game._drawPhaseDisconnects = {};
+    game._drawPhaseDisconnects[socket.id] = { username };
+
+    const msg = `${username} left during card draw.`;
+    game.addLogEntry(msg, null, 'system');
+    game.broadcast(io, 'gameLogEntry', { message: msg, type: 'system' });
+
+    game.leaveRoom(io, socket.id);
+    gameManager.playerGames.delete(socket.id);
+    if (user) {
+        gameManager.clearActiveGame(user.username);
+    }
+    socket.emit('leftGame');
+
+    socketLogger.info('Player left during draw phase', { gameId: game.gameId, username });
+
+    if (game.drawIndex === 4) {
+        const { handleDrawComplete } = require('./gameHandlers');
+        handleDrawComplete(io, game);
+    }
 }
 
 function chatMessage(socket, io, data) {
@@ -268,6 +326,12 @@ function chatMessage(socket, io, data) {
             }
             return;
         }
+        // /leave works during the draw phase too, before positions exist
+        if (!position && activeGame.phase === 'drawing' &&
+            data.message.trim().toLowerCase() === '/leave') {
+            handleDrawPhaseLeave(socket, io, activeGame);
+            return;
+        }
         if (position && handleSlashCommand(socket, io, activeGame, position, data.message)) {
             return;
         }
@@ -289,13 +353,16 @@ function chatMessage(socket, io, data) {
         username = player ? player.username : 'Unknown';
     }
 
+    const { filterProfanity } = require('../utils/profanityFilter');
+    const cleanMessage = filterProfanity(data.message);
+
     // Add to game log for reconnection persistence
-    activeGame.addLogEntry(`${username}: ${data.message}`, position, 'chat');
+    activeGame.addLogEntry(`${username}: ${cleanMessage}`, position, 'chat');
 
     // Broadcast to players in the same game only
     activeGame.broadcast(io, 'chatMessage', {
         position,
-        message: data.message,
+        message: cleanMessage,
         username,
         isSpectator: activeGame.isSpectator(socket.id)
     });

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -52,7 +52,17 @@ function triggerBotIfNeeded(io, game, actionType) {
         const delayMs = bot.getActionDelay(actionType);
 
         setTimeout(() => {
+            // Re-validate before acting: the game may have moved on during the
+            // delay (turn advanced, trick resolved, /active, game ended). A
+            // stale write here corrupts playedCards and wedges the game.
+            if (!gameManager.getGameById(game.gameId)) return;
+            if (!game.isLazy(bot.position)) return;
+            if (game.currentTurn !== bot.position) return;
+
             if (actionType === 'bid') {
+                if (!game.bidding) return;
+                if (game.playerBids[bot.position - 1] != null) return;
+
                 // Use player's hand for bot decision
                 const hand = game.getHand(playerSocketId);
                 const gameContext = {
@@ -67,6 +77,10 @@ function triggerBotIfNeeded(io, game, actionType) {
                 game.currentTurn = rotatePosition(game.currentTurn);
                 handlePostBid(io, game);
             } else if (actionType === 'play') {
+                if (game.bidding) return;
+                if (game.playedCardsIndex >= 4) return;
+                if (game.playedCards[bot.position - 1]) return;
+
                 const hand = game.getHand(playerSocketId);
                 if (!hand || hand.length === 0) return;
                 const card = bot.decideCard(hand, game.playedCards, game.leadCard, game.leadPosition, game.trump, game.isTrumpBroken, game.currentHand);
@@ -124,14 +138,17 @@ async function handlePostBid(io, game) {
             team2: (BID_RANKS[bids[1]] || 0) + (BID_RANKS[bids[3]] || 0)
         };
 
-        // Cap bids at hand size and calculate multipliers
+        // Multipliers apply whenever a bore was bid — even when the summed bid
+        // doesn't exceed the hand size (e.g. 'B' + '0' on the 13-card hand)
+        game.team1Mult = calculateMultiplier(bids[0], bids[2]);
+        game.team2Mult = calculateMultiplier(bids[1], bids[3]);
+
+        // Cap bids at hand size
         if (game.bids.team1 > game.currentHand) {
             game.bids.team1 = game.currentHand;
-            game.team1Mult = calculateMultiplier(bids[0], bids[2]);
         }
         if (game.bids.team2 > game.currentHand) {
             game.bids.team2 = game.currentHand;
-            game.team2Mult = calculateMultiplier(bids[1], bids[3]);
         }
 
         gameLogger.debug('Bidding complete', { team1: game.bids.team1, team2: game.bids.team2, gameId: game.gameId });
@@ -190,7 +207,24 @@ async function handlePostBid(io, game) {
 async function handlePostPlay(io, game) {
     // Check if trick is complete
     if (game.playedCardsIndex === 4) {
+        // Guard against double resolution while we pause for the animation
+        if (game._trickResolving) return;
+        game._trickResolving = true;
+
         await delay(2000);
+
+        // Re-validate after the pause: if the trick array was corrupted by a
+        // stale action, log loudly instead of crashing the whole game loop
+        const trickCards = game.playedCards.slice(0, 4);
+        if (game.playedCardsIndex !== 4 || trickCards.length < 4 || trickCards.some(c => !c)) {
+            gameLogger.error('Trick state invalid after resolution delay, skipping', {
+                gameId: game.gameId,
+                playedCardsIndex: game.playedCardsIndex,
+                playedCards: game.playedCards
+            });
+            game._trickResolving = false;
+            return;
+        }
 
         const winner = determineWinner(game.playedCards, game.leadPosition, game.trump);
 
@@ -224,6 +258,7 @@ async function handlePostPlay(io, game) {
 
         game.playedCards = [];
         game.playedCardsIndex = 0;
+        game._trickResolving = false;
 
         // Check if hand is complete
         if (game.cardIndex === game.currentHand * 4) {
@@ -832,22 +867,11 @@ async function handleHandComplete(game, io) {
                 });
 
                 if (result && result.roundComplete) {
-                    if (tournament.isTournamentComplete()) {
-                        // Tournament is complete
-                        tournament.broadcast(io, 'tournamentComplete', {
-                            scoreboard: tournament.getScoreboard()
-                        });
-                        await gameManager.clearActiveTournamentForAll(tournament.tournamentId);
-                        // Clean up tournament from memory and update lobby
-                        gameManager.deleteTournament(tournament.tournamentId);
-                    } else {
-                        // Round complete, waiting for next round
-                        tournament.broadcast(io, 'tournamentRoundComplete', {
-                            scoreboard: tournament.getScoreboard(),
-                            currentRound: tournament.currentRound,
-                            totalRounds: tournament.totalRounds
-                        });
-                    }
+                    // Broadcasts tournamentRoundComplete, or tournamentComplete
+                    // with the tournament kept alive briefly so players can
+                    // return from the game-end screen and see final standings
+                    const { broadcastRoundOutcome } = require('./tournamentHandlers');
+                    await broadcastRoundOutcome(io, tournament);
                 }
             }
         }

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -13,6 +13,7 @@ const reconnectHandlers = require('./reconnectHandlers');
 const profileHandlers = require('./profileHandlers');
 const tournamentHandlers = require('./tournamentHandlers');
 const voiceHandlers = require('./voiceHandlers');
+const safetyHandlers = require('./safetyHandlers');
 const { asyncHandler, syncHandler, safeHandler, rateLimiter } = require('./errorHandler');
 const { socketLogger } = require('../utils/logger');
 
@@ -29,6 +30,9 @@ function setupSocketHandlers(io) {
         );
         socket.on('restoreSession', (data) =>
             asyncHandler('restoreSession', authHandlers.restoreSession)(socket, io, data)
+        );
+        socket.on('deleteAccount', (data) =>
+            asyncHandler('deleteAccount', authHandlers.deleteAccount)(socket, io, data)
         );
 
         // Queue events - no data to validate
@@ -47,7 +51,7 @@ function setupSocketHandlers(io) {
             syncHandler('chatMessage', mainRoomHandlers.mainRoomChat)(socket, io, data)
         );
         socket.on('createLobby', (data) =>
-            safeHandler(mainRoomHandlers.createLobby)(socket, io, data || {})
+            asyncHandler('createLobby', mainRoomHandlers.createLobby)(socket, io, data || {})
         );
         socket.on('joinLobby', (data) =>
             safeHandler(mainRoomHandlers.joinLobby)(socket, io, data)
@@ -126,27 +130,27 @@ function setupSocketHandlers(io) {
             asyncHandler('getPlayerProfile', profileHandlers.getPlayerProfile)(socket, io, data)
         );
 
-        // Tournament events
+        // Tournament events - rate limited via their schema names
         socket.on('createTournament', () =>
-            safeHandler(tournamentHandlers.createTournament)(socket, io, {})
+            asyncHandler('createTournament', tournamentHandlers.createTournament)(socket, io, {})
         );
         socket.on('joinTournament', (data) =>
             asyncHandler('joinTournament', tournamentHandlers.joinTournament)(socket, io, data)
         );
         socket.on('leaveTournament', () =>
-            safeHandler(tournamentHandlers.leaveTournament)(socket, io, {})
+            asyncHandler('leaveTournament', tournamentHandlers.leaveTournament)(socket, io, {})
         );
         socket.on('tournamentReady', () =>
-            safeHandler(tournamentHandlers.tournamentReady)(socket, io, {})
+            asyncHandler('tournamentReady', tournamentHandlers.tournamentReady)(socket, io, {})
         );
         socket.on('tournamentUnready', () =>
-            safeHandler(tournamentHandlers.tournamentUnready)(socket, io, {})
+            asyncHandler('tournamentUnready', tournamentHandlers.tournamentUnready)(socket, io, {})
         );
         socket.on('beginTournament', () =>
-            safeHandler(tournamentHandlers.beginTournament)(socket, io, {})
+            asyncHandler('beginTournament', tournamentHandlers.beginTournament)(socket, io, {})
         );
         socket.on('beginNextRound', () =>
-            safeHandler(tournamentHandlers.beginNextRound)(socket, io, {})
+            asyncHandler('beginNextRound', tournamentHandlers.beginNextRound)(socket, io, {})
         );
         socket.on('tournamentChat', (data) =>
             syncHandler('chatMessage', tournamentHandlers.tournamentChat)(socket, io, data)
@@ -158,10 +162,21 @@ function setupSocketHandlers(io) {
             asyncHandler('spectateTournamentGame', tournamentHandlers.spectateTournamentGame)(socket, io, data)
         );
         socket.on('returnToTournament', () =>
-            safeHandler(tournamentHandlers.returnToTournament)(socket, io, {})
+            asyncHandler('returnToTournament', tournamentHandlers.returnToTournament)(socket, io, {})
         );
         socket.on('cancelTournament', () =>
             asyncHandler('cancelTournament', tournamentHandlers.cancelTournament)(socket, io, {})
+        );
+
+        // Safety / moderation events
+        socket.on('reportUser', (data) =>
+            asyncHandler('reportUser', safetyHandlers.reportUser)(socket, io, data)
+        );
+        socket.on('blockUser', (data) =>
+            asyncHandler('blockUser', safetyHandlers.blockUser)(socket, io, data)
+        );
+        socket.on('unblockUser', (data) =>
+            asyncHandler('unblockUser', safetyHandlers.unblockUser)(socket, io, data)
         );
 
         // Voice chat signaling relay

--- a/server/socket/lobbyHandlers.js
+++ b/server/socket/lobbyHandlers.js
@@ -121,7 +121,8 @@ function lobbyChat(socket, io, data) {
         return;
     }
 
-    const result = gameManager.addLobbyMessage(socket.id, message.trim());
+    const { filterProfanity } = require('../utils/profanityFilter');
+    const result = gameManager.addLobbyMessage(socket.id, filterProfanity(message.trim()));
 
     if (!result.success) {
         socketLogger.debug('Lobby chat rejected', { socketId: socket.id, error: result.error });

--- a/server/socket/mainRoomHandlers.js
+++ b/server/socket/mainRoomHandlers.js
@@ -62,7 +62,8 @@ function mainRoomChat(socket, io, data) {
         return;
     }
 
-    const result = gameManager.addMainRoomMessage(socket.id, message.trim());
+    const { filterProfanity } = require('../utils/profanityFilter');
+    const result = gameManager.addMainRoomMessage(socket.id, filterProfanity(message.trim()));
 
     if (!result.success) {
         socket.emit('error', { message: result.error });
@@ -87,7 +88,8 @@ function mainRoomChat(socket, io, data) {
 function createLobby(socket, io, data) {
     const { name } = data || {};
 
-    const result = gameManager.createNamedLobby(socket.id, name);
+    const { filterProfanity } = require('../utils/profanityFilter');
+    const result = gameManager.createNamedLobby(socket.id, name ? filterProfanity(name) : name);
 
     if (!result.success) {
         socket.emit('error', { message: result.error });

--- a/server/socket/profileHandlers.js
+++ b/server/socket/profileHandlers.js
@@ -203,12 +203,19 @@ async function recordGameResult(game) {
     if (!gameRecordsCollection) return;
 
     try {
+        // Users who deleted their account mid-game must not reappear in new
+        // records — deletion already anonymized their historical ones
+        const gameManager = require('../game/GameManager');
+        const recordName = (p) => {
+            if (!p || !p.username) return null;
+            return gameManager.deletedUsernames.has(p.username) ? '[deleted]' : p.username;
+        };
         const team1Players = [game.getOriginalPlayer(1), game.getOriginalPlayer(3)]
-            .filter(p => p && p.username)
-            .map(p => p.username);
+            .map(recordName)
+            .filter(Boolean);
         const team2Players = [game.getOriginalPlayer(2), game.getOriginalPlayer(4)]
-            .filter(p => p && p.username)
-            .map(p => p.username);
+            .map(recordName)
+            .filter(Boolean);
 
         // Calculate team-level bags (total tricks taken minus total tricks bid)
         const ps = game.playerStats || {};

--- a/server/socket/queueHandlers.js
+++ b/server/socket/queueHandlers.js
@@ -6,6 +6,7 @@ const gameManager = require('../game/GameManager');
 const Deck = require('../game/Deck');
 const { delay } = require('../utils/timing');
 const { socketLogger } = require('../utils/logger');
+const { handleAbortedTournamentGame } = require('./tournamentHandlers');
 
 async function joinQueue(socket, io) {
     const result = gameManager.joinQueue(socket.id);
@@ -213,6 +214,8 @@ async function handleDisconnect(socket, io) {
                 socketLogger.warn('No connected humans remain, aborting game', { gameId: result.gameId });
                 result.game.broadcast(io, 'abortGame', { reason: 'All players disconnected' });
                 await gameManager.clearActiveGameForAll(result.gameId);
+                // Tournament games must still count toward round completion
+                await handleAbortedTournamentGame(io, result.gameId);
                 result.game.leaveAllFromRoom(io);
                 gameManager.abortGame(result.gameId);
                 io.to('mainRoom').emit('lobbiesUpdated', {
@@ -260,6 +263,8 @@ async function handleDisconnect(socket, io) {
                     socketLogger.warn('All humans disconnected, aborting game', { gameId: result.gameId });
                     checkResult.game.broadcast(io, 'abortGame', { reason: 'All players disconnected' });
                     await gameManager.clearActiveGameForAll(result.gameId);
+                    // Tournament games must still count toward round completion
+                    await handleAbortedTournamentGame(io, result.gameId);
                     checkResult.game.leaveAllFromRoom(io);
                     gameManager.abortGame(result.gameId);
                     io.to('mainRoom').emit('lobbiesUpdated', {

--- a/server/socket/rateLimiter.js
+++ b/server/socket/rateLimiter.js
@@ -24,7 +24,32 @@ class RateLimiter {
 
             // Queue - prevent queue spam
             joinQueue: { max: 5, windowMs: 30000 },    // 5 per 30 seconds
-            leaveQueue: { max: 5, windowMs: 30000 }    // 5 per 30 seconds
+            leaveQueue: { max: 5, windowMs: 30000 },   // 5 per 30 seconds
+
+            // Lobby creation
+            createLobby: { max: 5, windowMs: 60000 },
+
+            // Tournaments - create/join/leave cycles trigger room-wide
+            // broadcasts, so keep them throttled
+            createTournament: { max: 3, windowMs: 60000 },
+            joinTournament: { max: 10, windowMs: 60000 },
+            leaveTournament: { max: 10, windowMs: 60000 },
+            tournamentReady: { max: 10, windowMs: 10000 },
+            tournamentUnready: { max: 10, windowMs: 10000 },
+            beginTournament: { max: 5, windowMs: 60000 },
+            beginNextRound: { max: 5, windowMs: 60000 },
+            returnToTournament: { max: 10, windowMs: 30000 },
+            spectateTournament: { max: 10, windowMs: 60000 },
+            spectateTournamentGame: { max: 10, windowMs: 60000 },
+            cancelTournament: { max: 3, windowMs: 60000 },
+
+            // Account management
+            deleteAccount: { max: 3, windowMs: 300000 },  // 3 per 5 minutes
+
+            // Safety / moderation
+            reportUser: { max: 5, windowMs: 300000 },     // 5 per 5 minutes
+            blockUser: { max: 10, windowMs: 60000 },
+            unblockUser: { max: 10, windowMs: 60000 }
         };
 
         // Track requests: Map<string, number[]> where key is "socketId:event"

--- a/server/socket/reconnectHandlers.js
+++ b/server/socket/reconnectHandlers.js
@@ -7,6 +7,35 @@ const { cancelAbortTimer } = require('./queueHandlers');
 const { socketLogger } = require('../utils/logger');
 
 /**
+ * If the rejoined game belongs to a tournament, reattach the player's
+ * tournament membership to their new socket and rejoin the tournament room.
+ * @returns {Object|null} - The tournament, or null
+ */
+function reattachTournament(io, socket, gameId, username) {
+    const tournamentId = gameManager.tournamentGames.get(gameId);
+    if (!tournamentId) return null;
+
+    // Scope the reattach to THIS game's tournament — the same username can
+    // linger as a ghost entry in an older tournament
+    const tournament = gameManager.reattachTournamentPlayer(socket.id, username, tournamentId);
+    if (tournament) {
+        socket.join(tournament.roomName);
+        // Let lobby viewers see the reconnect (and any creator handoff)
+        tournament.broadcast(io, 'tournamentPlayerJoined', {
+            username,
+            players: tournament.getClientState().players
+        });
+        socketLogger.info('Tournament membership reattached on rejoin', {
+            username, tournamentId: tournament.tournamentId, gameId
+        });
+        return tournament;
+    }
+    // Game maps to a tournament but no membership entry matched (e.g. the
+    // tournament was deleted) — still return whatever exists for the id
+    return gameManager.getTournamentById(tournamentId);
+}
+
+/**
  * Handle a player attempting to rejoin a game after disconnect
  */
 async function rejoinGame(socket, io, data) {
@@ -93,6 +122,10 @@ async function rejoinGame(socket, io, data) {
         // Map the human's new socket to the game
         gameManager.updatePlayerGameMapping(null, socket.id, gameId);
 
+        // Restore tournament membership for the new socket if this is a
+        // tournament game (disconnect only marks the player disconnected)
+        const lazyTournament = reattachTournament(io, socket, gameId, username);
+
         socketLogger.info('Player rejoined game in lazy mode', { username, gameId, position });
 
         // Send current game state (they'll be in lazy/spectator mode)
@@ -100,6 +133,7 @@ async function rejoinGame(socket, io, data) {
         const currentBotSocketId = game.positions[position];
         const rejoinState = game.getClientState(currentBotSocketId);
         rejoinState.isLazy = true;
+        rejoinState.tournamentId = lazyTournament ? lazyTournament.tournamentId : null;
         socket.emit('rejoinSuccess', rejoinState);
 
         // Notify other players
@@ -127,10 +161,15 @@ async function rejoinGame(socket, io, data) {
     // Register user with new socket
     gameManager.registerUser(socket.id, username);
 
+    // Restore tournament membership for the new socket if this is a
+    // tournament game (disconnect only marks the player disconnected)
+    const tournament = reattachTournament(io, socket, gameId, username);
+
     socketLogger.info('Player rejoined game', { username, gameId, position: existingPlayer.position });
 
     // Send current game state to rejoining player
     const gameState = game.getClientState(socket.id);
+    gameState.tournamentId = tournament ? tournament.tournamentId : null;
     socket.emit('rejoinSuccess', gameState);
 
     // Notify other players

--- a/server/socket/safetyHandlers.js
+++ b/server/socket/safetyHandlers.js
@@ -1,0 +1,109 @@
+/**
+ * User-safety socket event handlers: reporting and blocking other users.
+ * Required for App Store Guideline 1.2 (UGC apps need a mechanism to report
+ * offensive content and block abusive users).
+ */
+
+const { getUsersCollection, getReportsCollection } = require('../database');
+const gameManager = require('../game/GameManager');
+const { socketLogger } = require('../utils/logger');
+
+/**
+ * File a report against another user. Stored in the reports collection for
+ * review; reporters get an acknowledgement immediately.
+ */
+async function reportUser(socket, io, data) {
+    const reporter = gameManager.getUserBySocketId(socket.id);
+    if (!reporter) {
+        socket.emit('reportUserResponse', { success: false, message: 'Not signed in' });
+        return;
+    }
+
+    const { username, reason, context } = data;
+    if (username === reporter.username) {
+        socket.emit('reportUserResponse', { success: false, message: 'You cannot report yourself' });
+        return;
+    }
+
+    const reports = getReportsCollection();
+    if (!reports) {
+        socket.emit('reportUserResponse', { success: false, message: 'Service unavailable. Try again.' });
+        return;
+    }
+
+    try {
+        await reports.insertOne({
+            reporter: reporter.username,
+            reported: username,
+            reason,
+            context: context || '',
+            createdAt: new Date()
+        });
+
+        socket.emit('reportUserResponse', { success: true });
+        socketLogger.info('User report filed', {
+            reporter: reporter.username, reported: username, reason
+        });
+    } catch (error) {
+        socketLogger.error('Failed to store user report', { error: error.message });
+        socket.emit('reportUserResponse', { success: false, message: 'Failed to submit report. Try again.' });
+    }
+}
+
+/**
+ * Block a user: their chat messages are hidden on this account's clients.
+ * The block list persists on the user document and is sent at sign-in.
+ */
+async function blockUser(socket, io, data) {
+    await updateBlockList(socket, data.username, '$addToSet');
+}
+
+async function unblockUser(socket, io, data) {
+    await updateBlockList(socket, data.username, '$pull');
+}
+
+async function updateBlockList(socket, targetUsername, op) {
+    const user = gameManager.getUserBySocketId(socket.id);
+    if (!user) {
+        socket.emit('blockListUpdated', { success: false, message: 'Not signed in' });
+        return;
+    }
+    if (targetUsername === user.username) {
+        socket.emit('blockListUpdated', { success: false, message: 'You cannot block yourself' });
+        return;
+    }
+
+    const usersCollection = getUsersCollection();
+    if (!usersCollection) {
+        socket.emit('blockListUpdated', { success: false, message: 'Service unavailable. Try again.' });
+        return;
+    }
+
+    try {
+        await usersCollection.updateOne(
+            { username: user.username },
+            { [op]: { blockedUsers: targetUsername } }
+        );
+        const updated = await usersCollection.findOne(
+            { username: user.username },
+            { projection: { blockedUsers: 1 } }
+        );
+
+        socket.emit('blockListUpdated', {
+            success: true,
+            blockedUsers: updated?.blockedUsers || []
+        });
+        socketLogger.info('Block list updated', {
+            username: user.username, target: targetUsername, op
+        });
+    } catch (error) {
+        socketLogger.error('Failed to update block list', { error: error.message });
+        socket.emit('blockListUpdated', { success: false, message: 'Failed to update block list. Try again.' });
+    }
+}
+
+module.exports = {
+    reportUser,
+    blockUser,
+    unblockUser
+};

--- a/server/socket/tournamentHandlers.js
+++ b/server/socket/tournamentHandlers.js
@@ -55,7 +55,7 @@ function createTournament(socket, io) {
 /**
  * Join an existing tournament
  */
-function joinTournament(socket, io, data) {
+async function joinTournament(socket, io, data) {
     const { tournamentId } = data;
     if (!tournamentId) {
         socket.emit('error', { message: 'Tournament ID required' });
@@ -65,6 +65,18 @@ function joinTournament(socket, io, data) {
     const result = gameManager.joinTournament(socket.id, tournamentId);
     if (!result.success) {
         socket.emit('error', { message: result.error });
+        // An active member of another tournament stays where they are — only
+        // genuinely unattached players get dropped into the main room (the
+        // clients auto-emit joinTournament after sign-in, so a failure must
+        // not strand them on a blank screen).
+        if (result.error === 'Already in a tournament') {
+            return;
+        }
+        const failedUser = gameManager.getUserBySocketId(socket.id);
+        if (failedUser && !gameManager.getTournamentById(tournamentId)) {
+            await gameManager.clearActiveTournament(failedUser.username);
+        }
+        sendToMainRoom(socket);
         return;
     }
 
@@ -101,31 +113,10 @@ function joinTournament(socket, io, data) {
 }
 
 /**
- * Leave a tournament
+ * Send a player back to the main room (used after leaving a tournament or
+ * when a tournament they reference no longer exists).
  */
-function leaveTournament(socket, io) {
-    const tournament = gameManager.getPlayerTournament(socket.id);
-    if (!tournament) {
-        socket.emit('error', { message: 'Not in a tournament' });
-        return;
-    }
-
-    const user = gameManager.getUserBySocketId(socket.id);
-    const tournamentId = tournament.tournamentId;
-
-    // Leave tournament room
-    tournament.leaveRoom(io, socket.id);
-
-    const result = gameManager.leaveTournament(socket.id);
-    if (!result.success) {
-        socket.emit('error', { message: result.error });
-        return;
-    }
-
-    // Notify leaving player
-    socket.emit('tournamentLeft', {});
-
-    // Auto-rejoin main room
+function sendToMainRoom(socket) {
     const mainRoomResult = gameManager.joinMainRoom(socket.id);
     socket.join('mainRoom');
     const onlineUsers = gameManager.getOnlineUsernames();
@@ -137,6 +128,59 @@ function leaveTournament(socket, io) {
         inProgressGames: gameManager.getInProgressGames(),
         tournaments: gameManager.getAllTournaments()
     });
+}
+
+/**
+ * Leave a tournament
+ */
+async function leaveTournament(socket, io) {
+    const tournament = gameManager.getPlayerTournament(socket.id);
+    const user = gameManager.getUserBySocketId(socket.id);
+
+    if (!tournament) {
+        // Spectators aren't in playerTournaments — resolve via spectator maps
+        for (const [, t] of gameManager.tournaments) {
+            if (t.isSpectator(socket.id)) {
+                t.removeSpectator(socket.id);
+                t.leaveRoom(io, socket.id);
+                socket.emit('tournamentLeft', {});
+                sendToMainRoom(socket);
+                socketLogger.info('Spectator left tournament', {
+                    socketId: socket.id, tournamentId: t.tournamentId
+                });
+                return;
+            }
+        }
+
+        // Nothing to leave (e.g. tournament already cleaned up) — still land
+        // the player somewhere sane instead of erroring.
+        socket.emit('tournamentLeft', {});
+        sendToMainRoom(socket);
+        return;
+    }
+
+    const tournamentId = tournament.tournamentId;
+
+    // Leave tournament room
+    tournament.leaveRoom(io, socket.id);
+
+    const result = gameManager.leaveTournament(socket.id);
+    if (!result.success) {
+        socket.emit('error', { message: result.error });
+        return;
+    }
+
+    // Explicit leave is permanent — clear the DB pointer so future sign-ins
+    // don't try to rejoin this tournament.
+    if (user) {
+        await gameManager.clearActiveTournament(user.username);
+    }
+
+    // Notify leaving player
+    socket.emit('tournamentLeft', {});
+
+    // Auto-rejoin main room
+    sendToMainRoom(socket);
 
     if (result.deleted) {
         // Tournament was deleted — notify main room
@@ -232,12 +276,23 @@ async function beginTournament(socket, io) {
         return;
     }
 
-    // Set active tournament in DB for all players
-    for (const [, player] of tournament.players) {
-        await gameManager.setActiveTournament(player.username, tournament.tournamentId);
-    }
+    // Flip the phase synchronously before any awaits so a double-click or
+    // retry can't pass the phase guard and start round 1 twice.
+    tournament.phase = 'starting';
 
-    await startTournamentRound(io, tournament, 1);
+    try {
+        // Set active tournament in DB for all players
+        for (const [, player] of tournament.players) {
+            await gameManager.setActiveTournament(player.username, tournament.tournamentId);
+        }
+
+        await startTournamentRound(io, tournament, 1);
+    } catch (error) {
+        if (tournament.phase === 'starting') {
+            tournament.phase = 'lobby';
+        }
+        throw error;
+    }
 }
 
 /**
@@ -271,17 +326,30 @@ async function beginNextRound(socket, io) {
         return;
     }
 
-    await startTournamentRound(io, tournament, nextRound);
+    // Same double-start protection as beginTournament
+    tournament.phase = 'starting';
+
+    try {
+        await startTournamentRound(io, tournament, nextRound);
+    } catch (error) {
+        if (tournament.phase === 'starting') {
+            tournament.phase = 'between_rounds';
+        }
+        throw error;
+    }
 }
 
 /**
  * Start a tournament round — creates games, assigns players, starts draw phase
  */
 async function startTournamentRound(io, tournament, roundNumber) {
-    // Shuffle player usernames
+    // Shuffle player usernames (connected players only — disconnected members
+    // keep their scores but sit out rounds until they reattach)
     const usernames = [];
     for (const [, player] of tournament.players) {
-        usernames.push(player.username);
+        if (player.connected !== false) {
+            usernames.push(player.username);
+        }
     }
     // Fisher-Yates shuffle
     for (let i = usernames.length - 1; i > 0; i--) {
@@ -303,19 +371,33 @@ async function startTournamentRound(io, tournament, roundNumber) {
 
     // Create each game
     for (const assignment of assignments) {
-        // Collect human socket IDs
+        // Collect human socket IDs. A player may have left/disconnected during
+        // the delays above — back-fill their seat with a bot so the game still
+        // has 4 participants and the draw phase can complete.
         const humanSocketIds = [];
+        const presentHumans = [];
         for (const username of assignment.humans) {
             const playerInfo = tournament.getPlayerByUsername(username);
-            if (playerInfo) {
+            if (playerInfo && playerInfo.connected !== false &&
+                io.sockets.sockets.get(playerInfo.socketId)) {
                 humanSocketIds.push(playerInfo.socketId);
+                presentHumans.push(username);
             }
+        }
+        const botCount = assignment.botCount + (assignment.humans.length - presentHumans.length);
+
+        if (humanSocketIds.length === 0) {
+            // Nobody from this table is still here — skip it entirely
+            socketLogger.warn('Skipping tournament game with no connected humans', {
+                tournamentId: tournament.tournamentId, roundNumber
+            });
+            continue;
         }
 
         // Create bot socket IDs
         const botSocketIds = [];
         const usedPersonalities = [];
-        for (let i = 0; i < assignment.botCount; i++) {
+        for (let i = 0; i < botCount; i++) {
             const available = PERSONALITY_LIST.filter(p => !usedPersonalities.includes(p));
             const personality = available[Math.floor(Math.random() * available.length)];
             usedPersonalities.push(personality);
@@ -340,10 +422,10 @@ async function startTournamentRound(io, tournament, roundNumber) {
         }
 
         // Add game to tournament round
-        tournament.addGameToRound(game.gameId, assignment.humans, assignment.botCount);
+        tournament.addGameToRound(game.gameId, presentHumans, botCount);
 
         // Set active game in DB for humans
-        for (const username of assignment.humans) {
+        for (const username of presentHumans) {
             await gameManager.setActiveGame(username, game.gameId);
         }
 
@@ -385,6 +467,26 @@ async function startTournamentRound(io, tournament, roundNumber) {
             botDrawOrder++;
             botController.scheduleBotDraw(io, game, botInfo.socketId, botDrawOrder);
         }
+    }
+
+    // If every table was skipped (everyone left during the start delays),
+    // roll the round back so the tournament isn't stuck in round_active
+    // waiting on games that don't exist.
+    const startedRound = tournament.getCurrentRound();
+    if (startedRound && startedRound.roundNumber === roundNumber && startedRound.games.size === 0) {
+        tournament.rounds.pop();
+        tournament.currentRound = roundNumber - 1;
+        tournament.phase = roundNumber === 1 ? 'lobby' : 'between_rounds';
+        tournament.broadcast(io, 'tournamentMessage', {
+            username: 'System',
+            message: 'Round could not start — no connected players.',
+            isSpectator: false,
+            timestamp: Date.now()
+        });
+        socketLogger.warn('Tournament round rolled back, no games created', {
+            tournamentId: tournament.tournamentId, roundNumber
+        });
+        return;
     }
 
     // Update main room
@@ -429,10 +531,11 @@ function tournamentChat(socket, io, data) {
         return;
     }
 
+    const { filterProfanity } = require('../utils/profanityFilter');
     const user = gameManager.getUserBySocketId(socket.id);
     const chatMessage = foundTournament.addMessage(
         user?.username || 'Unknown',
-        message.trim(),
+        filterProfanity(message.trim()),
         isSpectator
     );
 
@@ -575,9 +678,12 @@ async function cancelTournament(socket, io) {
     // Clear active tournament in DB for all players
     await gameManager.clearActiveTournamentForAll(tournamentId);
 
-    // Remove all players from tournament room
+    // Remove all players and spectators from tournament room
     for (const [playerSocketId] of tournament.players) {
         tournament.leaveRoom(io, playerSocketId);
+    }
+    for (const [spectatorSocketId] of tournament.spectators) {
+        tournament.leaveRoom(io, spectatorSocketId);
     }
 
     // Delete tournament and clean up maps
@@ -600,9 +706,31 @@ async function cancelTournament(socket, io) {
  * Return to tournament lobby from game/spectating
  */
 function returnToTournament(socket, io) {
-    const tournament = gameManager.getPlayerTournament(socket.id);
+    let tournament = gameManager.getPlayerTournament(socket.id);
+
+    // Tournament spectators aren't in playerTournaments
     if (!tournament) {
-        socket.emit('error', { message: 'Not in a tournament' });
+        for (const [, t] of gameManager.tournaments) {
+            if (t.isSpectator(socket.id)) {
+                tournament = t;
+                break;
+            }
+        }
+    }
+
+    // Last resort: reattach by username (e.g. socket changed while in a game)
+    if (!tournament) {
+        const user = gameManager.getUserBySocketId(socket.id);
+        if (user) {
+            tournament = gameManager.reattachTournamentPlayer(socket.id, user.username);
+        }
+    }
+
+    if (!tournament) {
+        // Tournament is gone (completed and cleaned up, or cancelled) — land
+        // the player in the main room instead of leaving them stranded.
+        socket.emit('tournamentLeft', {});
+        sendToMainRoom(socket);
         return;
     }
 
@@ -621,6 +749,94 @@ function returnToTournament(socket, io) {
     socket.emit('tournamentJoined', tournament.getClientState());
 }
 
+// Completed tournaments stay in memory for a grace window so players coming
+// from the game-end screen can still return and see the final standings.
+const COMPLETED_TOURNAMENT_TTL_MS = 10 * 60 * 1000;
+const cleanupTimers = new Map(); // tournamentId → timer
+
+function scheduleTournamentCleanup(io, tournamentId, delayMs = COMPLETED_TOURNAMENT_TTL_MS) {
+    if (cleanupTimers.has(tournamentId)) {
+        clearTimeout(cleanupTimers.get(tournamentId));
+    }
+    const timer = setTimeout(() => {
+        cleanupTimers.delete(tournamentId);
+        const tournament = gameManager.getTournamentById(tournamentId);
+        if (!tournament) return;
+
+        for (const [playerSocketId] of tournament.players) {
+            tournament.leaveRoom(io, playerSocketId);
+        }
+        for (const [spectatorSocketId] of tournament.spectators) {
+            tournament.leaveRoom(io, spectatorSocketId);
+        }
+        gameManager.deleteTournament(tournamentId);
+
+        io.to('mainRoom').emit('lobbiesUpdated', {
+            lobbies: gameManager.getAllLobbies(),
+            inProgressGames: gameManager.getInProgressGames(),
+            tournaments: gameManager.getAllTournaments()
+        });
+        socketLogger.info('Completed tournament cleaned up', { tournamentId });
+    }, delayMs);
+    if (timer.unref) timer.unref();
+    cleanupTimers.set(tournamentId, timer);
+}
+
+/**
+ * Broadcast the outcome of a finished round: either the between-rounds prompt
+ * or the final standings. Shared by the normal game-end and abort paths.
+ */
+async function broadcastRoundOutcome(io, tournament) {
+    if (tournament.isTournamentComplete()) {
+        tournament.broadcast(io, 'tournamentComplete', {
+            scoreboard: tournament.getScoreboard(),
+            winners: tournament.getWinners()
+        });
+        await gameManager.clearActiveTournamentForAll(tournament.tournamentId);
+        scheduleTournamentCleanup(io, tournament.tournamentId);
+    } else {
+        tournament.broadcast(io, 'tournamentRoundComplete', {
+            scoreboard: tournament.getScoreboard(),
+            currentRound: tournament.currentRound,
+            totalRounds: tournament.totalRounds
+        });
+    }
+}
+
+/**
+ * A tournament game ended without reaching gameEnd (aborted/abandoned).
+ * Mark it complete with no scores recorded so the round can still advance —
+ * otherwise the tournament is stuck in round_active forever.
+ */
+async function handleAbortedTournamentGame(io, gameId) {
+    const game = gameManager.getGameById(gameId);
+    const result = gameManager.handleTournamentGameEnd(gameId);
+    if (!result) return;
+
+    const tournament = result.tournament;
+    tournament.broadcast(io, 'tournamentGameComplete', {
+        gameId,
+        score: game ? game.score : { team1: 0, team2: 0 },
+        aborted: true,
+        activeGames: tournament.getActiveGames(),
+        scoreboard: tournament.getScoreboard(),
+        currentRound: tournament.currentRound,
+        totalRounds: tournament.totalRounds
+    });
+
+    if (result.roundComplete) {
+        await broadcastRoundOutcome(io, tournament);
+        // Everyone may be gone already (that's often why the game aborted)
+        if (tournament.getConnectedPlayerCount() === 0) {
+            gameManager.deleteTournament(tournament.tournamentId);
+        }
+    }
+
+    socketLogger.info('Aborted tournament game resolved', {
+        gameId, tournamentId: tournament.tournamentId, roundComplete: result.roundComplete
+    });
+}
+
 module.exports = {
     createTournament,
     joinTournament,
@@ -633,5 +849,8 @@ module.exports = {
     tournamentChat,
     spectateTournament,
     spectateTournamentGame,
-    returnToTournament
+    returnToTournament,
+    broadcastRoundOutcome,
+    handleAbortedTournamentGame,
+    scheduleTournamentCleanup
 };

--- a/server/socket/validators.js
+++ b/server/socket/validators.js
@@ -55,6 +55,12 @@ const schemas = {
         message: Joi.string().min(1).max(500).required()
     }),
 
+    // Lobby creation — the name is run through the profanity filter, so it
+    // must be length-capped here
+    createLobby: Joi.object({
+        name: Joi.string().max(50).allow('', null).optional()
+    }),
+
     // Queue (no data needed, but validate anyway)
     joinQueue: Joi.object({}).unknown(true),
     leaveQueue: Joi.object({}).unknown(true),
@@ -95,6 +101,36 @@ const schemas = {
 
     spectateTournamentGame: Joi.object({
         gameId: Joi.string().uuid().required()
+    }),
+
+    // No-payload tournament events (schemas exist so rate limiting applies)
+    createTournament: Joi.object({}).unknown(true),
+    leaveTournament: Joi.object({}).unknown(true),
+    tournamentReady: Joi.object({}).unknown(true),
+    tournamentUnready: Joi.object({}).unknown(true),
+    beginTournament: Joi.object({}).unknown(true),
+    beginNextRound: Joi.object({}).unknown(true),
+    returnToTournament: Joi.object({}).unknown(true),
+    cancelTournament: Joi.object({}).unknown(true),
+
+    // Account management
+    deleteAccount: Joi.object({
+        password: Joi.string().min(1).max(100).required()
+    }),
+
+    // Safety / moderation
+    reportUser: Joi.object({
+        username: Joi.string().min(1).max(50).required(),
+        reason: Joi.string().min(1).max(500).required(),
+        context: Joi.string().max(1000).allow('').optional()
+    }),
+
+    blockUser: Joi.object({
+        username: Joi.string().min(1).max(50).required()
+    }),
+
+    unblockUser: Joi.object({
+        username: Joi.string().min(1).max(50).required()
     })
 };
 

--- a/server/utils/__tests__/profanityFilter.test.js
+++ b/server/utils/__tests__/profanityFilter.test.js
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the profanity filter applied to chat, usernames, and
+ * lobby names.
+ */
+
+const { containsProfanity, containsProfanitySubstring, filterProfanity } = require('../profanityFilter');
+
+describe('profanityFilter', () => {
+    describe('containsProfanity', () => {
+        test('detects banned words case-insensitively', () => {
+            expect(containsProfanity('what the FUCK')).toBe(true);
+            expect(containsProfanity('Shit happens')).toBe(true);
+        });
+
+        test('detects common leetspeak substitutions', () => {
+            expect(containsProfanity('sh1t')).toBe(true);
+            expect(containsProfanity('fuck')).toBe(true);
+            expect(containsProfanity('b!tch')).toBe(true);
+        });
+
+        test('does not flag clean text', () => {
+            expect(containsProfanity('nice hand, partner!')).toBe(false);
+            expect(containsProfanity('')).toBe(false);
+            expect(containsProfanity(null)).toBe(false);
+        });
+
+        test('avoids classic substring false positives', () => {
+            expect(containsProfanity('the class assassin passed')).toBe(false);
+            expect(containsProfanity('Scunthorpe United')).toBe(false);
+        });
+
+        test('catches banned words adjacent to substitution characters', () => {
+            // '!' normalizes to 'i', merging into the word — the raw-text
+            // pass must still catch it
+            expect(containsProfanity('shit!')).toBe(true);
+            expect(containsProfanity('what the fuck!')).toBe(true);
+        });
+
+        test('catches banned words with trailing/leading digits', () => {
+            // digits are word characters AND leetspeak sources — the
+            // separator pass must still catch these
+            expect(containsProfanity('shit5')).toBe(true);
+            expect(containsProfanity('fuck1')).toBe(true);
+        });
+
+        test('does not flag ordinary messages containing digits', () => {
+            expect(containsProfanity('I bid 5')).toBe(false);
+            expect(containsProfanity('I have 5 spades and $100')).toBe(false);
+            expect(containsProfanity('Grape5')).toBe(false);
+        });
+    });
+
+    describe('containsProfanitySubstring', () => {
+        test('catches unambiguous slurs embedded in usernames', () => {
+            expect(containsProfanitySubstring('xXmotherfucker99')).toBe(true);
+        });
+
+        test('catches word-boundary profanity in usernames', () => {
+            expect(containsProfanitySubstring('shit.lord')).toBe(true);
+            expect(containsProfanitySubstring('mr-fuck')).toBe(true);
+            expect(containsProfanitySubstring('shit5')).toBe(true);
+        });
+
+        test('accepts real-world names containing banned substrings', () => {
+            expect(containsProfanitySubstring('Torpedo')).toBe(false);
+            expect(containsProfanitySubstring('Spice')).toBe(false);
+            expect(containsProfanitySubstring('Therapist')).toBe(false);
+            expect(containsProfanitySubstring('Grape123')).toBe(false);
+            expect(containsProfanitySubstring('Atwater')).toBe(false);
+            expect(containsProfanitySubstring('Scunthorpe')).toBe(false);
+        });
+
+        test('accepts normal usernames', () => {
+            expect(containsProfanitySubstring('cardshark42')).toBe(false);
+            expect(containsProfanitySubstring('alice')).toBe(false);
+            expect(containsProfanitySubstring('')).toBe(false);
+        });
+    });
+
+    describe('filterProfanity', () => {
+        test('masks banned words but keeps the rest of the message', () => {
+            expect(filterProfanity('what the fuck was that')).toBe('what the **** was that');
+        });
+
+        test('masks multiple occurrences', () => {
+            const result = filterProfanity('shit shit');
+            expect(result).toBe('**** ****');
+        });
+
+        test('masks leetspeak variants', () => {
+            expect(filterProfanity('sh1t happens')).toBe('**** happens');
+        });
+
+        test('masks words adjacent to substitution characters', () => {
+            expect(filterProfanity('shit!')).toBe('****!');
+        });
+
+        test('masks words with trailing digits', () => {
+            expect(filterProfanity('shit5')).toBe('****5');
+        });
+
+        test('mask length always equals input length', () => {
+            const inputs = ['shit!', 'sh1t', 'what the fuck was that', 'b!tch b!tch'];
+            for (const input of inputs) {
+                expect(filterProfanity(input)).toHaveLength(input.length);
+            }
+        });
+
+        test('leaves clean messages untouched', () => {
+            expect(filterProfanity('good game everyone')).toBe('good game everyone');
+        });
+
+        test('handles empty input', () => {
+            expect(filterProfanity('')).toBe('');
+            expect(filterProfanity(null)).toBe(null);
+        });
+    });
+});

--- a/server/utils/profanityFilter.js
+++ b/server/utils/profanityFilter.js
@@ -1,0 +1,134 @@
+/**
+ * Basic profanity filter for user-generated text (chat messages, usernames,
+ * lobby names). Required for App Store Guideline 1.2 (UGC apps must filter
+ * objectionable content).
+ *
+ * Matching runs against three views of the input so common evasions are
+ * caught while indices stay aligned for masking:
+ *   raw        — catches plain words and words touching punctuation ("shit!")
+ *   normalized — leetspeak undone ("sh1t" → "shit")
+ *   separated  — substitution chars as spaces ("shit5" → "shit ", since a
+ *                trailing digit is a word character and defeats \b otherwise)
+ *
+ * Word-boundary matching avoids the classic false positives ("class",
+ * "assassin", "Scunthorpe") in chat. Usernames additionally use
+ * containsProfanitySubstring, which embeds-matches only unambiguous slurs so
+ * real names like "Torpedo" or "Spice" aren't rejected.
+ */
+
+const BANNED_WORDS = [
+    'fuck', 'shit', 'bitch', 'cunt', 'asshole', 'dickhead', 'cocksucker',
+    'motherfucker', 'nigger', 'nigga', 'faggot', 'fag', 'retard', 'whore',
+    'slut', 'twat', 'wanker', 'prick', 'pussy', 'kike', 'spic', 'chink',
+    'wetback', 'tranny', 'dyke', 'rape', 'rapist', 'pedo', 'pedophile',
+    'nazi', 'hitler', 'kys'
+];
+
+// Long/unambiguous terms that should be rejected in usernames even when
+// embedded in a longer handle. Deliberately excludes short words that appear
+// inside ordinary English ("pedo" in Torpedo, "spic" in Spice, "rape" in
+// Grape, "twat" in Atwater, ...).
+const EMBEDDED_BLOCKLIST = [
+    'nigger', 'nigga', 'faggot', 'motherfucker', 'cocksucker', 'pedophile'
+];
+
+// Map common letter substitutions back to letters before matching
+const SUBSTITUTIONS = {
+    '0': 'o', '1': 'i', '!': 'i', '3': 'e', '4': 'a', '@': 'a',
+    '5': 's', '$': 's', '7': 't', '+': 't', '8': 'b'
+};
+
+/**
+ * Lowercase the text strictly one output unit per input unit so match
+ * indices stay aligned with the original string. (Full-string toLowerCase()
+ * can change length for some Unicode, e.g. 'İ' → 'i̇'.)
+ */
+function alignedLowercase(text) {
+    let result = '';
+    for (let i = 0; i < text.length; i++) {
+        const lower = text[i].toLowerCase();
+        result += lower.length === 1 ? lower : text[i];
+    }
+    return result;
+}
+
+/** Leetspeak undone: substitution chars become their letter. */
+function normalize(text) {
+    const lower = alignedLowercase(text);
+    let result = '';
+    for (let i = 0; i < lower.length; i++) {
+        result += SUBSTITUTIONS[lower[i]] || lower[i];
+    }
+    return result;
+}
+
+/** Substitution chars treated as separators (catches "shit5", "fuck1"). */
+function separate(text) {
+    const lower = alignedLowercase(text);
+    let result = '';
+    for (let i = 0; i < lower.length; i++) {
+        result += SUBSTITUTIONS[lower[i]] ? ' ' : lower[i];
+    }
+    return result;
+}
+
+const WORD_PATTERNS = BANNED_WORDS.map(word => new RegExp(`\\b${word}\\b`, 'i'));
+
+/**
+ * Check whether text contains banned words (word-boundary matching, suited
+ * to prose like chat messages).
+ * @param {string} text
+ * @returns {boolean}
+ */
+function containsProfanity(text) {
+    if (!text) return false;
+    const variants = [text, normalize(text), separate(text)];
+    return WORD_PATTERNS.some(pattern => variants.some(v => pattern.test(v)));
+}
+
+/**
+ * Stricter check for usernames/handles: unambiguous slurs count even when
+ * embedded in a longer string, everything else at word boundaries.
+ * @param {string} text
+ * @returns {boolean}
+ */
+function containsProfanitySubstring(text) {
+    if (!text) return false;
+    const normalized = normalize(text);
+    if (EMBEDDED_BLOCKLIST.some(word => normalized.includes(word))) {
+        return true;
+    }
+    return containsProfanity(text);
+}
+
+/**
+ * Replace banned words with asterisks, preserving the rest of the message.
+ * Masking uses a char array so cost stays O(length), even for inputs packed
+ * with matches.
+ * @param {string} text
+ * @returns {string}
+ */
+function filterProfanity(text) {
+    if (!text) return text;
+
+    // All three variants are 1:1 with the input, so match indices align
+    const variants = [text, normalize(text), separate(text)];
+    const chars = text.split('');
+
+    for (const word of BANNED_WORDS) {
+        const pattern = new RegExp(`\\b${word}\\b`, 'gi');
+        for (const variant of variants) {
+            pattern.lastIndex = 0;
+            let match;
+            while ((match = pattern.exec(variant)) !== null) {
+                for (let i = match.index; i < match.index + match[0].length; i++) {
+                    chars[i] = '*';
+                }
+            }
+        }
+    }
+
+    return chars.join('');
+}
+
+module.exports = { containsProfanity, containsProfanitySubstring, filterProfanity };


### PR DESCRIPTION
## Summary

Fixes the tournament-mode breakage (18 audited bugs, 5 critical — no tournament had ever completed in production) and addresses all three App Store rejection grounds.

### Tournament fixes
- **Round 2 could never start**: the web Begin button emitted `beginTournament` instead of `beginNextRound` after the lobby rebuilt (`TournamentLobby.js` module state reset). This alone made tournaments unfinishable.
- **Disconnect grace + reattach**: a refresh/backgrounding no longer ejects players from the tournament; membership and scores survive, and reconnection reattaches via both the game-rejoin and sign-in paths (scoped to the correct tournament; creator role recovers from dead sockets).
- **Aborted games count toward round completion** — a single abandoned table no longer stalls the round forever.
- **Completed tournaments linger 10 min** so everyone sees final standings ("Return to Tournament" now works on both clients), with membership self-healing so the lingering state never blocks creating/joining the next tournament.
- **Production crash fixed**: the lazy-bot trick race that corrupted `playedCards` and wedged a real tournament game (`logs/combined3.log`) — guards added at write and trick-resolution time.
- Also: double-start race, spectator leave dead-end, draw-phase `/leave` (server + iOS button), missing-player bot backfill at round start, B-bid 2x multiplier on the 13-card hand, scoreboard round-column alignment, co-winner ties, ghost-tournament cleanup, deterministic winner sorting, tournament event rate limits + validation schemas.

### Guideline 5.1.1(v) — account deletion
- `deleteAccount` socket event: password re-confirm, `users` doc deletion, username anonymized in `gameRecords`, force-logout of other devices.
- iOS: new Account Settings sheet (gear icon) with **Sign Out** (previously missing entirely), **Delete Account**, blocked-users management, legal links. Web: profile-page Danger Zone.
- Privacy/support pages rewritten to describe the in-app path.

### Guideline 4 — exit affordances
- iOS in-game **Leave/Exit** button for all phases including draw (server now handles `/leave` before positions exist), spectator exit button replaces the "type /leave" banner, Done buttons on leaderboard/voice sheets, terms notice on registration.

### Guideline 1.2 — UGC safety (preempts the chat follow-up)
- Profanity filter (leetspeak-aware, O(n) masking) on all four chat surfaces, usernames, lobby names.
- Report → `reports` collection; block/unblock persisted per account, enforced on live + replayed chat on both clients; iOS long-press report/block context menus on every chat surface; `/terms` page with zero-tolerance language.

### Verification
- Two multi-agent adversarial review passes over the change set; all confirmed findings fixed (including a ReferenceError that would have broken web reconnection, a 10-minute tournament-creation lockout, and an event-loop DoS via unbounded lobby names).
- `npm test`: **276 passed** (62 new tournament/filter tests; tournament code previously had zero coverage). `npm run test:client`: **240 passed**. Web build clean.
- iOS: full Swift compile + link **BUILD SUCCEEDED**, zero errors. Note: the asset-catalog (actool) step needs the iOS 26.5 simulator runtime mounted on the build machine (`xcodebuild -downloadPlatform iOS`, then reboot or `sudo killall simdiskimaged`) — environment-only, unrelated to code.

### Suggested App Review notes for resubmission
- Q1 (friends): no friends system — public lobby list, quick-play queue, optional bots; no invites, codes, or private lobbies.
- Q2 (chat): yes — global main-room text chat, lobby/game/tournament chat, P2P voice among matched players. Users can report and block any player in-app; text is profanity-filtered; Terms of Use state zero tolerance. Account deletion: main room gear icon → Delete Account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)