### PR TITLE
Add ambient bot activity so the app is never an empty room

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ npm run test:client  # Client tests (Vitest)
 - In-game leave is a chat command (`/leave`, `/lazy`, `/active`) routed through `chatMessage` — both clients' Leave buttons send `/leave`; it also works during the draw phase (before positions exist)
 - Account deletion (`authHandlers.deleteAccount`) requires an authenticated socket + password re-confirm; it anonymizes the username in `gameRecords`
 - Express pages: `/privacy`, `/support`, `/terms` (App Store compliance copy lives in `server/routes/index.js`)
+- Ambient bot activity (`server/demo/ambientBots.js`): keeps one spectatable bot-vs-bot game running and seeds main-room chat with bot-persona messages, so the app is never an empty room (added for App Review Guideline 2.1(a) — reviewers must see other users' chats and games). On by default in production; `AMBIENT_BOTS=true|false` overrides
 - iOS builds: prebuilt WebRTC (stasel/WebRTC via SPM) ships no dSYM — the archive warning at upload is expected and safe to ignore
 
 ## Common Files to Check

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ npm run build:atlas
 
 The server runs on `http://localhost:3000` by default.
 
+**Ambient bot activity**: in production the server keeps one bot-vs-bot game running (spectatable from the main room) and seeds the global chat with bot-persona messages, so new players never land in an empty room. Control with `AMBIENT_BOTS=true|false` (default: on in production, off in development).
+
 ## How to Play
 
 1. **Sign up/Sign in** - Create an account (auto-logs in) or log in

--- a/server/demo/__tests__/ambientBots.test.js
+++ b/server/demo/__tests__/ambientBots.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for ambient bot activity: enablement rules, chat seeding, and the
+ * self-driving bot game.
+ */
+
+const fakeIo = { to: () => ({ emit: () => {} }), sockets: { sockets: new Map() } };
+
+let ambient;
+let gameManager;
+
+beforeEach(() => {
+    jest.resetModules();
+    ambient = require('../ambientBots');
+    gameManager = require('../../game/GameManager');
+});
+
+afterEach(() => {
+    ambient.stopAmbientActivity();
+    jest.useRealTimers();
+});
+
+describe('shouldEnable', () => {
+    test('defaults on in production', () => {
+        expect(ambient.shouldEnable({ NODE_ENV: 'production' })).toBe(true);
+    });
+
+    test('can be disabled in production', () => {
+        expect(ambient.shouldEnable({ NODE_ENV: 'production', AMBIENT_BOTS: 'false' })).toBe(false);
+    });
+
+    test('defaults off in development', () => {
+        expect(ambient.shouldEnable({ NODE_ENV: 'development' })).toBe(false);
+    });
+
+    test('can be enabled in development', () => {
+        expect(ambient.shouldEnable({ NODE_ENV: 'development', AMBIENT_BOTS: 'true' })).toBe(true);
+    });
+});
+
+describe('seedMainRoomChat', () => {
+    test('seeds an empty room with back-dated messages', () => {
+        expect(ambient.seedMainRoomChat()).toBe(true);
+
+        const messages = gameManager.mainRoomMessages;
+        expect(messages.length).toBeGreaterThanOrEqual(3);
+        for (const m of messages) {
+            expect(typeof m.username).toBe('string');
+            expect(typeof m.message).toBe('string');
+            expect(m.timestamp).toBeLessThanOrEqual(Date.now());
+        }
+        // Timestamps ascend so the history reads naturally
+        for (let i = 1; i < messages.length; i++) {
+            expect(messages[i].timestamp).toBeGreaterThan(messages[i - 1].timestamp);
+        }
+    });
+
+    test('does not overwrite existing chat history', () => {
+        gameManager.mainRoomMessages.push({ username: 'real', message: 'hi', timestamp: Date.now() });
+        expect(ambient.seedMainRoomChat()).toBe(false);
+        expect(gameManager.mainRoomMessages).toHaveLength(1);
+    });
+});
+
+describe('maybePostChat', () => {
+    test('posts when the room has been quiet', () => {
+        gameManager.mainRoomMessages.push({
+            username: 'real', message: 'old', timestamp: Date.now() - 60 * 60 * 1000
+        });
+        expect(ambient.maybePostChat(fakeIo)).toBe(true);
+        expect(gameManager.mainRoomMessages).toHaveLength(2);
+    });
+
+    test('stays silent while the room is active', () => {
+        gameManager.mainRoomMessages.push({
+            username: 'real', message: 'recent', timestamp: Date.now()
+        });
+        expect(ambient.maybePostChat(fakeIo)).toBe(false);
+    });
+});
+
+describe('startBotGame', () => {
+    test('creates a 4-bot game that reaches bidding on its own', async () => {
+        jest.useFakeTimers();
+
+        const game = ambient.startBotGame(fakeIo);
+        expect(game.isDemo).toBe(true);
+        expect(gameManager.getGameById(game.gameId)).toBe(game);
+        expect(game.phase).toBe('drawing');
+
+        // Bots draw on staggered timers, then handleDrawComplete assigns
+        // positions and starts bidding (drawIndex is reset during hand setup)
+        await jest.advanceTimersByTimeAsync(30 * 1000);
+
+        expect(game.players.size).toBe(4);
+        expect(['bidding', 'playing']).toContain(game.phase);
+        for (const [, player] of game.players) {
+            expect(player.isBot).toBe(true);
+        }
+
+        const { botController } = require('../../game/bot');
+        botController.cleanupGame(game.gameId);
+    });
+
+    test('demo games appear in the in-progress list once underway', async () => {
+        jest.useFakeTimers();
+
+        const game = ambient.startBotGame(fakeIo);
+        await jest.advanceTimersByTimeAsync(30 * 1000);
+
+        const inProgress = gameManager.getInProgressGames();
+        expect(inProgress.some(g => g.gameId === game.gameId)).toBe(true);
+
+        const { botController } = require('../../game/bot');
+        botController.cleanupGame(game.gameId);
+    });
+});

--- a/server/demo/ambientBots.js
+++ b/server/demo/ambientBots.js
@@ -1,0 +1,209 @@
+/**
+ * Ambient activity for an otherwise-empty server.
+ *
+ * Keeps one bot-vs-bot game running at all times (it appears in the main
+ * room's in-progress list and can be spectated, with the bots chatting via
+ * their personality hooks) and seeds the main-room chat with messages from
+ * the bot personas so the room is never empty.
+ *
+ * Why: a new player — or an App Store reviewer (Guideline 2.1(a) requires
+ * that reviewers can see other users' chats and other users playing) — who
+ * signs in at a quiet hour should still find a live game to watch and chat
+ * messages to interact with (long-press report/block needs a target).
+ *
+ * Enabled by default in production; disable with AMBIENT_BOTS=false.
+ * Enable in development with AMBIENT_BOTS=true.
+ */
+
+const gameManager = require('../game/GameManager');
+const Deck = require('../game/Deck');
+const { botController, personalities } = require('../game/bot');
+const { PERSONALITY_LIST, getDisplayName } = personalities;
+const { logger } = require('../utils/logger');
+
+const CHECK_INTERVAL_MS = 30 * 1000;        // poll cadence
+const RESTART_DELAY_MS = 90 * 1000;         // pause between games
+const MAX_GAME_AGE_MS = 90 * 60 * 1000;     // recycle a wedged game
+const CHAT_IDLE_MS = 30 * 60 * 1000;        // post bot chatter when room is quiet this long
+const MAX_MESSAGES = 50;                    // mirrors GameManager.MAX_MAIN_ROOM_MESSAGES
+
+// Bot personas keep the 🤖 prefix everywhere — ambient chatter is visibly
+// bot-authored, consistent with how bots appear in games.
+const SEED_MESSAGES = [
+    { username: '🤖 Mary', message: 'Anyone up for a game? Starting a table now' },
+    { username: '🤖 Danny', message: 'gl everyone, feeling a 3-bid kind of day' },
+    { username: '🤖 Sharon', message: 'You can spectate our game from the list below 👇' },
+    { username: '🤖 Mike', message: 'I never get set. Watch and learn' },
+    { username: '🤖 Zach', message: 'Mike got set twice last game, do not listen to him' },
+];
+
+const ROTATING_MESSAGES = [
+    { username: '🤖 Mary', message: 'New game starting — come watch!' },
+    { username: '🤖 Mike', message: 'Bidding board on the 13 hand again. No regrets' },
+    { username: '🤖 Sharon', message: 'A conservative 2 bid never hurt anyone' },
+    { username: '🤖 Danny', message: 'Rainbow bonus on the 4-card hand, count it' },
+    { username: '🤖 Zach', message: 'gg — running it back' },
+];
+
+let intervalHandle = null;
+let currentGameId = null;
+let currentGameStartedAt = 0;
+let nextGameAt = 0;
+let rotationIndex = 0;
+
+/**
+ * Ambient activity runs in production unless explicitly disabled, and in
+ * development only when explicitly enabled.
+ */
+function shouldEnable(env = process.env) {
+    if (env.AMBIENT_BOTS === 'false') return false;
+    if (env.AMBIENT_BOTS === 'true') return true;
+    return env.NODE_ENV === 'production';
+}
+
+/**
+ * Seed the main-room chat history if it's empty (fresh server start),
+ * back-dated so it reads as recent activity rather than a wall of
+ * same-second messages.
+ */
+function seedMainRoomChat() {
+    if (gameManager.mainRoomMessages.length > 0) return false;
+
+    const now = Date.now();
+    SEED_MESSAGES.forEach((m, i) => {
+        gameManager.mainRoomMessages.push({
+            username: m.username,
+            message: m.message,
+            timestamp: now - (SEED_MESSAGES.length - i) * 7 * 60 * 1000
+        });
+    });
+    return true;
+}
+
+/**
+ * Post a rotating bot message when the room has been quiet for a while,
+ * so the chat always has recent content.
+ */
+function maybePostChat(io) {
+    const messages = gameManager.mainRoomMessages;
+    const last = messages[messages.length - 1];
+    if (last && Date.now() - last.timestamp < CHAT_IDLE_MS) return false;
+
+    const m = ROTATING_MESSAGES[rotationIndex % ROTATING_MESSAGES.length];
+    rotationIndex++;
+
+    const chatMessage = { username: m.username, message: m.message, timestamp: Date.now() };
+    messages.push(chatMessage);
+    if (messages.length > MAX_MESSAGES) {
+        messages.shift();
+    }
+    io.to('mainRoom').emit('mainRoomMessage', chatMessage);
+    return true;
+}
+
+/**
+ * Start a fresh 4-bot game. Same flow as tournament bot seats: create and
+ * register bots, then kick off the draw phase — processBotDraw chains into
+ * handleDrawComplete and the bots play the game to completion on their own.
+ */
+function startBotGame(io) {
+    const bots = [];
+    const usedPersonalities = [];
+    for (let i = 0; i < 4; i++) {
+        const available = PERSONALITY_LIST.filter(p => !usedPersonalities.includes(p));
+        const personality = available[Math.floor(Math.random() * available.length)];
+        usedPersonalities.push(personality);
+        bots.push(botController.createBot(`🤖 ${getDisplayName(personality)}`, personality));
+    }
+
+    const game = gameManager.createGame(bots.map(b => b.socketId));
+    game.isDemo = true;
+    for (const bot of bots) {
+        botController.registerBot(game.gameId, bot);
+    }
+
+    game.deck = new Deck();
+    game.deck.shuffle();
+    game.phase = 'drawing';
+
+    let drawOrder = 0;
+    for (const bot of bots) {
+        drawOrder++;
+        botController.scheduleBotDraw(io, game, bot.socketId, drawOrder);
+    }
+
+    currentGameId = game.gameId;
+    currentGameStartedAt = Date.now();
+    logger.info('Ambient bot game started', { gameId: game.gameId });
+    return game;
+}
+
+/**
+ * Keep exactly one ambient game alive: start a new one shortly after the
+ * previous ends, and recycle a game that has somehow wedged.
+ */
+function tick(io) {
+    maybePostChat(io);
+
+    if (currentGameId) {
+        const game = gameManager.getGameById(currentGameId);
+        if (!game) {
+            // Finished normally (endGame removed it) — schedule the next one
+            currentGameId = null;
+            nextGameAt = Date.now() + RESTART_DELAY_MS;
+            return;
+        }
+        if (Date.now() - currentGameStartedAt > MAX_GAME_AGE_MS) {
+            logger.warn('Ambient bot game exceeded max age, recycling', { gameId: currentGameId });
+            botController.cleanupGame(currentGameId);
+            game.leaveAllFromRoom(io);
+            gameManager.abortGame(currentGameId);
+            currentGameId = null;
+            nextGameAt = Date.now() + RESTART_DELAY_MS;
+        }
+        return;
+    }
+
+    if (Date.now() >= nextGameAt) {
+        startBotGame(io);
+    }
+}
+
+/**
+ * Entry point — call once at server startup.
+ */
+function startAmbientActivity(io) {
+    if (intervalHandle) return;
+
+    seedMainRoomChat();
+    startBotGame(io);
+
+    intervalHandle = setInterval(() => {
+        try {
+            tick(io);
+        } catch (error) {
+            logger.error('Ambient activity tick failed', { error: error.message, stack: error.stack });
+        }
+    }, CHECK_INTERVAL_MS);
+    if (intervalHandle.unref) intervalHandle.unref();
+
+    logger.info('Ambient bot activity enabled');
+}
+
+function stopAmbientActivity() {
+    if (intervalHandle) {
+        clearInterval(intervalHandle);
+        intervalHandle = null;
+    }
+}
+
+module.exports = {
+    startAmbientActivity,
+    stopAmbientActivity,
+    shouldEnable,
+    // exported for tests
+    seedMainRoomChat,
+    maybePostChat,
+    startBotGame,
+    tick
+};

--- a/server/index.js
+++ b/server/index.js
@@ -80,6 +80,13 @@ const io = new Server(server, {
 // Setup socket event handlers
 setupSocketHandlers(io);
 
+// Ambient bot activity (spectatable bot games + seeded main-room chat) so
+// the app is never an empty room — on by default in production
+const { startAmbientActivity, shouldEnable } = require('./demo/ambientBots');
+if (shouldEnable()) {
+    startAmbientActivity(io);
+}
+
 // Start server
 function start() {
     // Hardcode port 3000 - Railway requires this (using PORT env var causes 502)


### PR DESCRIPTION
## Summary

App Review rejected build 1.0 (27) under **Guideline 2.1(a)**: the reviewer signed in as the demo account and found an empty server — no other users, no chats — so multiplayer features and the report/block UI couldn't be verified ("make sure the demo accounts include pre-populated content... other user's chats and other users are playing the game").

This adds `server/demo/ambientBots.js`:

- **Always one live bot-vs-bot game**: created at startup and restarted ~90s after each game ends; appears in the main room's in-progress list and is spectatable, with the bots' existing personality chat visible to spectators. Wedged games recycle after 90 minutes.
- **Seeded main-room chat**: bot-persona messages (🤖-prefixed, consistent with how bots appear in games) seed the history on a fresh start, plus an occasional message when the room has been quiet >30 min — so the chat always has content to long-press for Report/Block.
- Bot games are already excluded from player stats and gameRecords (existing `hasBots` guard), so no leaderboard/records pollution.
- On by default in production, off in development; `AMBIENT_BOTS=true|false` overrides.

## Verification

- 10 new Jest tests (enable rules, chat seeding/rotation, self-driving bot game reaching bidding with 4 bot players, in-progress list inclusion); full suite 286 green.
- End-to-end against a local server via socket client: fresh account → `joinMainRoom` shows 5 seeded messages + 1 in-progress bot game → `joinAsSpectator` observes live card plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)