### PR TITLE
Fix main-room chat history not appearing on iOS

### DIFF
--- a/iOSClient/BABOnline/Networking/Handlers/LobbySocketHandler.swift
+++ b/iOSClient/BABOnline/Networking/Handlers/LobbySocketHandler.swift
@@ -28,7 +28,9 @@ final class LobbySocketHandler {
                 if let users = dict["onlineUsers"] as? [String] {
                     self.mainRoomState.onlineUsers = users
                 }
-                if let messages = dict["recentMessages"] as? [[String: Any]] {
+                // The server sends the replay under "messages" (and mirrors it
+                // as "recentMessages" for app builds that read this key)
+                if let messages = (dict["recentMessages"] ?? dict["messages"]) as? [[String: Any]] {
                     self.mainRoomState.messages = messages
                         .compactMap { ChatMessage.from($0) }
                         .filter { !self.safetyState.isBlocked($0.username) }

--- a/server/socket/lobbyHandlers.js
+++ b/server/socket/lobbyHandlers.js
@@ -201,6 +201,7 @@ function leaveLobby(socket, io) {
     socket.emit('leftLobby', {});
     socket.emit('mainRoomJoined', {
         messages: mainRoomResult.messages,
+        recentMessages: mainRoomResult.messages, // iOS reads this key
         lobbies: mainRoomResult.lobbies,
         onlineCount: onlineUsers.length,
         onlineUsers,

--- a/server/socket/mainRoomHandlers.js
+++ b/server/socket/mainRoomHandlers.js
@@ -23,9 +23,12 @@ function joinMainRoom(socket, io) {
     // Compute online users once so count and list always agree
     const onlineUsers = gameManager.getOnlineUsernames();
 
-    // Send initial state to the player
+    // Send initial state to the player.
+    // recentMessages duplicates messages: the iOS client reads that key for
+    // the chat history replay (web reads messages) — keep both populated.
     socket.emit('mainRoomJoined', {
         messages: result.messages,
+        recentMessages: result.messages,
         lobbies: result.lobbies,
         onlineCount: onlineUsers.length,
         onlineUsers,

--- a/server/socket/tournamentHandlers.js
+++ b/server/socket/tournamentHandlers.js
@@ -122,6 +122,7 @@ function sendToMainRoom(socket) {
     const onlineUsers = gameManager.getOnlineUsernames();
     socket.emit('mainRoomJoined', {
         messages: mainRoomResult.messages,
+        recentMessages: mainRoomResult.messages, // iOS reads this key
         lobbies: mainRoomResult.lobbies,
         onlineCount: onlineUsers.length,
         onlineUsers,


### PR DESCRIPTION
## Summary

The iOS app reads the main-room chat replay from `mainRoomJoined.recentMessages`, but the server sends `messages` — so iOS never displayed chat history on entry (web reads `messages` and worked). This also hid the seeded ambient chat from App Review on the device that matters.

**Fix is server-side so the already-uploaded build 1.0 (27) starts working without a new binary**: all three `mainRoomJoined` emit sites now mirror the array under both keys. The iOS handler also now accepts either key, for future builds.

## Verification

- Local socket probe: `mainRoomJoined` carries `messages: 5, recentMessages: 5` (identical arrays).
- Full Jest suite: 286 green. iOS target compiles with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)