### PR TITLE
Make ambient chat copy layout-neutral

### DIFF
--- a/server/demo/ambientBots.js
+++ b/server/demo/ambientBots.js
@@ -32,7 +32,7 @@ const MAX_MESSAGES = 50;                    // mirrors GameManager.MAX_MAIN_ROOM
 const SEED_MESSAGES = [
     { username: '🤖 Mary', message: 'Anyone up for a game? Starting a table now' },
     { username: '🤖 Danny', message: 'gl everyone, feeling a 3-bid kind of day' },
-    { username: '🤖 Sharon', message: 'You can spectate our game from the list below 👇' },
+    { username: '🤖 Sharon', message: 'You can watch our game from the games list — tap Spectate' },
     { username: '🤖 Mike', message: 'I never get set. Watch and learn' },
     { username: '🤖 Zach', message: 'Mike got set twice last game, do not listen to him' },
 ];


### PR DESCRIPTION
One-line copy fix: the seeded 🤖 Sharon message said to spectate "from the list below 👇", but the games list renders above the chat. Now references the games list by name ("tap Spectate"), which holds on both web and iOS layouts. Re-seeds automatically on deploy since the server restart starts with an empty chat history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)