### PR TITLE
Announce ambient games when they actually start; shrink the gap

### DIFF
--- a/server/demo/__tests__/ambientBots.test.js
+++ b/server/demo/__tests__/ambientBots.test.js
@@ -113,4 +113,28 @@ describe('startBotGame', () => {
         const { botController } = require('../../game/bot');
         botController.cleanupGame(game.gameId);
     });
+
+    test('announces in chat exactly once, only after the game is visible', async () => {
+        jest.useFakeTimers();
+        // Pre-fill chat so maybePostChat stays quiet during the test
+        gameManager.mainRoomMessages.push({ username: 'real', message: 'hi', timestamp: Date.now() });
+
+        const game = ambient.startBotGame(fakeIo);
+
+        // Still drawing — no announcement yet
+        ambient.tick(fakeIo);
+        expect(gameManager.mainRoomMessages).toHaveLength(1);
+
+        await jest.advanceTimersByTimeAsync(30 * 1000);
+        expect(game.phase).not.toBe('drawing');
+
+        // Visible — announce once, then stay quiet
+        ambient.tick(fakeIo);
+        ambient.tick(fakeIo);
+        expect(gameManager.mainRoomMessages).toHaveLength(2);
+        expect(gameManager.mainRoomMessages[1].message).toMatch(/game/i);
+
+        const { botController } = require('../../game/bot');
+        botController.cleanupGame(game.gameId);
+    });
 });

--- a/server/demo/ambientBots.js
+++ b/server/demo/ambientBots.js
@@ -21,8 +21,8 @@ const { botController, personalities } = require('../game/bot');
 const { PERSONALITY_LIST, getDisplayName } = personalities;
 const { logger } = require('../utils/logger');
 
-const CHECK_INTERVAL_MS = 30 * 1000;        // poll cadence
-const RESTART_DELAY_MS = 90 * 1000;         // pause between games
+const CHECK_INTERVAL_MS = 15 * 1000;        // poll cadence
+const RESTART_DELAY_MS = 30 * 1000;         // pause between games (keep the gap short)
 const MAX_GAME_AGE_MS = 90 * 60 * 1000;     // recycle a wedged game
 const CHAT_IDLE_MS = 30 * 60 * 1000;        // post bot chatter when room is quiet this long
 const MAX_MESSAGES = 50;                    // mirrors GameManager.MAX_MAIN_ROOM_MESSAGES
@@ -37,19 +37,28 @@ const SEED_MESSAGES = [
     { username: '🤖 Zach', message: 'Mike got set twice last game, do not listen to him' },
 ];
 
+// Idle chatter must be timeless — anything temporal ("new game starting")
+// belongs in announceGameVisible, where it's actually true
 const ROTATING_MESSAGES = [
-    { username: '🤖 Mary', message: 'New game starting — come watch!' },
     { username: '🤖 Mike', message: 'Bidding board on the 13 hand again. No regrets' },
     { username: '🤖 Sharon', message: 'A conservative 2 bid never hurt anyone' },
     { username: '🤖 Danny', message: 'Rainbow bonus on the 4-card hand, count it' },
-    { username: '🤖 Zach', message: 'gg — running it back' },
+    { username: '🤖 Zach', message: 'Our table is pretty much always running — tap Spectate to watch' },
+];
+
+const GAME_START_MESSAGES = [
+    { username: '🤖 Mary', message: 'New game starting — come watch!' },
+    { username: '🤖 Danny', message: 'Cards are dealt, new game underway — spectators welcome' },
+    { username: '🤖 Mike', message: 'Fresh game just started. Come watch me not get set' },
 ];
 
 let intervalHandle = null;
 let currentGameId = null;
 let currentGameStartedAt = 0;
+let currentGameAnnounced = false;
 let nextGameAt = 0;
 let rotationIndex = 0;
+let startIndex = 0;
 
 /**
  * Ambient activity runs in production unless explicitly disabled, and in
@@ -102,6 +111,23 @@ function maybePostChat(io) {
 }
 
 /**
+ * Once the new game leaves the draw phase it shows up in the main room's
+ * in-progress list (handleDrawComplete broadcasts lobbiesUpdated) — that is
+ * the moment a "new game starting" chat message is actually true.
+ */
+function announceGameVisible(io) {
+    const m = GAME_START_MESSAGES[startIndex % GAME_START_MESSAGES.length];
+    startIndex++;
+
+    const chatMessage = { username: m.username, message: m.message, timestamp: Date.now() };
+    gameManager.mainRoomMessages.push(chatMessage);
+    if (gameManager.mainRoomMessages.length > MAX_MESSAGES) {
+        gameManager.mainRoomMessages.shift();
+    }
+    io.to('mainRoom').emit('mainRoomMessage', chatMessage);
+}
+
+/**
  * Start a fresh 4-bot game. Same flow as tournament bot seats: create and
  * register bots, then kick off the draw phase — processBotDraw chains into
  * handleDrawComplete and the bots play the game to completion on their own.
@@ -134,6 +160,7 @@ function startBotGame(io) {
 
     currentGameId = game.gameId;
     currentGameStartedAt = Date.now();
+    currentGameAnnounced = false;
     logger.info('Ambient bot game started', { gameId: game.gameId });
     return game;
 }
@@ -152,6 +179,10 @@ function tick(io) {
             currentGameId = null;
             nextGameAt = Date.now() + RESTART_DELAY_MS;
             return;
+        }
+        if (!currentGameAnnounced && game.phase !== 'drawing' && game.phase !== 'waiting') {
+            currentGameAnnounced = true;
+            announceGameVisible(io);
         }
         if (Date.now() - currentGameStartedAt > MAX_GAME_AGE_MS) {
             logger.warn('Ambient bot game exceeded max age, recycling', { gameId: currentGameId });
@@ -204,6 +235,7 @@ module.exports = {
     // exported for tests
     seedMainRoomChat,
     maybePostChat,
+    announceGameVisible,
     startBotGame,
     tick
 };


### PR DESCRIPTION
## Summary

Two polish issues observed while testing the ambient bot activity:

1. **Misleading announcement timing**: "New game starting — come watch!" was in the idle chat rotation (posts after 30 quiet minutes), so it could land right after a game *ended* — pointing at an empty games list for the duration of the restart gap. Game-start messages now post from the ambient tick exactly when the new game leaves the draw phase, which is the same moment `handleDrawComplete` broadcasts it into the in-progress list. The idle rotation keeps only timeless lines.
2. **Restart gap**: between-games pause reduced 90s → 30s with a 15s tick, so the games list has at most a ~60s empty window instead of ~2½ minutes.

## Verification

New test: announcement posts exactly once, only after the game becomes visible, never during the draw phase. Suite: 287 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)