### PR TITLE
Rework bot AI: contract-aware play, calibrated bidding, sim-tuned personalities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ bab-online/
 │   │   ├── GameState.js       # Game state encapsulation
 │   │   ├── GameManager.js     # Singleton: manages games, queue, lobbies, tournaments
 │   │   ├── TournamentState.js # Per-tournament state (4 rounds, scoreboard)
-│   │   └── bot/               # AI player system
+│   │   └── bot/               # AI player system (strategy, personalities, sim/ harness)
 │   ├── socket/                # Socket.IO handlers by domain
 │   │   ├── gameHandlers.js    # Core gameplay (draw, bid, play)
 │   │   ├── lobbyHandlers.js   # Pre-game lobby
@@ -124,11 +124,12 @@ npm run build:client # Production build
 
 npm test             # Server tests (Jest)
 npm run test:client  # Client tests (Vitest)
+npm run sim          # Bot-vs-bot simulation (tuning/regression; see server/game/bot/sim/README.md)
 ```
 
 ## Important Implementation Details
 
-- Bots have socketIds like `bot:{username}:{uuid}`, use `BotStrategy.js` for AI
+- Bots have socketIds like `bot:{username}:{uuid}`, use `BotStrategy.js` for AI. Card play is contract-aware: `processBotPlay` passes a play context (team bids/tricks/bores) into `decideCard`. Personalities (`personalities.js`) define `bidStyle` + `playStyle` consumed by the strategy; Mary is the sim-tuned optimal baseline, the others are slight measured variations. Strategy changes must be benchmarked with `npm run sim` against the frozen legacy snapshot (`sim/legacyStrategy.js`)
 - Reconnection uses session tokens stored in MongoDB; rejoining a tournament game also reattaches tournament membership to the new socket
 - Socket rooms: players join `game:{gameId}` for broadcasts; tournaments use `tournament:{tournamentId}`
 - Event constants in `client/src/constants/events.js` (web) and `iOSClient/.../Constants/SocketEvents.swift` (iOS) prevent typos — keep all three sides of the contract in sync
@@ -144,6 +145,7 @@ npm run test:client  # Client tests (Vitest)
 | Task | Files |
 |------|-------|
 | Game rules/logic | `server/game/rules.js`, `docs/RULES.md` |
+| Bot AI / strategy | `server/game/bot/BotStrategy.js`, `docs/bot-strategy-guide.md`, `server/game/bot/sim/` |
 | Card play handling | `server/socket/gameHandlers.js` |
 | Client card legality | `client/src/rules/legality.js` |
 | UI screens | `client/src/ui/screens/` |

--- a/README.md
+++ b/README.md
@@ -119,9 +119,10 @@ bab-online/
 │   │   └── bot/                       # Bot player system
 │   │       ├── BotPlayer.js           # Bot player class with card memory
 │   │       ├── BotController.js       # Bot lifecycle and personality hooks
-│   │       ├── BotStrategy.js         # AI strategy functions
-│   │       ├── personalities.js       # Bot personality definitions
-│   │       └── __tests__/             # Bot strategy tests
+│   │       ├── BotStrategy.js         # AI strategy (contract-aware, card-counting)
+│   │       ├── personalities.js       # Personality registry (bid + play styles)
+│   │       ├── sim/                   # Bot-vs-bot simulation harness (npm run sim)
+│   │       └── __tests__/             # Strategy tests + legality fuzz suite
 │   ├── socket/
 │   │   ├── index.js                   # Socket event routing
 │   │   ├── authHandlers.js            # Auth events + account deletion
@@ -175,6 +176,10 @@ npm test
 
 # Run client tests (Vitest)
 npm run test:client
+
+# Bot-vs-bot simulation: benchmarks strategy changes against a frozen
+# baseline and validates every bot decision against the rules engine
+npm run sim
 
 # Vite dev server only (port 5173, proxies to :3000)
 npm run dev:client
@@ -268,7 +273,7 @@ The server uses a modular architecture with clear separation of concerns:
 - **TournamentState** - Per-tournament state managing players, rounds, scoring, and game distribution
 - **Deck** - Card deck with Fisher-Yates shuffle
 - **rules.js** - Pure functions for game logic (testable)
-- **BotController / BotStrategy** - AI bot system with 5 personalities, hand-size-aware bidding, card memory, and in-game chat
+- **BotController / BotStrategy** - AI bot system: contract-aware card play (bore execution/defense, set denial), card-counting trick play, hand-size-aware bidding, card memory, and in-game chat. Five personalities layer measured bid/play variations over the optimal "Mary" baseline; strategy changes are benchmarked with the simulation harness (`npm run sim`) against a frozen snapshot
 - **Socket handlers** - Organized by domain (auth, queue, game, chat, profile, reconnect, tournament)
 
 ### Web Client Architecture

--- a/docs/bot-strategy-guide.md
+++ b/docs/bot-strategy-guide.md
@@ -2,6 +2,8 @@
 
 This guide describes optimal strategy for Back Alley Bridge, intended as a reference for both human players and the Mary bot implementation. It covers bidding, card play, and the strategic reasoning behind each decision.
 
+Strategy claims here are validated empirically: `npm run sim` plays the real bot code through thousands of full games against a frozen benchmark (see `server/game/bot/sim/README.md`). This edition of the guide was rewritten after a ~250,000-game tuning campaign (June 2026), and several pieces of received wisdom from earlier editions did not survive contact with the data. Where intuition and measurement disagreed, the measurements won — those reversals are called out inline and collected at the end.
+
 ## Core Principle: The Set Penalty Asymmetry
 
 The single most important strategic fact in Back Alley Bridge is the scoring asymmetry:
@@ -10,18 +12,25 @@ The single most important strategic fact in Back Alley Bridge is the scoring asy
 - **Getting set** on a bid of 3 costs -30 points
 - **Overtricks** are worth only +1 point each
 
-This creates a ~30:1 penalty ratio. Bidding 3 and winning 4 tricks gives you +31. Bidding 4 and winning 3 gives you -40. The cost of over-bidding by 1 trick is catastrophic compared to the cost of under-bidding by 1 trick. Therefore: **when in doubt, bid one fewer than you think you can win.** It is always preferable to slightly under-bid than over-bid.
+Do the marginal math on raising a bid by one. If you make the higher bid, you gain +9 (a 10-point trick instead of a 1-point overtrick). If the extra trick doesn't come, you swing from roughly +20 to -30 — about **-50 points** on a bid of 2→3. That ratio means a marginal bid increase needs to succeed roughly 85% of the time just to break even.
+
+So: **when in doubt, bid one fewer than you think you can win** — but only *one* fewer. Optimal play runs at roughly a 90% team make-rate. Below that you're donating sets; much above it you're systematically leaving 9 points per hand on the table as overtricks. Both failure modes are real:
+
+- Tuning the bot's bids upward by about half a trick tripled its set rate and *lost* games despite "bidding closer to true strength."
+- The original bot's triple-stacked conservatism (pessimistic values, floor rounding, extra first-bidder discount) made its bid only ~93% of the time — and it lost to versions of itself that simply bid more.
+
+The equilibrium: evaluate pessimistically, round down, and **stop there**. Don't add further "safety" adjustments on top — each one double-counts uncertainty that the evaluation already priced in.
 
 ## Bidding: Hand-Size-Dependent Card Evaluation
 
-Card values change dramatically based on hand size. This is the most important strategic concept to internalize.
+Card values change dramatically based on hand size. This is the most important evaluation concept to internalize.
 
 ### Why Hand Size Matters
 
 With 54 cards in the deck and 4 players:
 - **12-card hand**: 48 of 54 cards dealt. Every player has nearly every suit. A non-trump Ace is almost guaranteed to win its trick.
 - **6-card hand**: 24 cards dealt. Voids (having zero cards of a suit) become common. A non-trump King might lose to a trump card.
-- **2-card hand**: Only 8 cards dealt. The chance an opponent is void in your non-trump suit is very high (~60-80%). Non-trump high cards are nearly worthless.
+- **2-card hand**: Only 8 cards dealt. The chance an opponent is void in your non-trump suit is very high. Non-trump high cards are nearly worthless.
 - **1-card hand**: Only trump matters. A non-trump card is essentially a zero bid.
 
 ### Large Hands (8-13 cards)
@@ -29,194 +38,161 @@ With 54 cards in the deck and 4 players:
 - **Non-trump Aces**: Strong — worth roughly 0.7-0.8 of a trick. Opponents almost certainly have the suit and must follow.
 - **Non-trump Kings**: Moderate — worth roughly 0.3-0.4 of a trick. Reliable if you also hold the Ace, but risky alone since the Ace is out there and may not belong to your partner.
 - **Trump cards**: Very strong when you hold many (5+). Trump length gives control over the hand.
+- **Every trump card counts.** Even low trump (2-6) carries fractional value at every hand size — each one ruffs a trick or forces out a bigger trump. An earlier edition valued mid trump at zero on large hands; that produced absurd inversions (a trump Jack rated below an off-suit King) and was the single largest source of underbidding the simulation found. As a rule of thumb: mid trump (7-J) ≈ 0.15-0.25 tricks, low trump ≈ 0.05-0.1, scaling up as hands shrink.
 - **Voids**: Valuable in combination with trump — each void is an opportunity to trump in on that suit.
-- **Single trump card risk**: If you hold exactly one trump card in a large hand and it's not a joker, it's likely to be outmatched by someone with more/higher trump. Devalue it by ~30%.
+- **Single trump risk**: One lone non-joker trump in a large hand is likely to be outdrawn. Devalue it.
 
 ### Medium Hands (4-7 cards)
 
 - **Non-trump Aces**: Worth about half a trick. Voids are common enough that someone may trump your Ace.
 - **Non-trump Kings**: Risky — worth very little unless the Ace has already been played.
-- **Trump cards**: Increasingly valuable as each trump card is more likely to be the only one at the table.
-- **Voids + trump**: The combination becomes very powerful. Being void in a suit with 2+ trump cards means you can control multiple tricks.
+- **Trump cards**: Increasingly valuable; mid trump approaches a third of a trick each.
+- **Voids + trump**: The combination becomes very powerful.
 
 ### Small Hands (1-3 cards)
 
-- **Non-trump high cards**: Nearly worthless on their own. At 2 cards, the chance an opponent is void in your suit approaches 75%. At 1 card, a non-trump card can only win if you lead and everyone happens to have that suit.
-- **Any trump card**: Valuable because fewer total trump are in play. A mid-trump card (7, 8, 9) that would be worthless in a 12-card hand can win tricks here.
+- **Non-trump high cards**: Nearly worthless on their own.
+- **Any trump card**: Valuable because so few trump are in play. On a 1-card hand, even a trump **7** wins often enough (~70%) that bidding 1 on it is profitable — and nonzero bids avoid pointless all-zero redeals. On a 2-card hand, a trump Queen or any *pair* of trump is worth a bid of 1.
 - **HI/LO jokers and trump Ace**: Near-guaranteed tricks at any hand size.
+
+### The Flipped Card Is Out of Play
+
+The card flipped to set trump is removed from the game, and your evaluation should use that:
+- **Trump Ace flipped** → your trump King is the boss trump card after the jokers. Value it like an Ace.
+- **Trump King flipped** → promote your Queen the same way.
+- **HI joker flipped** (no-trump hand) → your **LO joker is unbeatable**. It's the single strongest card in the game at that point; bid and bore accordingly.
 
 ### No-Trump Hands (Joker Flipped)
 
-When a joker is flipped as trump, the game changes fundamentally:
-- Only the remaining joker(s) are trump — there is no trump suit
-- **Non-trump Aces become very strong** (~1.3 tricks) since nobody can trump in on your suit
-- **Non-trump Kings become moderate** (~0.7 tricks)
-- Long suits are powerful — you can run them without fear of being trumped
-- Voids are nearly worthless (you can't trump in without trump cards)
-- Bidding focuses on how many high cards you have in suits you can lead
+When a joker is flipped, there is no trump suit — but **the other joker is still trump**, a one-card ruffing threat that most players forget:
+- **Non-trump Aces become very strong** (~1.3 tricks); Kings moderate (~0.7).
+- An Ace is only truly safe once the live joker is accounted for — a player void in your suit can still ruff you with it.
+- Voids are nearly worthless to you unless you hold the live joker.
+- On small NT hands, count sure winners directly: jokers and Aces are near-certain tricks (an A-A 2-card NT hand is a bid of 2, and a bore candidate as dealer).
 
 ## Bidding: Reading Other Players' Bids
 
 ### Bid Order Position
 
-Players bid clockwise starting left of dealer. The dealer bids last with the most information.
-
-- **First bidder**: Has the least information. Should bid slightly more conservatively (round down aggressively).
-- **Middle bidders**: Can see some bids. Adjust based on what's already been bid.
-- **Dealer (last)**: Has full information. Can adjust precisely and make informed bore decisions.
+- **A seat that hasn't bid yet is NOT a zero bid — it's no information at all.** Several bore rules below key off "everyone signaled weakness"; that signal only exists for bids you have actually seen. The original bot treated unbid seats as zeros and bored as first bidder on garbage.
+- **First bidder**: has the least information, but should *not* take an extra discount for it. A pessimistic evaluation plus floor rounding already prices in the uncertainty; a further flat -1 was measured to cost about 1.2% win rate. This is the guide's most counterintuitive reversal: more conservatism is not free.
+- **Dealer (last)**: has full information. The "weak field" bore cases below are only fully confirmed from this seat.
 
 ### What Bids Tell You
 
-- **Everyone bids 0**: All hands are weak. This is a key signal for bore decisions (see below).
-- **Opponents bid high**: They have strong hands. Be more conservative — the tricks you expected to win may be taken.
-- **Partner bid high**: Be careful not to overbid as a team. If your partner bid 4 on a 6-card hand, they expect to win most tricks — bid conservatively.
-- **Partner bored**: They think they can win every trick. Consider supporting with a double-bore, unless them having the lead is critical to their strategy.
-
-### Partner Bid Coordination
-
-Your team's combined bid should never exceed the hand size. If your partner already bid high, reduce yours. The set penalty applies to the combined bid, so both partners share the risk.
+- **Everyone bids 0**: all hands are weak — the key bore signal.
+- **Opponents bid high**: be more conservative; the tricks you counted may be taken.
+- **Partner bid high**: your team's combined bid can never usefully exceed the hand size — cap your bid at `handSize - partnerBid`. (And re-check the cap after any adjustment; the original bot applied personality tweaks *after* the cap and occasionally bid its team into mathematically unmakeable contracts.)
+- **An opponent bored**: cap your own bid at 1. Either they sweep (you're set regardless of what you bid) or you take a trick and set them — your own bid only adds risk. Defense happens in the play, not the auction.
 
 ## Bore Strategy
 
-Bore is a double-or-nothing bet to win ALL tricks. It's the most misunderstood part of the game — bore is most valuable on **small hands**, not large ones.
+Bore is a double-or-nothing bet to win ALL tricks. It's most valuable on **small hands**: a 2-card bore is worth 40 points against 20 for a plain bid of 2 — same requirement, double the reward — while a 12-card bore needs an extraordinary hand to be anything but a donation. In practice, well-judged bores succeed about 90% of the time, and ~85% of kept 1-card hands contain one.
 
-### Why Bore on Small Hands?
+### 1-Card Hands
 
-On a 2-card hand, a normal bid of 2 is worth 20 points. A bore is worth 40. The risk is the same (you need to win all tricks either way), but bore doubles the reward.
+- **HI joker** (or LO when the HI was flipped): bore **unconditionally** — the card is unbeatable, and the bore itself wins you the lead.
+- **LO joker or trump Ace**: bore unless an opponent has already bored (their bore may be the HI joker). Expected value strongly favors the bore: ~94% to win doubles your payoff for a small added risk.
+- **Trump King**: bore only as dealer after seeing all three others bid 0.
+- **Trump Queen or lower**: don't bore; trump 7+ still bids 1.
 
-On a 12-card hand, a bore is worth 240 points but requires winning all 12 tricks — missing even one costs -240. The probability of sweeping 12 tricks is very low unless your hand is extraordinary.
+### 2-Card Hands (after seeing at least one bid, all seen bids 0)
 
-### 2-Card Hand Bore Decisions
-
-When all other players bid 0 (key signal — everyone has weak hands):
-
-- **Two trump cards (at least one mid+ like 7 or higher)**: BORE. Two trump in a weak field will likely take both tricks.
-- **One high trump (HI joker, LO joker, or trump Ace) + one high non-trump (Ace or King)**: BORE. Lead the non-trump first — opponents likely can't beat it since they signaled weakness, then win the second trick with trump.
-- **One high trump + one mid/low non-trump**: Do NOT bore. The non-trump card is too likely to lose, and then you're set on a bore.
-- **Two high non-trump cards (e.g., two Aces of different suits)**: Consider boring if everyone bid 0 and you're the dealer (last to bid with full info). Lead one, and if the field is weak, you may take both.
-
-### 1-Card Hand Bore Decisions
-
-When all others bid 0:
-- **HI joker**: Always bore (guaranteed win when leading)
-- **LO joker or trump Ace**: Bore (very likely to win)
-- **Trump King**: Bore (likely to win when the field is weak)
-- **Lower trump**: Don't bore (too uncertain)
+- **Two trump, at least one mid (7+)**: bore.
+- **One top trump (joker or trump Ace) + one high off-suit card (A/K)**: bore — lead the off-suit card into the weak field first.
+- **No-trump A+A** (as dealer, weak field): bore — nothing can ruff you.
+- **One top trump + junk**: do NOT bore. The junk card will lose a trick.
 
 ### 3-5 Card Hands
 
-Bore only with near-all-trump holdings + HI joker when everyone bids 0. The more tricks you need to sweep, the less likely a bore succeeds.
+Bore only with the HI joker plus a near-all-trump holding. The more tricks you must sweep, the faster bore equity evaporates.
 
 ### Large Hands (10+)
 
-Bore only with extraordinary holdings: both jokers, 7+ trump, 8+ evaluation points. These are very rare.
+Only with both jokers and 7+ trump. These are once-a-season hands.
 
-### Partner Bore Support (Double Bore)
+### Bore Escalation (2B/3B/4B)
 
-If your partner bores, consider double-boring (2B) to support them — this quadruples the multiplier. Do this when:
-- The hand is small (4 cards or fewer)
-- You hold decent trump (at least half your hand)
-- You don't think having the lead yourself is critical
+Support your partner's bore with the next level up when the hand is small (≤4 cards) and you hold decent trump. Two rules the original bot got wrong:
+- Escalate **above the highest bore on the table**, not blindly to "the next level" — re-boring at the same level isn't a thing.
+- If an **opponent** holds the highest bore, escalating doubles the stakes on a hand someone else thinks they'll sweep. Only do it holding the unbeatable card yourself (HI joker, or LO when HI was flipped).
 
-Don't double-bore on large hands — the risk is too high.
+## Playing the Contract
+
+Card play must know the contract state — the bids, the tricks taken so far, and any bores. Three regimes:
+
+- **Every trick matters** (your team bored; your remaining bid equals the remaining tricks; an opponent bore is still alive; or setting the opponents requires winning out and is genuinely within reach): play raw strength. Lead the HI joker, then boss trump, then established winners. Overtake even your partner's wins if they could be beaten, and trump in to secure tricks you'd otherwise concede. One trick taken against an opposing bore sets it for a huge swing — it justifies any card in your hand.
+- **Contested middle** (bids still in play): standard play, described in the sections below.
+- **Only overtricks left** (both teams' bids decided): every remaining trick is worth ±1 and **cards have no value beyond this hand** — keep playing to win tricks; just never read more into them than a point. Cash established winners while you have the lead.
+
+Two important boundaries on the first regime:
+
+- **A bore that loses a trick is dead.** Stop sweeping; fall back to whatever objective is still alive (usually denying the opponents their bid).
+- **Don't chase unrealistic sets.** "Win out to deny their bid" is only worth pursuing when the required sweep is close to what your own bid already demanded, or the opposing contract is a bore. The bot's first implementation went into sweep-everything mode whenever opponents sat one trick from a small bid — all hand long, from trick one. Denial is a finishing move, not a lifestyle.
+
+### The Lesson Hiding in the Third Regime
+
+Earlier thinking said: "once your bid is made, conserve your trump and honors." The simulation says that's backwards, and the reason generalizes: **within a hand, a card you "save" with no remaining objective is a card you wasted.** There is no next hand for it. Conservation is only meaningful in the middle regime, where a specific future trick (the one that makes your bid, or sets theirs) needs the card more than this trick does. Once nothing but ±1s remain, straightforward trick-maximizing play *is* optimal play. A version of the bot that ducked "worthless" overtricks measurably lost points — it was donating +1s to the opponents out of misplaced thrift.
+
+## Card Play: Counting and the "Boss" Concept
+
+Strong play in this game is mostly bookkeeping. Track what's been played (plus the flipped card, plus your own hand), and for any card ask: **how many cards still in unknown hands outrank it?** A card with the answer *zero* is **boss** — it cannot lose to anything except a ruff.
+
+Boss status drives almost every follow decision:
+
+- **Opponent winning, players still to act**: play the **cheapest boss winner** if you have one — it wins as surely as your highest card while spending less. With no boss available, fight with your highest non-joker winner. (Pure "lowest card that beats the current winner" — classical whist economy — measured worse here: at +1 per overtrick and -10×bid per set, securing tricks beats saving face cards.)
+- **Opponent winning, you act last**: the lowest winner *always* holds — never spend more. (Corollary: "protecting" a King when you're last to act is meaningless; nothing plays after you.)
+- **Partner winning**: count before you duck. If players still act and your partner's card can still be beaten — higher cards outstanding, or a known-void opponent who can ruff — overtake with your cheapest boss. If their card is boss, play your lowest and bank the trick. The original bot overtook its partner's winning trump Queen "just in case" even when every higher trump was accounted for; counting ends that.
+- **A win is vulnerable** when higher cards remain in unknown hands, or (for non-trump winners) when a remaining opponent is known void in the suit. In no-trump, that ruff risk persists exactly until the live joker is accounted for.
 
 ## Card Play: Leading
 
 ### HI Joker
 
-Leading HI joker forces opponents to play their highest trump while partner plays their lowest. This clears the opponents' best trump cards and sets up your remaining trump to run. Generally lead HI joker early in larger hands when you have other trump to follow up with.
+Leading HI joker wins the trick outright and forces opponents to play their highest trump while your partner plays their lowest — it strips the opponents' best trump and promotes everything your team holds. Lead it early. Held in hand, its only extra value is the forcing effect; it will win exactly one trick whenever it's played.
 
-### Suit Selection for Leads
+### Suit Selection
 
 Score each suit and lead from the best one:
 
-1. **Lead suits your partner is void in** — Partner can trump in to win the trick for your team. This is one of the strongest plays in the game.
-2. **Avoid leading suits opponents are void in** — This gifts opponents a free trump-in, which is the opposite of what you want.
-3. **Prefer suits where you hold the Ace** — Guaranteed trick winner.
-4. **Prefer shorter suits** — If you're long in a suit, opponents are more likely void (the cards went to you, not them). Leading from short suits also voids you faster, creating future trump-in opportunities.
-5. **Avoid suits where you hold King but the Ace hasn't been played** — The Ace could come from an opponent and beat your King.
-
-### King/Ace Timing
-
-**On large hands (8+ cards)**, almost all cards are dealt, so if you don't have the Ace it's almost certainly in another player's hand. Don't lead or play a King until the Ace of that suit has been played (unless you also hold the Ace):
-- If you lead a King and an opponent has the Ace, you lose the trick and waste your second-best card.
-- Wait for the Ace to appear (either played by an opponent or by your partner), then your King becomes the highest remaining card in that suit.
-- Exception: If you're the last player in a trick and no one has played the Ace, your King wins — play it.
-
-**On small hands (4 or fewer cards)**, this rule relaxes. With only 8-16 cards dealt out of 54, there's a good chance the Ace is still in the deck and was never dealt. Leading a King becomes a reasonable risk, especially when you have few options.
+1. **Lead suits your partner is void in** — they trump in, and only one of your team's trump gets spent.
+2. **Avoid suits opponents are void in** — that's a free ruff for them. (This includes no-trump hands while the live joker is unaccounted for.)
+3. **Prefer suits where you hold the Ace or an established boss card** — cash sure tricks while you have the lead; jokers and boss trump can win from any seat later, but off-suit winners need the lead.
+4. **Prefer shorter suits** — voids you faster and runs into opponents' voids less.
+5. **Don't lead a King while the Ace is unaccounted for** (large hands). On small hands this relaxes — the Ace may simply not have been dealt.
 
 ### Leading Trump
 
-- Generally avoid leading trump (other than HI joker). Leading trump forces your partner to spend their trump too, wasting team resources. You're better off saving trump to play on suited tricks where you're void — that way only your trump card is spent, not your partner's.
-- Only lead trump after trump is broken (unless your hand is all trump).
+Generally avoid leading trump (other than HI joker) — it drains your partner's trump along with the opponents'. Save trump for ruffing. Exception: in sweep mode (bores, must-win-out), lead boss trump from the top to strip the field; a borer who leads *low* trump to "feel things out" is busting their own bore — lead strength or don't bore.
 
-## Card Play: Following
+## Discarding
 
-### When You Can Follow Suit
-
-- **Partner is winning**: Play your lowest card in the suit. Don't waste high cards when your team is already winning.
-- **Opponent is winning**: Play the lowest card that beats the current winner. Don't overspend — a King that barely wins is just as good as an Ace that dominates.
-- **King protection**: If your King is the lowest card that can win, but the Ace of that suit hasn't been played yet and there are players still to act, consider playing a higher card or just playing low and conceding. An opponent behind you might have the Ace.
-- **Can't win**: Play your lowest card in the suit.
-
-### When You're Void (Can't Follow Suit)
-
-- **Partner is winning**: Discard (slough) a low card from your shortest non-trump suit. Don't waste trump.
-- **Opponent is winning and you have trump**: Trump in with your lowest trump that beats the current winner. If an opponent already trumped, you need to over-trump (play a higher trump).
-- **Can't beat the current winner**: Discard strategically — dump cards from your shortest non-trump suit to create new voids for future tricks.
-
-### Play Position Awareness
-
-Your position in the trick matters:
-- **4th player (last)**: You have perfect information about who's winning. Play precisely — win cheaply when you can, don't waste cards when you can't.
-- **2nd player**: Two players still act after you. Be cautious about committing high cards since opponents may still beat you.
-
-## Void and Trump Synergy
-
-Being void in a suit is valuable **in proportion to how many trump cards you hold**:
-- Void + 5 trump = extremely valuable (you can trump in on that suit multiple times)
-- Void + 1 trump = modestly valuable (one trump-in opportunity, but that single trump might be needed elsewhere)
-- Void + 0 trump = the void means nothing (you can't trump in)
-
-When bidding, weight voids more heavily when you have more trump.
-
-## Discarding to Create Voids
-
-When you must discard (can't follow suit, partner winning or can't beat the trick):
-- Discard from your **shortest non-trump suit** to create a void
-- A new void means future opportunities to trump in
-- Prefer discarding low cards that won't win tricks anyway
+When you can't follow and shouldn't trump:
+- Discard from your **shortest non-trump suit** to create voids — but only if you hold trump to exploit them; with no trump, voids are worthless, so just dump your lowest card.
+- **Protect winners, not ranks.** Don't slough a card just because it's "low" if counting says it's boss, and don't cling to a King whose suit-mates make it dead. A Queen with the A-K-J gone is a winner; a King under a live Ace is a hope.
 
 ## Game-Level Score Awareness
 
-Your overall risk tolerance should shift based on the score and how many hands remain:
-
-- **Behind with few hands left**: You need to take bigger risks to catch up. Bid more aggressively, consider bore bids you'd normally pass on, and accept higher variance. Playing safe when you're losing is a slow way to guarantee a loss.
-- **Ahead with few hands left**: Protect your lead. Bid conservatively, avoid bore bids unless they're near-certain, and prioritize not getting set over maximizing points. A safe +20 is better than a risky +40 when you're already winning.
-- **Early in the game**: Score differential matters less — there are many hands left to make up ground. Play fundamentally sound strategy without adjusting for score.
-
-## Trump Conservation
-
-Don't waste high trump on marginal tricks:
-- If your team has already made your bid, the remaining tricks are only worth +1 each. Don't spend your trump Ace to win an overtrick worth 1 point — you might need it later.
-- If a low trump will win the trick, play it instead of a high trump.
-- Save jokers and trump Ace for when they're needed (e.g., to overtrump an opponent's trump, or to guarantee a critical trick).
+Shift risk tolerance with the scoreboard, late in the game only:
+- **Behind by 30+ with few hands left**: bid up the close calls, take the marginal bores. Safe play locks in the loss.
+- **Ahead by 30+ late**: take the discount on close calls; deny variance.
+- **Early game**: play straight — there's time for the math to work.
 
 ## The 4-Card Hand (Rainbow)
 
-The 4-card hand is special because of the rainbow bonus (+10 points). A rainbow hand has one card of each suit. Key considerations:
-- Rainbow hands have exactly one trump card, no voids, and three non-trump cards — generally weak for trick-taking
-- The +10 bonus is awarded even if your team gets set
-- Don't overbid a rainbow hand hoping the bonus saves you — bid based on your trick-winning ability, and treat the +10 as a bonus
+A rainbow (one card of each suit) pays +10 even if you're set, and rainbow hands are structurally weak (exactly one trump, no voids). Bid the hand on its trick-taking merit and treat the bonus as found money — never bid *for* it.
 
-## Summary of Key Principles
+## What 250,000 Games Taught Us (Counterintuitive Findings)
 
-1. **Under-bid rather than over-bid** — the set penalty is devastating
-2. **Card values depend on hand size** — non-trump cards lose value as hands shrink
-3. **Bore on small hands, not large ones** — bore is most profitable at 1-2 cards
-4. **Read the bids** — everyone bidding 0 is your signal to bore
-5. **Don't play Kings until Aces are gone** — patience wins (on large hands)
-6. **Lead into partner's voids, not opponent's** — enable your team to trump in
-7. **Trump + voids = power** — more trump makes each void more valuable
-8. **Save high cards for when they matter** — overtricks are worth 1 point, sets cost 30+
-9. **Adjust risk to the scoreboard** — bid aggressively when behind late in the game, conservatively when ahead
+1. **Stacked conservatism loses.** Pessimistic evaluation + floor rounding is the right amount; every additional "to be safe" adjustment (first-bidder discounts, strong-hand trims) measurably cost win rate. One layer of safety, applied once.
+2. **More aggression also loses.** Adding ~half a trick of bid aggression tripled the set rate and lost games. The make-rate sweet spot is ~90%; both directions away from it are downhill.
+3. **Low trump is never worthless.** Zeroing mid/low trump value was worth several points a hand in underbids. If it can ruff, it counts.
+4. **There is no card conservation without an objective.** Once both contracts are decided, "saving" a card wastes it. Play every remaining trick to win.
+5. **Secure beats cheap when contesting.** Cheapest *boss* winner first; failing that, fight high. Classical lowest-that-beats economy assumes a scoring system this game doesn't have.
+6. **A partner's safe win is sacred; a vulnerable one isn't.** Count, then duck or overtake — don't guess by rank.
+7. **Bores are a small-hand weapon with ~90% success when properly gated** — and the gates are informational (bids actually seen), not just material.
+8. **The flipped card is information.** Promote honors under it; in no-trump, know where the live joker is before calling anything safe.
+
+---
+
+*The bot personalities (Sharon, Danny, Mike, Zach) deliberately deviate from this guide in small, characterful ways — trimmed bids, flashy overspends, the occasional partner overtake. Those are features, not strategy: see `server/game/bot/personalities.js`. Mary plays the guide.*

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "test:client:watch": "vitest --config client/vite.config.js",
         "test:watch": "jest --watch",
         "test:coverage": "jest --coverage",
-        "build:atlas": "node scripts/build-atlas.js"
+        "build:atlas": "node scripts/build-atlas.js",
+        "sim": "node server/game/bot/sim/simulate.js"
     },
     "dependencies": {
         "bcryptjs": "^3.0.2",

--- a/server/game/GameManager.js
+++ b/server/game/GameManager.js
@@ -860,6 +860,10 @@ class GameManager {
 
         this.games.delete(gameId);
 
+        // Release bots and cancel their pending timers — otherwise the bot
+        // registry leaks and stale timers fire into the dead game
+        botController.cleanupGame(gameId);
+
         return socketIds;
     }
 

--- a/server/game/bot/BotController.js
+++ b/server/game/bot/BotController.js
@@ -16,6 +16,28 @@ class BotController {
     }
 
     /**
+     * Contract state passed into card-play decisions: team bids, tricks taken
+     * so far, raw player bids (for bore detection), and multipliers.
+     * @param {Object} game - GameState
+     * @returns {Object}
+     */
+    buildPlayContext(game) {
+        // game.bids is position-keyed during bidding and only takes its
+        // {team1, team2} shape once handlePostBid runs; outside the play
+        // phase pass null so strategy falls back to contract-blind play
+        // rather than misreading the field
+        const bids = game.bids;
+        const teamShaped = bids && typeof bids.team1 === 'number' && typeof bids.team2 === 'number';
+        return {
+            playerBids: game.playerBids,
+            bids: teamShaped ? bids : null,
+            tricks: game.tricks,
+            team1Mult: game.team1Mult,
+            team2Mult: game.team2Mult
+        };
+    }
+
+    /**
      * Create a new bot for a lobby
      * @param {string} username - Bot name (default: "Mary")
      * @returns {BotPlayer}
@@ -126,6 +148,11 @@ class BotController {
 
         const actionKey = `${game.gameId}:${botSocketId}:draw`;
 
+        // Clear any previously scheduled draw for this bot
+        if (this.pendingActions.has(actionKey)) {
+            clearTimeout(this.pendingActions.get(actionKey));
+        }
+
         const timeoutId = setTimeout(() => {
             this.pendingActions.delete(actionKey);
             this.processBotDraw(io, game, bot);
@@ -182,9 +209,17 @@ class BotController {
      * @param {Object} io - Socket.IO server
      * @param {Object} game - GameState
      * @param {BotPlayer} bot - Bot player
+     * @returns {boolean} - true if the bid was made; false if the game state
+     *   no longer allows it (callers must NOT advance the turn on false)
      */
     processBotBid(io, game, bot) {
-        if (!game.bidding || game.currentTurn !== bot.position) return;
+        if (!game.bidding || game.currentTurn !== bot.position) {
+            gameLogger.warn('Bot bid skipped: stale game state', {
+                gameId: game.gameId, botName: bot.username,
+                bidding: game.bidding, currentTurn: game.currentTurn, botPosition: bot.position
+            });
+            return false;
+        }
 
         const hand = game.getHand(bot.socketId);
         const gameContext = {
@@ -212,6 +247,7 @@ class BotController {
         });
 
         // Let the caller handle post-bid logic (turn advancement, etc.)
+        return true;
     }
 
     /**
@@ -219,12 +255,36 @@ class BotController {
      * @param {Object} io - Socket.IO server
      * @param {Object} game - GameState
      * @param {BotPlayer} bot - Bot player
+     * @returns {boolean} - true if a card was played; false if the game state
+     *   no longer allows it (callers must NOT advance the turn on false)
      */
     processBotPlay(io, game, bot) {
-        if (game.bidding || game.currentTurn !== bot.position) return;
+        if (game.bidding || game.currentTurn !== bot.position) {
+            gameLogger.warn('Bot play skipped: stale game state', {
+                gameId: game.gameId, botName: bot.username,
+                bidding: game.bidding, currentTurn: game.currentTurn, botPosition: bot.position
+            });
+            return false;
+        }
+
+        // The game may have moved on while this action sat on a timer (e.g.
+        // forceResign during trick resolution) — never inject a 5th card or
+        // overwrite an occupied slot
+        if (game.playedCardsIndex >= 4 || game.playedCards[bot.position - 1] != null) {
+            gameLogger.warn('Bot play skipped: trick already full or slot occupied', {
+                gameId: game.gameId, botName: bot.username, position: bot.position,
+                playedCardsIndex: game.playedCardsIndex
+            });
+            return false;
+        }
 
         const hand = game.getHand(bot.socketId);
-        if (!hand || hand.length === 0) return;
+        if (!hand || hand.length === 0) {
+            gameLogger.warn('Bot play skipped: empty hand', {
+                gameId: game.gameId, botName: bot.username, position: bot.position
+            });
+            return false;
+        }
 
         const card = bot.decideCard(
             hand,
@@ -233,7 +293,8 @@ class BotController {
             game.leadPosition,
             game.trump,
             game.isTrumpBroken,
-            game.currentHand
+            game.currentHand,
+            this.buildPlayContext(game)
         );
 
         gameLogger.debug('Bot playing card', {
@@ -271,9 +332,10 @@ class BotController {
         });
 
         // Notify all bots about this card play
-        this.notifyCardPlayed(game.gameId, card, bot.position, game.trump);
+        this.notifyCardPlayed(game.gameId, card, bot.position, game.trump, game.leadPosition);
 
         // Let the caller handle post-play logic (turn advancement, trick completion, etc.)
+        return true;
     }
 
     /**
@@ -297,13 +359,14 @@ class BotController {
      * @param {Object} card - Card played
      * @param {number} position - Position of player who played
      * @param {Object} trump - Trump card
+     * @param {number} [leadPosition] - Position that led the current trick
      */
-    notifyCardPlayed(gameId, card, position, trump) {
+    notifyCardPlayed(gameId, card, position, trump, leadPosition) {
         const gameBots = this.gamesBots.get(gameId);
         if (!gameBots) return;
 
         for (const bot of gameBots.values()) {
-            bot.recordCardPlayed(card, position, trump);
+            bot.recordCardPlayed(card, position, trump, leadPosition);
         }
     }
 
@@ -331,7 +394,10 @@ class BotController {
      */
     sendBotChat(io, game, bot, message, delayMs = null) {
         const delay = delayMs !== null ? delayMs : 500 + Math.random() * 500; // default 500-1000ms
-        const actionKey = `${game.gameId}:${bot.socketId}:chat`;
+        // Unique key per message so queued messages don't orphan each other's
+        // timers; cleanupGame clears by gameId prefix either way
+        this.chatSeq = (this.chatSeq || 0) + 1;
+        const actionKey = `${game.gameId}:${bot.socketId}:chat:${this.chatSeq}`;
 
         const timeoutId = setTimeout(() => {
             this.pendingActions.delete(actionKey);
@@ -436,10 +502,11 @@ class BotController {
             if (bot.personality !== 'zach') continue;
 
             const partnerPosition = bot.position === 1 ? 3 : bot.position === 3 ? 1 : bot.position === 2 ? 4 : 2;
-            const partnerBidStr = game.playerBids[partnerPosition - 1];
-            // Treat bore bids as 0 for tracking purposes (bore hands are special)
-            const bidStr = String(partnerBidStr);
-            const partnerBidValue = bidStr.includes('B') ? 0 : parseInt(bidStr, 10) || 0;
+            const partnerBidStr = String(game.playerBids[partnerPosition - 1]);
+            // Skip bore hands entirely: logging a successful bore as "bid 0,
+            // took N" would poison the over/under-bid signal Zach adapts to
+            if (partnerBidStr.includes('B')) continue;
+            const partnerBidValue = parseInt(partnerBidStr, 10) || 0;
             const partnerTricks = game.handTricks[partnerPosition] || 0;
 
             bot.recordPartnerHand(partnerBidValue, partnerTricks);
@@ -453,13 +520,11 @@ class BotController {
     cleanupGame(gameId) {
         const gameBots = this.gamesBots.get(gameId);
         if (gameBots) {
-            for (const [socketId] of gameBots) {
-                // Clear any pending actions
-                for (const [key, timeoutId] of this.pendingActions) {
-                    if (key.startsWith(`${gameId}:`)) {
-                        clearTimeout(timeoutId);
-                        this.pendingActions.delete(key);
-                    }
+            // Clear any pending actions for this game
+            for (const [key, timeoutId] of this.pendingActions) {
+                if (key.startsWith(`${gameId}:`)) {
+                    clearTimeout(timeoutId);
+                    this.pendingActions.delete(key);
                 }
             }
             this.gamesBots.delete(gameId);

--- a/server/game/bot/BotPlayer.js
+++ b/server/game/bot/BotPlayer.js
@@ -72,15 +72,19 @@ class BotPlayer {
      * @param {Object} card - { suit, rank }
      * @param {number} position - Position of player who played it (1-4)
      * @param {Object} trump - Trump card for determining trump status
+     * @param {number} [leadPosition] - Position that led the current trick.
+     *   Recording this explicitly (rather than assuming the first recorded
+     *   card led) keeps void inference correct for bots that join mid-trick.
      */
-    recordCardPlayed(card, position, trump) {
+    recordCardPlayed(card, position, trump, leadPosition) {
         if (!this.cardMemory) return;
 
         this.cardMemory.playedCards.push({
             suit: card.suit,
             rank: card.rank,
             position,
-            trickIndex: this.cardMemory.trickIndex
+            trickIndex: this.cardMemory.trickIndex,
+            isLead: leadPosition !== undefined ? position === leadPosition : undefined
         });
 
         // Track aces
@@ -158,9 +162,12 @@ class BotPlayer {
      * @param {number|null} leadPosition - Position that led
      * @param {Object} trump - Trump card
      * @param {boolean} trumpBroken - Whether trump has been broken
+     * @param {number} handSize - Cards dealt per player this hand
+     * @param {Object|null} playContext - Contract state (team bids/tricks/bores);
+     *   see BotController.buildPlayContext. Null falls back to contract-blind play.
      * @returns {Object} - Card to play
      */
-    decideCard(hand, playedCards, leadCard, leadPosition, trump, trumpBroken, handSize) {
+    decideCard(hand, playedCards, leadCard, leadPosition, trump, trumpBroken, handSize, playContext = null) {
         return selectOptimalCard(
             hand,
             playedCards,
@@ -170,7 +177,9 @@ class BotPlayer {
             trumpBroken,
             this.position,
             this.getMemorySnapshot(),
-            handSize
+            handSize,
+            playContext,
+            this.personality
         );
     }
 

--- a/server/game/bot/__tests__/BotIntegrity.test.js
+++ b/server/game/bot/__tests__/BotIntegrity.test.js
@@ -1,0 +1,401 @@
+/**
+ * Bot integrity tests:
+ *  1. Legality invariant — across randomized full hands (all sizes, all trump
+ *     types including no-trump, all personalities, live bores), every card a
+ *     bot selects must be in its hand and legal per rules.isLegalMove.
+ *  2. Contract-aware behavior — bots must execute bores (lead strength, not
+ *     junk), defend against opponent bores, and read the contract state.
+ */
+
+const rules = require('../../rules');
+const BotPlayer = require('../BotPlayer');
+const {
+    selectLead,
+    selectFollow,
+    getContractState,
+    countHigherUnseen
+} = require('../BotStrategy');
+
+const card = (suit, rank) => ({ suit, rank });
+const HI = card('joker', 'HI');
+const LO = card('joker', 'LO');
+
+// Deterministic RNG so failures are reproducible
+function mulberry32(seed) {
+    let a = seed >>> 0;
+    return function () {
+        a |= 0; a = (a + 0x6D2B79F5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+const SUITS = ['spades', 'hearts', 'diamonds', 'clubs'];
+const RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A'];
+
+function freshDeck(rng) {
+    const cards = [];
+    for (const suit of SUITS) for (const rank of RANKS) cards.push({ suit, rank });
+    cards.push({ ...HI });
+    cards.push({ ...LO });
+    for (let i = cards.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1));
+        [cards[i], cards[j]] = [cards[j], cards[i]];
+    }
+    return cards;
+}
+
+const isBore = (b) => ['B', '2B', '3B', '4B'].includes(b);
+
+/**
+ * Play one full randomized hand with 4 bots, asserting every selection is
+ * legal. Returns per-team trick counts.
+ * @param {boolean} forceBore - Overwrite seat 1's bid with 'B' so multi-trick
+ *   bore execution paths are exercised deterministically (bots rarely bore
+ *   organically on larger random hands)
+ */
+function playLegalHand(rng, handSize, personalities, forceNoTrump, forceBore = false) {
+    const deck = freshDeck(rng);
+    let trump;
+    if (forceNoTrump) {
+        const jokerIdx = deck.findIndex(c => c.suit === 'joker');
+        trump = deck.splice(jokerIdx, 1)[0];
+    } else {
+        trump = deck[4 * handSize];
+    }
+
+    const bots = {};
+    const hands = {};
+    for (let p = 1; p <= 4; p++) {
+        bots[p] = new BotPlayer(`🤖 Test${p}`, personalities[p - 1]);
+        bots[p].assignToGame('test-game', p, p);
+        bots[p].resetCardMemory(handSize, trump);
+        hands[p] = deck.slice((p - 1) * handSize, p * handSize);
+    }
+
+    // Bidding
+    const playerBids = [undefined, undefined, undefined, undefined];
+    const firstBidder = 1 + Math.floor(rng() * 4);
+    for (let i = 0; i < 4; i++) {
+        const pos = ((firstBidder - 1 + i) % 4) + 1;
+        const bid = bots[pos].decideBid(hands[pos].slice(), trump, playerBids, handSize,
+            { teamScore: 0, oppScore: 0, currentHandSize: handSize });
+        expect(typeof bid).toBe('string');
+        if (!isBore(bid)) {
+            const n = parseInt(bid, 10);
+            expect(Number.isNaN(n)).toBe(false);
+            expect(n).toBeGreaterThanOrEqual(0);
+            expect(n).toBeLessThanOrEqual(handSize);
+        }
+        playerBids[pos - 1] = bid;
+    }
+
+    if (forceBore) {
+        playerBids[0] = 'B';
+    }
+
+    const teamBid = {
+        team1: Math.min(handSize, (rules.BID_RANKS[playerBids[0]] || 0) + (rules.BID_RANKS[playerBids[2]] || 0)),
+        team2: Math.min(handSize, (rules.BID_RANKS[playerBids[1]] || 0) + (rules.BID_RANKS[playerBids[3]] || 0))
+    };
+
+    // Play
+    let lead = rules.findHighestBidder(firstBidder, playerBids) + 1;
+    let trumpBroken = false;
+    const teamTricks = { team1: 0, team2: 0 };
+
+    for (let t = 0; t < handSize; t++) {
+        const playedCards = [undefined, undefined, undefined, undefined];
+        let leadCard = null;
+        const leadPosition = lead;
+        for (let i = 0; i < 4; i++) {
+            const pos = ((lead - 1 + i) % 4) + 1;
+            const isLeading = i === 0;
+            const hand = hands[pos];
+            const playContext = {
+                playerBids,
+                bids: teamBid,
+                tricks: { ...teamTricks },
+                team1Mult: rules.calculateMultiplier(playerBids[0], playerBids[2]),
+                team2Mult: rules.calculateMultiplier(playerBids[1], playerBids[3])
+            };
+
+            const chosen = bots[pos].decideCard(hand.slice(), playedCards,
+                isLeading ? null : leadCard, isLeading ? null : leadPosition,
+                trump, trumpBroken, handSize, playContext);
+
+            // THE invariant: the chosen card is in hand and legal
+            const inHand = hand.find(c => c.suit === chosen.suit && c.rank === chosen.rank);
+            expect(inHand).toBeDefined();
+            const remaining = hand.filter(c => c !== inHand);
+            const legal = rules.isLegalMove(inHand, remaining, leadCard || inHand, isLeading,
+                trump, trumpBroken, pos, isLeading ? pos : leadPosition);
+            if (!legal) {
+                throw new Error(`Illegal card ${chosen.rank} of ${chosen.suit} ` +
+                    `(hand: ${hand.map(c => `${c.rank}${c.suit[0]}`).join(' ')}, ` +
+                    `trump: ${trump.rank} of ${trump.suit}, lead: ${leadCard ? `${leadCard.rank} of ${leadCard.suit}` : 'none'}, ` +
+                    `trumpBroken: ${trumpBroken})`);
+            }
+
+            hands[pos] = remaining;
+            playedCards[pos - 1] = inHand;
+            if (isLeading) leadCard = inHand;
+            if (inHand.suit === trump.suit || inHand.suit === 'joker') trumpBroken = true;
+            for (let q = 1; q <= 4; q++) bots[q].recordCardPlayed(inHand, pos, trump, leadPosition);
+        }
+        const winner = rules.determineWinner(playedCards, leadPosition, trump);
+        expect(winner).toBeGreaterThanOrEqual(1);
+        expect(winner).toBeLessThanOrEqual(4);
+        teamTricks[winner === 1 || winner === 3 ? 'team1' : 'team2']++;
+        for (let q = 1; q <= 4; q++) bots[q].advanceTrick();
+        lead = winner;
+    }
+
+    // Every card must have been played — a falsifiable end-state check
+    for (let p = 1; p <= 4; p++) expect(hands[p]).toHaveLength(0);
+
+    return teamTricks;
+}
+
+describe('legality invariant (fuzz)', () => {
+    const realRandom = Math.random;
+    let rng;
+
+    beforeAll(() => {
+        rng = mulberry32(20260611);
+        Math.random = () => rng(); // Mike's modifier and erratic play use Math.random
+    });
+
+    afterAll(() => {
+        Math.random = realRandom;
+    });
+
+    const HAND_SIZES = [12, 10, 8, 6, 4, 2, 1, 3, 5, 7, 9, 11, 13];
+    const PERSONALITY_SETS = [
+        ['mary', 'mary', 'mary', 'mary'],
+        ['sharon', 'danny', 'mike', 'zach']
+    ];
+
+    test.each(HAND_SIZES)('%i-card hands: every bot selection is legal', (handSize) => {
+        for (const personalities of PERSONALITY_SETS) {
+            for (let iter = 0; iter < 4; iter++) {
+                const tricks = playLegalHand(rng, handSize, personalities, false);
+                expect(tricks.team1 + tricks.team2).toBe(handSize);
+            }
+        }
+    });
+
+    test('no-trump hands: every bot selection is legal', () => {
+        for (const handSize of HAND_SIZES) {
+            for (const personalities of PERSONALITY_SETS) {
+                const tricks = playLegalHand(rng, handSize, personalities, true);
+                expect(tricks.team1 + tricks.team2).toBe(handSize);
+            }
+        }
+    });
+
+    test('live bores (forced): every bot selection is legal at max effort', () => {
+        for (const handSize of HAND_SIZES) {
+            for (const personalities of PERSONALITY_SETS) {
+                const tricks = playLegalHand(rng, handSize, personalities, false, true);
+                expect(tricks.team1 + tricks.team2).toBe(handSize);
+            }
+        }
+    });
+});
+
+describe('contract awareness', () => {
+    const heartsTrump = card('hearts', '5');
+    const freshMemory = () => ({
+        playedCards: [],
+        trumpPlayed: [],
+        acesPlayed: { spades: false, hearts: false, diamonds: false, clubs: false },
+        trickIndex: 0,
+        totalCardsPlayed: 0
+    });
+
+    test('getContractState: live bore demands max effort', () => {
+        const ctx = {
+            playerBids: ['B', '0', '0', '0'],
+            bids: { team1: 3, team2: 0 },
+            tricks: { team1: 0, team2: 0 },
+            team1Mult: 2, team2Mult: 1
+        };
+        const contract = getContractState(ctx, 1, 3);
+        expect(contract.teamBored).toBe(true);
+        expect(contract.effort).toBe('max');
+    });
+
+    test('getContractState: opponent bore is max effort until a trick is taken', () => {
+        const ctx = {
+            playerBids: ['0', 'B', '0', '0'],
+            bids: { team1: 0, team2: 5 },
+            tricks: { team1: 0, team2: 0 },
+            team1Mult: 1, team2Mult: 2
+        };
+        expect(getContractState(ctx, 1, 5).effort).toBe('max');
+
+        // After our team takes one trick, their bore is dead
+        const after = {
+            ...ctx,
+            tricks: { team1: 1, team2: 1 }
+        };
+        expect(getContractState(after, 1, 5).effort).toBe('cheap');
+    });
+
+    test('getContractState: both bids made leaves only overtricks (cheap)', () => {
+        const ctx = {
+            playerBids: ['2', '1', '0', '0'],
+            bids: { team1: 2, team2: 1 },
+            tricks: { team1: 2, team2: 1 },
+            team1Mult: 1, team2Mult: 1
+        };
+        expect(getContractState(ctx, 1, 6).effort).toBe('cheap');
+    });
+
+    test('boring bot leads its strongest trump, not its lowest', () => {
+        // Regression: the borer used to lead LOW from a trump-tight hand,
+        // handing the first trick away and busting its own bore
+        const hand = [card('hearts', '3'), card('hearts', '9'), card('hearts', 'K')];
+        const ctx = {
+            playerBids: ['B', '0', '0', '0'],
+            bids: { team1: 3, team2: 0 },
+            tricks: { team1: 0, team2: 0 },
+            team1Mult: 2, team2Mult: 1
+        };
+        const contract = getContractState(ctx, 1, 3);
+        const result = selectLead(hand, heartsTrump, false, { position: 1 }, freshMemory(), 3, contract);
+        expect(result.rank).toBe('K');
+    });
+
+    test('at max effort a void bot trumps to secure partner\'s vulnerable win', () => {
+        // Partner (pos 3) winning with the spade King, the Ace is unseen and
+        // an opponent still acts. Contract-blind play discards; a live bore
+        // must secure the trick with trump.
+        const hand = [card('hearts', '9'), card('clubs', '2')];
+        const playedCards = [undefined, card('spades', '5'), card('spades', 'K'), undefined];
+        const leadCard = card('spades', '5');
+
+        const blind = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 1, freshMemory(), 4, null);
+        expect(blind.suit).toBe('clubs'); // discards, saves trump
+
+        const ctx = {
+            playerBids: ['B', '0', '0', '0'],
+            bids: { team1: 4, team2: 0 },
+            tricks: { team1: 0, team2: 0 },
+            team1Mult: 2, team2Mult: 1
+        };
+        const contract = getContractState(ctx, 1, 4);
+        const secured = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 1, freshMemory(), 4, contract);
+        expect(secured.suit).toBe('hearts'); // trumps in to guarantee the sweep
+    });
+
+    test('countHigherUnseen excludes the flipped card, own hand, and played cards', () => {
+        const memory = freshMemory();
+        // Trump is hearts 5 (flipped). Holding hearts K; hearts A was played.
+        memory.playedCards.push({ suit: 'hearts', rank: 'A', position: 2, trickIndex: 0, isLead: true });
+        const hand = [card('hearts', 'K'), card('hearts', 'Q')];
+        // Higher than K among trump: A (played), LO, HI (both unseen) => 2
+        expect(countHigherUnseen(card('hearts', 'K'), hand, memory, heartsTrump)).toBe(2);
+        // Higher than Q: K is in our own hand, A played => still just the jokers
+        expect(countHigherUnseen(card('hearts', 'Q'), hand, memory, heartsTrump)).toBe(2);
+    });
+
+    test('countHigherUnseen treats the flipped trump card itself as out of play', () => {
+        // Trump Ace flipped: only the jokers outrank the King. Without the
+        // flipped-card exclusion this would count the Ace too and read 3.
+        const flippedAce = card('hearts', 'A');
+        expect(countHigherUnseen(card('hearts', 'K'), [card('hearts', 'K')], freshMemory(), flippedAce)).toBe(2);
+    });
+});
+
+describe('personality play styles', () => {
+    const heartsTrump = card('hearts', '5');
+    const freshMemory = () => ({
+        playedCards: [],
+        trumpPlayed: [],
+        acesPlayed: { spades: false, hearts: false, diamonds: false, clubs: false },
+        trickIndex: 0,
+        totalCardsPlayed: 0
+    });
+
+    // Opponent (pos 2) led and is winning with the spade Queen; we (pos 1)
+    // hold K and 3 of spades; partner (pos 3) and opponent (pos 4) still act.
+    // The King beats the Queen but is not boss (Ace unseen).
+    const contestedTrick = () => ({
+        hand: [card('spades', 'K'), card('spades', '3')],
+        playedCards: [undefined, card('spades', 'Q'), undefined, undefined],
+        leadCard: card('spades', 'Q')
+    });
+
+    test('hoarding (Sharon) ducks a contested trick with no boss winner', () => {
+        const { hand, playedCards, leadCard } = contestedTrick();
+        const result = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 1, freshMemory(), 8, null, 'hoarding');
+        expect(result.rank).toBe('3');
+    });
+
+    test('hoarding (Sharon) still takes the trick with a boss winner', () => {
+        const { playedCards, leadCard } = contestedTrick();
+        const hand = [card('spades', 'A'), card('spades', '3')]; // Ace is boss
+        const result = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 1, freshMemory(), 8, null, 'hoarding');
+        expect(result.rank).toBe('A');
+    });
+
+    test('balanced (Mary) fights the same contested trick', () => {
+        const { hand, playedCards, leadCard } = contestedTrick();
+        const result = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 1, freshMemory(), 8, null, 'balanced');
+        expect(result.rank).toBe('K');
+    });
+
+    test('flashy (Danny) spends the Ace where balanced wins cheaply with the boss King', () => {
+        const { playedCards, leadCard } = contestedTrick();
+        // Holding A-K over the Queen: our own Ace makes the King boss, so
+        // balanced wins as cheaply as possible while flashy slams the Ace
+        const hand = [card('spades', 'A'), card('spades', 'K')];
+
+        const balanced = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 1, freshMemory(), 8, null, 'balanced');
+        expect(balanced.rank).toBe('K');
+
+        const flashy = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 1, freshMemory(), 8, null, 'flashy');
+        expect(flashy.rank).toBe('A');
+    });
+
+    test('erratic (Mike) overtakes a safely winning partner when the dice say so', () => {
+        // Partner (pos 3) winning with the spade Queen — safe only because we
+        // hold the A and K ourselves. Mary plays the 3; Mike sometimes can't help himself.
+        const hand = [card('spades', 'A'), card('spades', 'K'), card('spades', '3')];
+        const playedCards = [undefined, card('spades', '5'), card('spades', 'Q'), undefined];
+        const leadCard = card('spades', '5');
+
+        const realRandom = Math.random;
+        try {
+            Math.random = () => 0.05; // below the 0.12 erratic threshold
+            const overtaken = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 1, freshMemory(), 8, null, 'erratic');
+            expect(overtaken.rank).toBe('K');
+
+            Math.random = () => 0.5; // above the threshold — plays low like Mary
+            const normal = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 1, freshMemory(), 8, null, 'erratic');
+            expect(normal.rank).toBe('3');
+        } finally {
+            Math.random = realRandom;
+        }
+    });
+});
+
+describe('overconfident bid modifier (deterministic)', () => {
+    const { applyBidModifier } = require('../BotStrategy');
+    const makeEval = (points) => ({ points, trumpCount: 0, voids: 0, suitCounts: {}, hasHighJoker: false, hasLowJoker: false, hasTrumpAce: false });
+
+    test('mike overbids exactly when the roll is under 0.10', () => {
+        const realRandom = Math.random;
+        try {
+            Math.random = () => 0.05;
+            expect(applyBidModifier(3, 'mike', makeEval(3.0), 12, [])).toBe(4);
+            Math.random = () => 0.15;
+            expect(applyBidModifier(3, 'mike', makeEval(3.0), 12, [])).toBe(3);
+        } finally {
+            Math.random = realRandom;
+        }
+    });
+});

--- a/server/game/bot/__tests__/BotStrategy.test.js
+++ b/server/game/bot/__tests__/BotStrategy.test.js
@@ -45,13 +45,10 @@ describe('evaluateHand', () => {
                 card('hearts', '2'), card('diamonds', '2'), card('clubs', '2')
             ];
             const result = evaluateHand(hand, heartsTrump, 13);
-            // Ace: 0.8 * 1.0 = 0.8, hearts 2 = trump (no value), diamonds 2 = 0, clubs 2 = 0
-            // trumpCount = 1, single trump devaluation doesn't apply (handSize < 8 for this check... wait handSize=13)
-            // Actually single trump devaluation: trumpCount=1, handSize=13>=8, card is hearts 2 (not HI/LO)
-            // hearts 2 rank value = 2 < 7, so no points were added, devaluation doesn't subtract anything extra
-            // voids = 0 (all suits present)
+            // Ace: 0.8 * 1.0 = 0.8, hearts 2 = low trump (0.05 at hand size 8+),
+            // diamonds 2 = 0, clubs 2 = 0, voids = 0 (all suits present),
             // trump length bonus: trumpCount=1, < 4, so 0
-            expect(result.points).toBeCloseTo(0.8, 1);
+            expect(result.points).toBeCloseTo(0.85, 1);
         });
 
         test('non-trump Ace worth ~0.08 at hand size 2', () => {
@@ -418,14 +415,15 @@ describe('selectLead', () => {
 
 describe('selectFollow', () => {
     describe('King protection', () => {
-        test('avoids King as lowest winner when Ace unplayed on large hand', () => {
+        test('fights with King when it is the only winner, even with the Ace outstanding', () => {
             const hand = [
-                card('spades', 'K'), card('spades', 'A'), // Has both King and Ace
+                card('spades', 'K'), card('spades', '10'),
                 card('diamonds', '2'), card('diamonds', '3'),
                 card('clubs', '2'), card('clubs', '3'),
                 card('hearts', '2'), card('hearts', '3')
             ];
-            // Lead is spades, current winner is Q of spades from opponent
+            // Lead is spades, current winner is Q of spades from opponent;
+            // an opponent still acts after us and the Ace is unseen
             const playedCards = [undefined, card('spades', 'Q'), undefined, undefined];
             const leadCard = card('spades', 'Q');
             const memory = {
@@ -436,21 +434,31 @@ describe('selectFollow', () => {
                 totalCardsPlayed: 1
             };
 
-            // Position 1, lead position 2, Ace unplayed, but we HAVE both K and A
-            // King is lowest winner, A hasn't been played but we have it
-            // This should actually still play King (we own the Ace)
-            // Let's test a case where we DON'T have the Ace
-            const hand2 = [
-                card('spades', 'K'), card('spades', '10'),
+            const result = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 3, memory, 8);
+            // King is the only card that beats the Queen — contest the trick
+            expect(result.rank).toBe('K');
+        });
+
+        test('cashes both honors cheapest-first when holding A-K over the trick', () => {
+            const hand = [
+                card('spades', 'K'), card('spades', 'A'),
                 card('diamonds', '2'), card('diamonds', '3'),
                 card('clubs', '2'), card('clubs', '3'),
                 card('hearts', '2'), card('hearts', '3')
             ];
-            // King is lowest winner, Ace not played, players still to act
-            const result = selectFollow(hand2, playedCards, leadCard, 2, heartsTrump, false, 3, memory, 8);
-            // Should avoid playing King (play 10 instead since it can't win, or skip to lower)
-            // Actually, if Q is current winner, K beats Q, 10 doesn't beat Q
-            // So King is the ONLY winner - should still play it
+            const playedCards = [undefined, card('spades', 'Q'), undefined, undefined];
+            const leadCard = card('spades', 'Q');
+            const memory = {
+                playedCards: [],
+                trumpPlayed: [],
+                acesPlayed: { spades: false, hearts: false, diamonds: false, clubs: false },
+                trickIndex: 0,
+                totalCardsPlayed: 1
+            };
+
+            const result = selectFollow(hand, playedCards, leadCard, 2, heartsTrump, false, 3, memory, 8);
+            // Holding the Ace ourselves makes the King boss — win cheap, keep the Ace
+            expect(result.rank).toBe('K');
         });
 
         test('plays King when last to act', () => {
@@ -573,7 +581,7 @@ describe('selectFollow', () => {
             expect(result.rank).toBe('3');
         });
 
-        test('overtakes partner when opponent known void (trump-in risk)', () => {
+        test('plays low under partner when nothing in hand can overtake (despite trump-in risk)', () => {
             const hand = [
                 card('spades', 'K'), card('spades', '3')
             ];
@@ -868,32 +876,46 @@ describe('isWinVulnerable', () => {
 describe('bestWithoutHiJoker', () => {
     test('returns non-joker when HI joker is best and alternatives exist', () => {
         const sorted = [HI, card('hearts', 'K'), card('hearts', '5')];
-        const result = bestWithoutHiJoker(sorted, card('hearts', '3'));
+        const result = bestWithoutHiJoker(sorted, card('hearts', '3'), heartsTrump);
         expect(result.rank).toBe('K');
     });
 
     test('returns HI joker when it is the only option', () => {
         const sorted = [HI];
-        const result = bestWithoutHiJoker(sorted, card('hearts', '3'));
+        const result = bestWithoutHiJoker(sorted, card('hearts', '3'), heartsTrump);
         expect(result.rank).toBe('HI');
     });
 
     test('returns HI joker to beat LO joker', () => {
         const sorted = [HI, card('hearts', 'K')];
-        const result = bestWithoutHiJoker(sorted, LO);
+        const result = bestWithoutHiJoker(sorted, LO, heartsTrump);
         expect(result.rank).toBe('HI');
     });
 
     test('returns HI joker to beat trump Ace', () => {
         const sorted = [HI, card('hearts', 'K')];
-        const result = bestWithoutHiJoker(sorted, card('hearts', 'A'));
+        const result = bestWithoutHiJoker(sorted, card('hearts', 'A'), heartsTrump);
         expect(result.rank).toBe('HI');
+    });
+
+    test('holds HI joker when LO joker also beats the trump Ace', () => {
+        const sorted = [HI, LO];
+        const result = bestWithoutHiJoker(sorted, card('hearts', 'A'), heartsTrump);
+        expect(result.rank).toBe('LO');
     });
 
     test('returns non-joker when winning card is low trump', () => {
         const sorted = [HI, card('hearts', 'K')];
-        const result = bestWithoutHiJoker(sorted, card('hearts', '7'));
+        const result = bestWithoutHiJoker(sorted, card('hearts', '7'), heartsTrump);
         expect(result.rank).toBe('K');
+    });
+
+    test('holds HI joker against a NON-trump Ace — any trump in the list beats it', () => {
+        // Regression: the old code matched any non-joker Ace, burning HI to
+        // trump an opponent's side-suit Ace when low trump won identically
+        const sorted = [HI, card('hearts', '2')];
+        const result = bestWithoutHiJoker(sorted, card('spades', 'A'), heartsTrump);
+        expect(result.rank).toBe('2');
     });
 });
 
@@ -996,50 +1018,41 @@ describe('applyBidModifier', () => {
     });
 
     describe('sharon (conservative)', () => {
-        test('underbids strong hand by 1 (points >= handSize * 0.5)', () => {
-            // handSize=12, 0.5*12=6, points=6.5 >= 6
+        test('trims big bids by 1', () => {
+            expect(applyBidModifier(3, 'sharon', makeEval(3.5), 12, [])).toBe(2);
             expect(applyBidModifier(6, 'sharon', makeEval(6.5), 12, [])).toBe(5);
         });
 
-        test('underbids very strong hand by 2 (points >= handSize * 0.7)', () => {
-            // handSize=12, 0.7*12=8.4, points=9.0 >= 8.4
-            expect(applyBidModifier(8, 'sharon', makeEval(9.0), 12, [])).toBe(6);
-        });
-
-        test('does not modify weak hand bid', () => {
-            // handSize=12, 0.5*12=6, points=2.0 < 6
+        test('does not modify small bids', () => {
+            expect(applyBidModifier(0, 'sharon', makeEval(0.5), 12, [])).toBe(0);
+            expect(applyBidModifier(1, 'sharon', makeEval(1.5), 12, [])).toBe(1);
             expect(applyBidModifier(2, 'sharon', makeEval(2.0), 12, [])).toBe(2);
-        });
-
-        test('does not go below 0', () => {
-            // handSize=4, 0.5*4=2, points=2.5 >= 2, bid 1 - 1 = 0
-            expect(applyBidModifier(1, 'sharon', makeEval(2.5), 4, [])).toBe(0);
         });
     });
 
     describe('danny (calculated aggressive)', () => {
-        test('rounds up when points close to next integer (0.25+ over)', () => {
-            // baseBid=2 (from floor(2.7)), points=2.7, diff=0.7 >= 0.25
-            expect(applyBidModifier(2, 'danny', makeEval(2.7), 12, [])).toBe(3);
+        test('rounds up when points just missed the next trick (0.85+ over)', () => {
+            // baseBid=2 (from floor(2.9)), points=2.9, diff=0.9 >= 0.85
+            expect(applyBidModifier(2, 'danny', makeEval(2.9), 12, [])).toBe(3);
         });
 
-        test('does not round up when well below next integer', () => {
-            // baseBid=2, points=2.1, diff=0.1 < 0.25
-            expect(applyBidModifier(2, 'danny', makeEval(2.1), 12, [])).toBe(2);
+        test('does not round up when below the threshold', () => {
+            // baseBid=2, points=2.7, diff=0.7 < 0.85
+            expect(applyBidModifier(2, 'danny', makeEval(2.7), 12, [])).toBe(2);
         });
 
         test('does not exceed hand size', () => {
-            expect(applyBidModifier(4, 'danny', makeEval(4.5), 4, [])).toBe(4);
+            expect(applyBidModifier(4, 'danny', makeEval(4.9), 4, [])).toBe(4);
         });
 
         test('does not bump 0 to 1 on small hands (<=4 cards)', () => {
-            expect(applyBidModifier(0, 'danny', makeEval(0.5), 1, [])).toBe(0);
-            expect(applyBidModifier(0, 'danny', makeEval(0.5), 2, [])).toBe(0);
-            expect(applyBidModifier(0, 'danny', makeEval(0.5), 4, [])).toBe(0);
+            expect(applyBidModifier(0, 'danny', makeEval(0.9), 1, [])).toBe(0);
+            expect(applyBidModifier(0, 'danny', makeEval(0.9), 2, [])).toBe(0);
+            expect(applyBidModifier(0, 'danny', makeEval(0.9), 4, [])).toBe(0);
         });
 
         test('still bumps 0 to 1 on large hands when close', () => {
-            expect(applyBidModifier(0, 'danny', makeEval(0.5), 8, [])).toBe(1);
+            expect(applyBidModifier(0, 'danny', makeEval(0.9), 8, [])).toBe(1);
         });
     });
 
@@ -1067,42 +1080,55 @@ describe('applyBidModifier', () => {
     });
 
     describe('zach (adaptive)', () => {
-        test('does not modify bid with insufficient history (< 2 hands)', () => {
-            const history = [{ bid: 3, tricks: 5 }]; // only 1 hand
+        test('does not modify bid with insufficient history (< 3 hands)', () => {
+            const history = [{ bid: 3, tricks: 5 }, { bid: 3, tricks: 5 }]; // only 2 hands
             expect(applyBidModifier(3, 'zach', makeEval(3.5), 12, history)).toBe(3);
         });
 
         test('bids down when partner is aggressive (overbids)', () => {
-            // Partner bids more than they win: avg error = (2-3 + 1-3) / 2 = -1.5
+            // Partner bids more than they win: avg error = (2-3 + 1-3 + 2-3) / 3 = -1.33
             const history = [
                 { bid: 3, tricks: 2 },
-                { bid: 3, tricks: 1 }
+                { bid: 3, tricks: 1 },
+                { bid: 3, tricks: 2 }
             ];
             expect(applyBidModifier(3, 'zach', makeEval(3.5), 12, history)).toBe(2);
         });
 
-        test('cautiously bids up when partner is conservative and hand supports it', () => {
-            // Partner wins more than they bid: avg error = (5-2 + 4-2) / 2 = 2.5
+        test('cautiously bids up when partner sandbags heavily and hand supports it', () => {
+            // Partner wins far more than they bid: avg error = (5-2 + 4-2 + 4-2) / 3 = 2.33 > 1.5
             const history = [
                 { bid: 2, tricks: 5 },
+                { bid: 2, tricks: 4 },
                 { bid: 2, tricks: 4 }
             ];
-            // evaluation.points - baseBid = 3.5 - 3 = 0.5 >= 0.3 -> bid up
+            // evaluation.points - baseBid = 3.5 - 3 = 0.5 >= 0.5 -> bid up
             expect(applyBidModifier(3, 'zach', makeEval(3.5), 12, history)).toBe(4);
         });
 
+        test('ignores normal conservative surplus (calibrated partners run +0.5-1)', () => {
+            // avg error = +1.0 — within the deadband, not sandbagging
+            const history = [
+                { bid: 2, tricks: 3 },
+                { bid: 2, tricks: 3 },
+                { bid: 2, tricks: 3 }
+            ];
+            expect(applyBidModifier(3, 'zach', makeEval(3.9), 12, history)).toBe(3);
+        });
+
         test('does not bid up when hand does not support it', () => {
-            // Partner is conservative but hand evaluation barely supports current bid
             const history = [
                 { bid: 2, tricks: 5 },
+                { bid: 2, tricks: 4 },
                 { bid: 2, tricks: 4 }
             ];
-            // evaluation.points - baseBid = 3.1 - 3 = 0.1 < 0.3 -> stay
+            // evaluation.points - baseBid = 3.1 - 3 = 0.1 < 0.5 -> stay
             expect(applyBidModifier(3, 'zach', makeEval(3.1), 12, history)).toBe(3);
         });
 
         test('does not go below 0', () => {
             const history = [
+                { bid: 3, tricks: 0 },
                 { bid: 3, tricks: 0 },
                 { bid: 3, tricks: 0 }
             ];

--- a/server/game/bot/personalities.js
+++ b/server/game/bot/personalities.js
@@ -1,14 +1,31 @@
 /**
  * Bot personality definitions.
  * Each personality modifies Mary's base strategy with behavioral variations.
+ *
+ * This registry is the single source of truth: BotStrategy switches on
+ * `bidStyle` (applyBidModifier) and `playStyle` (selectFollow), so adding a
+ * personality here is what wires it into the strategy.
+ *
+ * bidStyle:
+ *  - neutral:               no adjustment (Mary's calibrated bid)
+ *  - conservative:          trims big bids by one — banks safety, forfeits upside
+ *  - calculated-aggressive: rounds up bids that just miss the next trick
+ *  - overconfident:         occasionally bids one more than the hand supports
+ *  - adaptive:              compensates for the partner's observed bid error
+ *
+ * playStyle:
+ *  - balanced: Mary's card play
+ *  - hoarding: ducks contested tricks instead of spending honors to fight
+ *  - flashy:   spends the big card when a cheaper winner would hold the trick
+ *  - erratic:  sometimes overtakes a partner who is already safely winning
  */
 
 const PERSONALITIES = {
-    mary:   { displayName: 'Mary',   bidStyle: 'neutral' },
-    sharon: { displayName: 'Sharon', bidStyle: 'conservative' },
-    danny:  { displayName: 'Danny',  bidStyle: 'calculated-aggressive' },
-    mike:   { displayName: 'Mike',   bidStyle: 'overconfident' },
-    zach:   { displayName: 'Zach',   bidStyle: 'adaptive' }
+    mary:   { displayName: 'Mary',   bidStyle: 'neutral',               playStyle: 'balanced' },
+    sharon: { displayName: 'Sharon', bidStyle: 'conservative',          playStyle: 'hoarding' },
+    danny:  { displayName: 'Danny',  bidStyle: 'calculated-aggressive', playStyle: 'flashy' },
+    mike:   { displayName: 'Mike',   bidStyle: 'overconfident',         playStyle: 'erratic' },
+    zach:   { displayName: 'Zach',   bidStyle: 'adaptive',              playStyle: 'balanced' }
 };
 
 const PERSONALITY_LIST = Object.keys(PERSONALITIES);
@@ -22,8 +39,24 @@ function getDisplayName(personality) {
     return PERSONALITIES[personality]?.displayName || 'Mary';
 }
 
+/**
+ * Get bid style for a personality key (default: neutral)
+ */
+function getBidStyle(personality) {
+    return PERSONALITIES[personality]?.bidStyle || 'neutral';
+}
+
+/**
+ * Get play style for a personality key (default: balanced)
+ */
+function getPlayStyle(personality) {
+    return PERSONALITIES[personality]?.playStyle || 'balanced';
+}
+
 module.exports = {
     PERSONALITIES,
     PERSONALITY_LIST,
-    getDisplayName
+    getDisplayName,
+    getBidStyle,
+    getPlayStyle
 };

--- a/server/game/bot/sim/README.md
+++ b/server/game/bot/sim/README.md
@@ -1,0 +1,61 @@
+# Bot Simulation Harness
+
+Plays full 13-hand bot-vs-bot games using the **real** `BotPlayer`/`BotStrategy`
+and `rules.js`, with an orchestration loop that mirrors
+`server/socket/gameHandlers.js` (team bids, bores, multipliers, redeals,
+rainbows, scoring, memory notifications). Use it to tune strategy changes and
+catch regressions: every chosen card is re-validated against
+`rules.isLegalMove`, and illegal selections or thrown exceptions are reported.
+A healthy strategy reports **zero of both**.
+
+## Usage
+
+```bash
+npm run sim                                   # all experiments, 2000 games each (~10s)
+npm run sim -- --games 8000                   # tighter confidence (~±1.1%)
+npm run sim -- --exp legacy                   # current Mary vs frozen pre-tuning Mary
+npm run sim -- --exp personalities            # each personality+Mary vs Mary+Mary
+npm run sim -- --team mary,danny --vs legacy:mary,legacy:mary
+```
+
+Personality specs: `mary | sharon | danny | mike | zach`, optionally prefixed
+with `legacy:` to use `legacyStrategy.js` — a frozen June-2026 snapshot of
+`BotStrategy.js` kept as a fixed benchmark. Never edit the legacy file; its
+value is that it never changes.
+
+One caveat: the harness always feeds Zach's partner history with the CURRENT
+policy (bore hands skipped), so `legacy:zach` is not a bit-perfect
+reproduction of the old adaptive behavior (which recorded bores as bid 0).
+Mary-pair comparisons (`legacy:mary,legacy:mary`) are exact and are the
+benchmark that matters.
+
+Matchups are seat-balanced (each pair plays both team seatings), so an even
+matchup reads 50.0%. The RNG is seeded (`--seed`); identical invocations are
+fully reproducible.
+
+## Reading results
+
+- `results[]` — win rate of `teamX` with a 95% CI, plus average score delta.
+  Identical strategies should read 50% within the CI.
+- `personalities{}` — per-spec bid/set/bore/accuracy stats pooled across all
+  matches in the run. `legacy:` specs are tracked separately.
+- `byHandSize{}` — redeal rate, combined team bid as a fraction of available
+  tricks, bore frequency.
+- `incidentCount` / `exceptionCount` — must be 0.
+
+## Baseline (June 2026, pre-tuning legacy snapshot, 4000 games/match)
+
+| Matchup | Win rate (X) |
+|---|---|
+| mary vs mary (control) | 50.6% ±1.6 |
+| mary vs legacy:mary (identical code at snapshot time) | 50.8% ±1.6 |
+| sharon+mary vs mary+mary | 49.6% ±1.6 |
+| danny+mary vs mary+mary | 51.3% ±1.6 |
+| zach+mary vs mary+mary | 51.5% ±1.6 |
+| mike+mary vs mary+mary | 48.1% ±1.6 |
+
+Notable legacy-snapshot facts (from the June 2026 evaluation): Danny and Zach
+beat Mary because their "aggressive" modifiers partially corrected her
+systematic underbidding; ~70% of 1-card deals and ~50% of 2-card deals were
+all-zero-bid redeals; bots bid only ~52–68% of available tricks on hands ≥3
+cards. Tuning goals are measured against these numbers.

--- a/server/game/bot/sim/legacyStrategy.js
+++ b/server/game/bot/sim/legacyStrategy.js
@@ -1,8 +1,7 @@
 /**
- * Pure strategy functions for bot decision making.
- * No side effects - all functions take inputs and return outputs.
- *
- * Strategy is informed by docs/bot-strategy-guide.md
+ * FROZEN SNAPSHOT of BotStrategy.js as of June 2026, kept as the benchmark
+ * opponent for the simulation harness (see ./simulate.js, `legacy:` prefix).
+ * Do not edit or "fix" this file — its value is that it never changes.
  */
 
 const {
@@ -13,8 +12,7 @@ const {
     isTrumpTight,
     isLegalMove,
     determineWinner
-} = require('../rules');
-const { getBidStyle, getPlayStyle } = require('./personalities');
+} = require('../../rules');
 
 // --- Hand progression for determining game phase ---
 const HAND_PROGRESSION = [12, 10, 8, 6, 4, 2, 1, 3, 5, 7, 9, 11, 13];
@@ -76,9 +74,9 @@ function hasOpponentsAfterMe(playedCards, position) {
 /**
  * Select the best card from a sorted-highest-first list, preserving HI joker for leading.
  * HI joker's forcing ability (opponents must play highest trump) is too valuable to waste
- * on a follow. Only play it when it's the sole winner or genuinely needed to hold the trick.
+ * on a follow. Only play it when it's the sole winner or needed to beat LO joker / trump Ace.
  */
-function bestWithoutHiJoker(sortedCards, winningCard, trump) {
+function bestWithoutHiJoker(sortedCards, winningCard) {
     if (sortedCards.length === 0) return null;
     const best = sortedCards[0];
 
@@ -89,16 +87,12 @@ function bestWithoutHiJoker(sortedCards, winningCard, trump) {
     // Yes if it's our only option
     if (sortedCards.length === 1) return best;
 
-    // Spend HI only when the current winner is trump strong enough that our
-    // next-best winner can't reliably hold the trick (LO joker or trump Ace).
-    // A non-trump winner never needs HI — every card in this list already
-    // beats it. And if our next-best winner is the LO joker, it is itself
-    // unbeatable (we hold the HI), so hold HI even then.
-    const winningIsTrump = winningCard && (winningCard.suit === 'joker' ||
-        (trump.suit !== 'joker' && winningCard.suit === trump.suit));
-    if (winningIsTrump && (winningCard.rank === 'LO' || winningCard.rank === 'A')) {
-        const next = sortedCards[1];
-        if (!(next.rank === 'LO' && next.suit === 'joker')) return best;
+    // Yes if we need it to beat LO joker or trump Ace (high-value trump only HI can reliably beat)
+    if (winningCard && (
+        (winningCard.rank === 'LO' && winningCard.suit === 'joker') ||
+        (winningCard.rank === 'A' && winningCard.suit !== 'joker')
+    )) {
+        return best;
     }
 
     // Otherwise hold HI joker for leading — use next best card
@@ -107,12 +101,15 @@ function bestWithoutHiJoker(sortedCards, winningCard, trump) {
 
 /**
  * Determine if the current winning card is vulnerable to being beaten by an opponent still to play.
- * A win is "good" (not vulnerable) if no card that outranks it remains in unseen hands
- * AND (for non-trump winners) no remaining opponent is known void in the led suit.
- * @param {Array} [hand] - Our own hand; cards we hold can't beat the winner from elsewhere
+ * A win is "good" (not vulnerable) if it's the highest remaining card in suit AND no remaining
+ * opponent is known void in the led suit. A win is "vulnerable" if higher cards could exist
+ * or an opponent could trump in.
  */
-function isWinVulnerable(winningCard, leadCard, trump, memory, playedCards, position, hand = []) {
+function isWinVulnerable(winningCard, leadCard, trump, memory, playedCards, position) {
     const noTrump = isNoTrump(trump);
+    const winningSuit = winningCard.suit === 'joker'
+        ? (noTrump ? 'joker' : trump.suit)
+        : winningCard.suit;
     const winningIsTrump = winningCard.suit === 'joker' || (!noTrump && winningCard.suit === trump.suit);
 
     // Check if any remaining opponent is known void in the led suit (trump-in risk)
@@ -129,26 +126,32 @@ function isWinVulnerable(winningCard, leadCard, trump, memory, playedCards, posi
         }
     }
 
-    // Trump winner: only a higher trump still in unseen hands threatens it.
-    // Counting actual outstanding cards lets a trump Queen stand once the
-    // jokers/A/K are accounted for, instead of overtaking partner "just in case".
-    if (winningIsTrump) {
-        if (!memory) {
-            // No memory: fall back to rank heuristics
-            return !(winningCard.rank === 'HI' || winningCard.rank === 'LO' || winningCard.rank === 'A');
-        }
-        return countHigherUnseen(winningCard, hand, memory, trump) > 0;
-    }
+    // HI joker: only vulnerable if it's somehow not winning (shouldn't happen) — treat as good
+    if (winningCard.rank === 'HI' && winningCard.suit === 'joker') return false;
 
-    // Non-trump winner: vulnerable to a ruff from a known-void opponent.
-    // In no-trump the one live joker is still trump — the ruff risk only
-    // disappears once that joker is accounted for.
-    if (opponentKnownVoid && (!noTrump || countLiveJokersOutside(hand, memory, trump) > 0)) {
+    // If winning card is trump, check for higher trump threats
+    if (winningIsTrump) {
+        // LO joker: only HI joker beats it — hard to assess, treat as mostly good
+        if (winningCard.rank === 'LO' && winningCard.suit === 'joker') return false;
+        // Trump Ace: only jokers beat it
+        if (winningCard.rank === 'A') return false;
+        // Other trump: vulnerable (higher trump could exist)
         return true;
     }
-    // ...or to a higher card of the suit in unseen hands
-    if (!memory) return winningCard.rank !== 'A';
-    return countHigherUnseen(winningCard, hand, memory, trump) > 0;
+
+    // Non-trump winning card
+    // Ace of led suit: only vulnerable if opponent could trump in
+    if (winningCard.rank === 'A') return opponentKnownVoid;
+
+    // King: vulnerable if Ace hasn't been played OR opponent known void
+    if (winningCard.rank === 'K') {
+        if (opponentKnownVoid) return true;
+        if (!memory) return true; // No memory, assume vulnerable
+        return !memory.acesPlayed[winningSuit];
+    }
+
+    // Queen and below: vulnerable by default when opponents remain
+    return true;
 }
 
 /**
@@ -170,8 +173,7 @@ function getOpponentVoidSuits(memory, position, trump) {
 
     for (const trickCards of Object.values(tricks)) {
         if (trickCards.length === 0) continue;
-        const leadEntry = findLeadEntry(trickCards);
-        if (!leadEntry) continue; // partially observed trick (bot joined mid-trick)
+        const leadEntry = trickCards[0];
         const leadSuit = leadEntry.suit === 'joker' ? (isNoTrump(trump) ? 'joker' : trump.suit) : leadEntry.suit;
 
         for (const entry of trickCards) {
@@ -184,18 +186,6 @@ function getOpponentVoidSuits(memory, position, trump) {
     }
 
     return voidSuits;
-}
-
-/**
- * Find the entry that led a recorded trick. Entries carry an explicit isLead
- * flag (recorded by BotPlayer); when absent (older recordings), fall back to
- * assuming the first recorded card led — only safe when the bot observed the
- * trick from its start.
- */
-function findLeadEntry(trickCards) {
-    const hasLeadInfo = trickCards.some(e => e.isLead !== undefined);
-    if (hasLeadInfo) return trickCards.find(e => e.isLead) || null;
-    return trickCards[0];
 }
 
 /**
@@ -216,8 +206,7 @@ function getPartnerVoidSuits(memory, position, trump) {
 
     for (const trickCards of Object.values(tricks)) {
         if (trickCards.length === 0) continue;
-        const leadEntry = findLeadEntry(trickCards);
-        if (!leadEntry) continue; // partially observed trick (bot joined mid-trick)
+        const leadEntry = trickCards[0];
         const leadSuit = leadEntry.suit === 'joker' ? (isNoTrump(trump) ? 'joker' : trump.suit) : leadEntry.suit;
 
         for (const entry of trickCards) {
@@ -230,131 +219,6 @@ function getPartnerVoidSuits(memory, position, trump) {
     }
 
     return voidSuits;
-}
-
-const SUIT_RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A'];
-
-/**
- * Count cards still in opponents'/partner's hands that would beat this card
- * in direct comparison: higher cards of its suit (for trump, higher trump
- * including jokers). Excludes cards already played, cards in our own hand,
- * and the flipped trump card (which is out of play). 0 means the card is
- * boss — nothing left in other hands outranks it (it can still lose to a
- * ruff if it isn't trump; that risk is tracked separately).
- */
-function countHigherUnseen(card, hand, memory, trump) {
-    const noTrump = isNoTrump(trump);
-    const cardIsTrump = card.suit === 'joker' || (!noTrump && card.suit === trump.suit);
-    const myVal = RANK_VALUES[card.rank];
-
-    const gone = new Set();
-    gone.add(`${trump.suit}:${trump.rank}`); // flipped card is out of play
-    for (const c of hand) gone.add(`${c.suit}:${c.rank}`);
-    if (memory && memory.playedCards) {
-        for (const e of memory.playedCards) gone.add(`${e.suit}:${e.rank}`);
-    }
-    if (memory && memory.acesPlayed) {
-        for (const [suit, played] of Object.entries(memory.acesPlayed)) {
-            if (played) gone.add(`${suit}:A`);
-        }
-    }
-
-    let count = 0;
-    if (cardIsTrump) {
-        if (!noTrump) {
-            for (const r of SUIT_RANKS) {
-                if (RANK_VALUES[r] > myVal && !gone.has(`${trump.suit}:${r}`)) count++;
-            }
-        }
-        if (RANK_VALUES['LO'] > myVal && !gone.has('joker:LO')) count++;
-        if (RANK_VALUES['HI'] > myVal && !gone.has('joker:HI')) count++;
-    } else {
-        for (const r of SUIT_RANKS) {
-            if (RANK_VALUES[r] > myVal && !gone.has(`${card.suit}:${r}`)) count++;
-        }
-    }
-    return count;
-}
-
-/**
- * Count jokers still in other players' hands (not flipped, not ours, not yet
- * played). In no-trump hands the one live joker is still trump and can ruff.
- */
-function countLiveJokersOutside(hand, memory, trump) {
-    const gone = new Set();
-    gone.add(`${trump.suit}:${trump.rank}`);
-    for (const c of hand) gone.add(`${c.suit}:${c.rank}`);
-    if (memory && memory.playedCards) {
-        for (const e of memory.playedCards) gone.add(`${e.suit}:${e.rank}`);
-    }
-    let count = 0;
-    if (!gone.has('joker:HI')) count++;
-    if (!gone.has('joker:LO')) count++;
-    return count;
-}
-
-/**
- * Derive the contract picture from play context (see BotController.buildPlayContext).
- * Returns null when context is unavailable; callers fall back to contract-blind play.
- *
- * The core output is `target` — how many of the remaining tricks the team
- * should fight for — and the effort level that follows from it:
- *  - 'max':    every remaining trick matters (live bore, or bid exactly
- *              coverable, or one trick sets an opponent bore)
- *  - 'cheap':  nothing left but ±1 overtricks — never spend honors or trump
- *  - 'normal': contested middle
- */
-function getContractState(playContext, position, handSize) {
-    if (!playContext || !playContext.bids || !playContext.tricks) return null;
-
-    const isTeam1 = position === 1 || position === 3;
-    const myBid = (isTeam1 ? playContext.bids.team1 : playContext.bids.team2) || 0;
-    const oppBid = (isTeam1 ? playContext.bids.team2 : playContext.bids.team1) || 0;
-    const myTricks = (isTeam1 ? playContext.tricks.team1 : playContext.tricks.team2) || 0;
-    const oppTricks = (isTeam1 ? playContext.tricks.team2 : playContext.tricks.team1) || 0;
-
-    const partnerPosition = getPartnerPosition(position);
-    const playerBids = playContext.playerBids || [];
-    const isBoreBid = (b) => ['B', '2B', '3B', '4B'].includes(String(b));
-    const teamBored = isBoreBid(playerBids[position - 1]) || isBoreBid(playerBids[partnerPosition - 1]);
-    const oppBored = getOpponentPositions(position).some(p => isBoreBid(playerBids[p - 1]));
-
-    const tricksRemaining = handSize - myTricks - oppTricks;
-    const needed = Math.max(0, myBid - myTricks);
-    const oppNeeded = Math.max(0, oppBid - oppTricks);
-
-    // Objectives still alive: making our own bid, and setting theirs
-    const makeTarget = needed <= tricksRemaining ? needed : 0; // 0 when our bid is already dead
-    const toSetOpp = oppNeeded > 0 ? tricksRemaining - oppNeeded + 1 : Infinity;
-    // Denial is worth chasing only when realistic: an opposing bore (huge
-    // swing), or a set that doesn't demand sweeping far beyond what our own
-    // bid already requires. Without this gate, opponents sitting one trick
-    // from a small bid would push the bot into sweep-everything mode all hand.
-    let setTarget = 0;
-    if (toSetOpp > 0 && toSetOpp <= tricksRemaining) {
-        if (oppBored || toSetOpp <= Math.max(makeTarget, Math.ceil(tricksRemaining / 2))) {
-            setTarget = toSetOpp;
-        }
-    }
-
-    const target = Math.max(makeTarget, setTarget);
-    let effort = 'normal';
-    if (target === 0) effort = 'cheap';
-    else if (target >= tricksRemaining) effort = 'max';
-    // An opposing bore is worth so much that the one trick that sets it
-    // always justifies maximum effort
-    else if (oppBored && myTricks === 0) effort = 'max';
-
-    return {
-        teamBored,
-        oppBored,
-        needed,
-        oppNeeded,
-        tricksRemaining,
-        target,
-        effort,
-        urgency: tricksRemaining > 0 ? target / tricksRemaining : 0
-    };
 }
 
 /**
@@ -394,27 +258,19 @@ function evaluateHand(hand, trump, handSize) {
         }
 
         // --- Point evaluation ---
-        // The flipped trump card is out of play: when it's the HI joker the LO
-        // becomes unbeatable, and a trump King under a flipped Ace is the boss
-        // trump card after the jokers.
         if (card.rank === 'HI') {
             points += 1.9;
         } else if (card.rank === 'LO') {
-            points += (trump.rank === 'HI' ? 1.9 : 1.4);
+            points += 1.4;
         } else if (isTrump && card.rank === 'A') {
             points += 1.4 * tScale;
         } else if (isTrump && card.rank === 'K') {
-            points += (trump.rank === 'A' ? 1.4 : 0.9) * tScale;
+            points += 0.9 * tScale;
         } else if (isTrump && card.rank === 'Q') {
-            points += (trump.rank === 'K' ? 0.9 : 0.4) * tScale;
-        } else if (isTrump) {
-            // Low/mid trump (2-J): every trump card pulls weight — it ruffs or
-            // forces out a bigger trump. Worth more in small hands (fewer
-            // trump in play) and when higher in rank.
-            const mid = RANK_VALUES[card.rank] >= 7;
-            if (handSize <= 4) points += (mid ? 0.45 : 0.35) * tScale;
-            else if (handSize <= 7) points += (mid ? 0.25 : 0.1) * tScale;
-            else points += (mid ? 0.15 : 0.05) * tScale;
+            points += 0.4 * tScale;
+        } else if (isTrump && RANK_VALUES[card.rank] >= 7) {
+            // Trump mid-cards (J-7): small value in small hands
+            points += (handSize <= 4) ? 0.3 * tScale : 0;
         } else if (!isTrump && card.rank === 'A') {
             if (noTrump) {
                 points += 1.3;
@@ -464,13 +320,11 @@ function evaluateHand(hand, trump, handSize) {
         points += voids * 0.1;
     }
 
-    // Trump length bonus (large hands only) — smaller than before since each
-    // trump card now carries value of its own; this models the extra control
-    // long trump gives beyond the sum of its cards
+    // Trump length bonus (large hands only)
     if (handSize >= 6 && !noTrump) {
-        if (trumpCount >= 6) points += 0.75;
-        else if (trumpCount >= 5) points += 0.4;
-        else if (trumpCount >= 4) points += 0.15;
+        if (trumpCount >= 6) points += 1.5;
+        else if (trumpCount >= 5) points += 0.75;
+        else if (trumpCount >= 4) points += 0.25;
     }
 
     return {
@@ -513,9 +367,8 @@ function calculateOptimalBid(hand, trump, position, existingBids, handSize, memo
 
     let opponentTotalBid = 0;
     let opponentBidCount = 0;
-    let allSeenBidsZero = true;
+    let allOthersBidZero = true;
     let partnerBored = false;
-    let opponentBored = false;
     let highestBore = null;
 
     for (let i = 0; i < 4; i++) {
@@ -523,36 +376,29 @@ function calculateOptimalBid(hand, trump, position, existingBids, handSize, memo
         if (bid === undefined || bid === null) continue;
         const bidValue = BID_RANKS[bid] || 0;
         const bidPosition = i + 1;
-        const isBoreBid = ['B', '2B', '3B', '4B'].includes(bid);
 
         if (bidPosition !== position) {
-            if (bidValue > 0 || isBoreBid) {
-                allSeenBidsZero = false;
+            if (bidValue > 0 || ['B', '2B', '3B', '4B'].includes(bid)) {
+                allOthersBidZero = false;
             }
         }
 
         if (opponentPositions.includes(bidPosition)) {
-            // Bores carry BID_RANKS values 13-16; keep them out of trick math
-            opponentTotalBid += isBoreBid ? 0 : bidValue;
+            opponentTotalBid += bidValue;
             opponentBidCount++;
         }
 
-        if (isBoreBid) {
-            if (!highestBore || BID_RANKS[bid] > BID_RANKS[highestBore]) {
-                highestBore = bid;
+        if (['B', '2B', '3B', '4B'].includes(bid)) {
+            highestBore = bid;
+            if (bidPosition === partnerPosition) {
+                partnerBored = true;
             }
-            if (bidPosition === partnerPosition) partnerBored = true;
-            if (opponentPositions.includes(bidPosition)) opponentBored = true;
         }
     }
 
     const bidsBefore = existingBids.filter(b => b !== undefined && b !== null).length;
     const isFirstBidder = bidsBefore === 0;
     const isDealer = bidsBefore === 3;
-    // "Weak field" signals for bore decisions. A seat that hasn't bid yet is
-    // NOT a zero bid — it's no information at all.
-    const weakFieldConfirmed = isDealer && allSeenBidsZero;          // saw all 3 others bid 0
-    const weakFieldLikely = bidsBefore >= 1 && allSeenBidsZero;      // saw 1+ bids, all 0
 
     // --- Game-level score awareness ---
     let riskAdjustment = 0; // positive = more aggressive, negative = more conservative
@@ -569,27 +415,19 @@ function calculateOptimalBid(hand, trump, position, existingBids, handSize, memo
 
     // --- BORE DECISIONS (check before normal bidding) ---
 
-    // When the flipped trump card is the HI joker, the LO joker is the boss
-    // trump — nothing in play beats it.
-    const loIsBoss = evaluation.hasLowJoker && trump.rank === 'HI';
-
     // 1-card hand bore
-    if (handSize === 1) {
-        // HI joker (or LO when HI was flipped): unbeatable — bore regardless of
-        // other bids. Bidding 'B' also wins the lead, guaranteeing the trick.
-        if (evaluation.hasHighJoker || loIsBoss) return 'B';
-        // LO joker / trump Ace: near-certain winners; bore unless an opponent
-        // has already shown a monster of their own
-        if ((evaluation.hasLowJoker || evaluation.hasTrumpAce) && !opponentBored) return 'B';
+    if (handSize === 1 && allOthersBidZero) {
+        if (evaluation.hasHighJoker) return 'B';
+        if (evaluation.hasLowJoker || evaluation.hasTrumpAce) return 'B';
         const card = hand[0];
         const isTrump = card.suit === 'joker' || (!noTrump && card.suit === trump.suit);
-        if (weakFieldConfirmed && isTrump && RANK_VALUES[card.rank] >= RANK_VALUES['K']) return 'B';
+        if (isTrump && RANK_VALUES[card.rank] >= RANK_VALUES['K']) return 'B';
         // With positive risk adjustment, lower the threshold
-        if (riskAdjustment > 0 && weakFieldConfirmed && isTrump && RANK_VALUES[card.rank] >= RANK_VALUES['Q']) return 'B';
+        if (riskAdjustment > 0 && isTrump && RANK_VALUES[card.rank] >= RANK_VALUES['Q']) return 'B';
     }
 
     // 2-card hand bore
-    if (handSize === 2 && weakFieldLikely) {
+    if (handSize === 2 && allOthersBidZero) {
         const c1 = hand[0];
         const c2 = hand[1];
         const c1Trump = c1.suit === 'joker' || (!noTrump && c1.suit === trump.suit);
@@ -609,28 +447,21 @@ function calculateOptimalBid(hand, trump, position, existingBids, handSize, memo
         if (bothTrump && hasMidTrumpPlus) return 'B';
         // One high trump + one high non-trump: BORE
         if (hasHighTrump && hasHighNonTrump) return 'B';
-        // No-trump: two Aces can't be ruffed — bore as dealer in a weak field
-        if (noTrump && weakFieldConfirmed && hand.every(c => c.rank === 'A' || c.rank === 'HI' || c.rank === 'LO')) {
-            return 'B';
-        }
     }
 
     // 3-5 card hand bore
-    if (handSize >= 3 && handSize <= 5 && weakFieldLikely) {
+    if (handSize >= 3 && handSize <= 5 && allOthersBidZero) {
         if (evaluation.hasHighJoker && evaluation.trumpCount >= handSize) return 'B';
         if (evaluation.hasHighJoker && evaluation.trumpCount >= handSize - 1 && evaluation.hasLowJoker) return 'B';
     }
 
-    // Partner bore support (escalate the multiplier)
+    // Partner bore support (double bore)
     if (partnerBored && !['B', '2B', '3B', '4B'].includes(existingBids[position - 1])) {
         if (handSize <= 4 && evaluation.trumpCount >= Math.ceil(handSize / 2)) {
-            // Escalating over an OPPONENT's counter-bore doubles the stakes on a
-            // contested hand — only do it holding the unbeatable card ourselves
-            if (!opponentBored || evaluation.hasHighJoker || loIsBoss) {
-                if (highestBore === 'B') return '2B';
-                if (highestBore === '2B') return '3B';
-                if (highestBore === '3B') return '4B';
-            }
+            // Determine the next bore level
+            if (highestBore === 'B') return '2B';
+            if (highestBore === '2B') return '3B';
+            if (highestBore === '3B') return '4B';
         }
     }
 
@@ -643,14 +474,13 @@ function calculateOptimalBid(hand, trump, position, existingBids, handSize, memo
 
     // --- NORMAL BIDDING ---
 
-    // Conservative rounding: floor instead of round. The set penalty
-    // (-10/trick) dwarfs the overtrick payoff (+1/trick); sim-tested against
-    // +0.2/+0.45 offsets — same win rate, materially fewer sets.
+    // Conservative rounding: floor instead of round
     let bid = Math.floor(evaluation.points);
 
-    // No extra first-bidder discount: the pessimistic evaluation plus floor()
-    // already price in the uncertainty — stacking a further -1 triple-counts
-    // it (sim-tested: the discount cost ~1.2% win rate).
+    // Additional conservatism for first bidder (least information)
+    if (isFirstBidder && bid > 1) {
+        bid = bid - 1;
+    }
 
     // Cap at hand size
     bid = Math.min(bid, handSize);
@@ -659,38 +489,19 @@ function calculateOptimalBid(hand, trump, position, existingBids, handSize, memo
     if (handSize === 1) {
         if (evaluation.hasHighJoker || evaluation.hasLowJoker || evaluation.hasTrumpAce) {
             bid = 1;
-        } else if (noTrump && (hand[0].rank === 'A' || hand[0].rank === 'K')) {
-            // No-trump: an Ace (or King) can't be ruffed and we lead as the
-            // highest bidder — near-certain winner
-            bid = 1;
-        } else if (!noTrump &&
-            (hand[0].suit === trump.suit || hand[0].suit === 'joker') &&
-            RANK_VALUES[hand[0].rank] >= RANK_VALUES['7']) {
-            // High trump is a likely winner even into an unknown field
-            bid = 1;
         } else {
             bid = 0;
         }
     } else if (handSize === 2) {
-        if (noTrump) {
-            // Nothing can be ruffed: jokers and aces are near-certain winners
-            let winners = 0;
-            for (const c of hand) {
-                if (c.rank === 'HI' || c.rank === 'LO' || c.rank === 'A') winners++;
-            }
-            bid = Math.min(winners, 2);
+        const hasTrump = hand.some(c => c.suit === 'joker' || (!noTrump && c.suit === trump.suit));
+        if (evaluation.hasHighJoker) {
+            bid = (evaluation.hasLowJoker || evaluation.hasTrumpAce) ? 2 : 1;
+        } else if (evaluation.hasLowJoker || evaluation.hasTrumpAce) {
+            bid = 1;
+        } else if (hasTrump) {
+            bid = 0;
         } else {
-            let winners = 0;
-            let trumps = 0;
-            for (const c of hand) {
-                const isTrumpCard = c.suit === 'joker' || c.suit === trump.suit;
-                if (isTrumpCard) trumps++;
-                if (c.rank === 'HI' || c.rank === 'LO') winners++;
-                else if (isTrumpCard && RANK_VALUES[c.rank] >= RANK_VALUES['Q']) winners++;
-            }
-            // Two trump cards: the higher one usually scores a trick
-            if (winners === 0 && trumps === 2) winners = 1;
-            bid = Math.min(winners, 2);
+            bid = 0;
         }
     } else if (handSize <= 4) {
         // Cap at trump-based estimate for small hands
@@ -711,12 +522,6 @@ function calculateOptimalBid(hand, trump, position, existingBids, handSize, memo
     // --- Opponent bid adjustments ---
     if (opponentBidCount === 2 && opponentTotalBid >= handSize * 0.6) {
         bid = Math.max(0, bid - 1);
-    }
-
-    // An opponent bored: either they sweep (we're set regardless of our bid)
-    // or we take a trick and set them. Keep our own bid minimal.
-    if (opponentBored) {
-        bid = Math.min(bid, 1);
     }
 
     if (partnerBidValue !== null && partnerBidValue >= Math.ceil(handSize * 0.5)) {
@@ -742,16 +547,6 @@ function calculateOptimalBid(hand, trump, position, existingBids, handSize, memo
     // Apply personality-specific bid modifier
     bid = applyBidModifier(bid, personality, evaluation, handSize, partnerHistory);
 
-    // Personality adjustments must still respect the combined-bid cap — a
-    // team bid above hand size is unmakeable — and the opponent-bore cap
-    if (partnerBidValue !== null) {
-        bid = Math.min(bid, Math.max(0, handSize - partnerBidValue));
-    }
-    if (opponentBored) {
-        bid = Math.min(bid, 1);
-    }
-    bid = Math.max(0, Math.min(bid, handSize));
-
     return String(bid);
 }
 
@@ -767,48 +562,46 @@ function calculateOptimalBid(hand, trump, position, existingBids, handSize, memo
 function applyBidModifier(baseBid, personality, evaluation, handSize, partnerHistory) {
     let bid = baseBid;
 
-    switch (getBidStyle(personality)) {
-        case 'conservative':
-            // Sharon trims big bids by one: banks the safety, forfeits ~9
-            // points of upside on hands she'd usually make anyway
-            if (bid >= 3) {
-                bid = bid - 1;
+    switch (personality) {
+        case 'sharon':
+            // Sharon underbids strong hands
+            if (handSize > 0 && evaluation.points >= handSize * 0.7) {
+                bid = Math.max(0, bid - 2);
+            } else if (handSize > 0 && evaluation.points >= handSize * 0.5) {
+                bid = Math.max(0, bid - 1);
             }
             break;
 
-        case 'calculated-aggressive':
-            // Danny rounds up bids that just missed the next trick.
+        case 'danny':
+            // Danny rounds up on close calls - calculated risk-taking
             // But don't override small-hand special logic: a 0 bid on ≤4 cards
             // means the hand genuinely lacks trick-taking power
-            if (evaluation.points - baseBid >= 0.85) {
+            if (evaluation.points - baseBid >= 0.25) {
                 if (baseBid === 0 && handSize <= 4) break;
                 bid = Math.min(baseBid + 1, handSize);
             }
             break;
 
-        case 'overconfident':
-            // Mike misjudges his hand now and then
-            if (Math.random() < 0.10) {
+        case 'mike':
+            // Mike randomly overbids ~25% of the time - he misjudges hands
+            if (Math.random() < 0.25) {
                 bid = Math.min(baseBid + 1, handSize);
             }
             break;
 
-        case 'adaptive': {
-            // Zach compensates for his partner's observed bid error. The
-            // deadband is asymmetric because well-calibrated partners run
-            // ~+0.5-1 tricks over their bid by design (conservative floor
-            // rounding) — only a clearly larger surplus means sandbagging.
-            if (partnerHistory.length >= 3) {
+        case 'zach': {
+            // Zach compensates for partner's tendencies with conservative lean
+            if (partnerHistory.length >= 2) {
                 const totalError = partnerHistory.reduce((sum, h) => sum + (h.tricks - h.bid), 0);
                 const avgError = totalError / partnerHistory.length;
 
                 if (avgError < -0.5) {
-                    // Partner overbids (gets set) - compensate down
+                    // Partner overbids (aggressive) - fully compensate down
                     bid = Math.max(0, bid - 1);
-                } else if (avgError > 1.5) {
-                    // Partner sandbags heavily - pick up the slack when the
-                    // hand supports it
-                    if (evaluation.points - baseBid >= 0.5) {
+                } else if (avgError > 0.5) {
+                    // Partner underbids (conservative) - cautious half-measure up
+                    // Only bid up if hand evaluation supports it
+                    if (evaluation.points - baseBid >= 0.3) {
                         bid = Math.min(bid + 1, handSize);
                     }
                 }
@@ -816,7 +609,7 @@ function applyBidModifier(baseBid, personality, evaluation, handSize, partnerHis
             break;
         }
 
-        // 'neutral' (Mary) and default: no modification
+        // 'mary' and default: no modification
     }
 
     return bid;
@@ -868,35 +661,9 @@ function getCurrentWinner(playedCards, leadPosition, trump) {
 }
 
 /**
- * Pick which of several trick-winning cards to actually play.
- * Always prefers the cheapest BOSS winner (a card nothing left in unseen
- * hands can beat — secure AND cheap). With no boss available: highest
- * winner when securing matters, lowest when it doesn't. HI joker is held
- * back whenever an alternative does the job.
- */
-function pickWinner(winners, hand, memory, trump, winningCard, secure) {
-    const asc = [...winners].sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank]);
-    const isHi = (c) => c.rank === 'HI' && c.suit === 'joker';
-
-    // Cheapest non-HI boss: secure AND cheap
-    const nonHiBoss = asc.filter(c => !isHi(c) && countHigherUnseen(c, hand, memory, trump) === 0);
-    if (nonHiBoss.length > 0) return nonHiBoss[0];
-
-    // HI is always boss but too valuable to spend while alternatives exist —
-    // bestWithoutHiJoker arbitrates the exceptions
-    if (asc.length === 1) return asc[0];
-    if (secure) {
-        const desc = [...winners].sort((a, b) => RANK_VALUES[b.rank] - RANK_VALUES[a.rank]);
-        return bestWithoutHiJoker(desc, winningCard, trump);
-    }
-    return asc[0];
-}
-
-/**
  * Select optimal card when leading
- * @param {Object|null} contract - From getContractState(); null = contract-blind
  */
-function selectLead(hand, trump, trumpBroken, gameState, memory, handSize, contract) {
+function selectLead(hand, trump, trumpBroken, gameState, memory, handSize) {
     const legalCards = getLegalCards(hand, null, true, trump, trumpBroken, gameState.position, gameState.position);
 
     if (legalCards.length === 1) return legalCards[0];
@@ -904,37 +671,6 @@ function selectLead(hand, trump, trumpBroken, gameState, memory, handSize, contr
     const noTrump = isNoTrump(trump);
     const opponentVoids = getOpponentVoidSuits(memory, gameState.position, trump);
     const partnerVoids = getPartnerVoidSuits(memory, gameState.position, trump);
-    const effort = contract ? contract.effort : 'normal';
-    const opponents = getOpponentPositions(gameState.position);
-
-    const legalTrump = legalCards.filter(c => c.suit === 'joker' || (!noTrump && c.suit === trump.suit));
-    const legalOffsuit = legalCards.filter(c => c.suit !== 'joker' && (noTrump || c.suit !== trump.suit));
-    // "Safe" boss: nothing outranks it AND no known-void opponent can ruff it
-    // (in no-trump, ruffs stay possible until the live joker is accounted for)
-    const ruffersExist = !noTrump || countLiveJokersOutside(hand, memory, trump) > 0;
-    const safeBossOffsuit = legalOffsuit.filter(c =>
-        countHigherUnseen(c, hand, memory, trump) === 0 &&
-        (!ruffersExist || !opponents.some(o => opponentVoids.has(`${o}:${c.suit}`))));
-
-    // --- Maximum effort (live bore / must-win-every-trick): lead raw strength ---
-    if (effort === 'max') {
-        const hiJoker = legalCards.find(c => c.rank === 'HI');
-        if (hiJoker) return hiJoker;
-        const bossTrump = legalTrump
-            .filter(c => countHigherUnseen(c, hand, memory, trump) === 0)
-            .sort((a, b) => RANK_VALUES[b.rank] - RANK_VALUES[a.rank])[0];
-        if (bossTrump) return bossTrump;
-        if (safeBossOffsuit.length > 0) return safeBossOffsuit[0];
-        if (legalTrump.length > 0) {
-            return legalTrump.sort((a, b) => RANK_VALUES[b.rank] - RANK_VALUES[a.rank])[0];
-        }
-        return legalCards.sort((a, b) => RANK_VALUES[b.rank] - RANK_VALUES[a.rank])[0];
-    }
-
-    // --- Only ±1 overtricks left: cash sure winners while we have the lead ---
-    if (effort === 'cheap' && safeBossOffsuit.length > 0) {
-        return safeBossOffsuit[0];
-    }
 
     // 1. Lead HI joker when we have it (draws out opponent trump)
     const highJoker = legalCards.find(c => c.rank === 'HI');
@@ -952,6 +688,7 @@ function selectLead(hand, trump, trumpBroken, gameState, memory, handSize, contr
     }
 
     // 3. Score each off-suit for leading
+    const opponents = getOpponentPositions(gameState.position);
     let bestSuit = null;
     let bestScore = -Infinity;
 
@@ -1016,11 +753,8 @@ function selectLead(hand, trump, trumpBroken, gameState, memory, handSize, contr
 
 /**
  * Select optimal card when following
- * @param {Object|null} contract - From getContractState(); null = contract-blind
- * @param {string} [playStyle] - Personality play style (see personalities.js);
- *   styles never apply at 'max' effort — flavor must not bust a live bore
  */
-function selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBroken, position, memory, handSize, contract, playStyle = 'balanced') {
+function selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBroken, position, memory, handSize) {
     const legalCards = getLegalCards(hand, leadCard, false, trump, trumpBroken, position, leadPosition);
 
     if (legalCards.length === 1) return legalCards[0];
@@ -1028,8 +762,7 @@ function selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBro
     const partnerPosition = getPartnerPosition(position);
     const { card: winningCard, position: winnerPosition } = getCurrentWinner(playedCards, leadPosition, trump);
     const partnerIsWinning = winnerPosition === partnerPosition;
-    const partnerHasPlayed = playedCards[partnerPosition - 1] != null;
-    const effort = contract ? contract.effort : 'normal';
+    const partnerHasPlayed = playedCards[partnerPosition - 1] !== undefined;
 
     const leadSuit = leadCard.suit === 'joker' ? trump.suit : leadCard.suit;
 
@@ -1043,26 +776,16 @@ function selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBro
 
     const opponentsRemain = hasOpponentsAfterMe(playedCards, position);
 
-    const effortIsMax = effort === 'max';
-
     if (canFollow) {
         // We can follow suit
         if (partnerIsWinning && partnerHasPlayed) {
-            const partnerVulnerable = isWinVulnerable(winningCard, leadCard, trump, memory, playedCards, position, hand);
-
-            // Mike sometimes overtakes a partner who is winning just fine
-            if (playStyle === 'erratic' && !effortIsMax && !partnerVulnerable && Math.random() < 0.12) {
-                const higherCards = followCards.filter(c => canBeatCard(c, winningCard, leadCard, trump));
-                if (higherCards.length > 0) {
-                    return pickWinner(higherCards, hand, memory, trump, winningCard, true);
-                }
-            }
-
             // If opponents still play after us and partner's win is vulnerable, overtake it
-            if (opponentsRemain && partnerVulnerable) {
+            if (opponentsRemain && isWinVulnerable(winningCard, leadCard, trump, memory, playedCards, position)) {
                 const higherCards = followCards.filter(c => canBeatCard(c, winningCard, leadCard, trump));
                 if (higherCards.length > 0) {
-                    return pickWinner(higherCards, hand, memory, trump, winningCard, true);
+                    // Play highest to secure the trick (but preserve HI joker for leading)
+                    const sorted = higherCards.sort((a, b) => RANK_VALUES[b.rank] - RANK_VALUES[a.rank]);
+                    return bestWithoutHiJoker(sorted, winningCard);
                 }
             }
             // Partner's win is good, or we can't beat it — play low
@@ -1073,29 +796,27 @@ function selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBro
         const winners = followCards.filter(c => canBeatCard(c, winningCard, leadCard, trump));
         if (winners.length > 0) {
             if (opponentsRemain) {
-                // Sharon won't spend honors on a contested trick — she ducks
-                // unless she holds a sure (boss) winner
-                if (playStyle === 'hoarding' && !effortIsMax) {
-                    const sureWinners = winners.filter(c =>
-                        !(c.rank === 'HI' && c.suit === 'joker') &&
-                        countHigherUnseen(c, hand, memory, trump) === 0);
-                    if (sureWinners.length === 0) {
-                        return followCards.sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank])[0];
-                    }
-                }
-                // Danny reaches straight for the big card a cheaper winner
-                // would have held with
-                if (playStyle === 'flashy' && !effortIsMax) {
-                    const desc = [...winners].sort((a, b) => RANK_VALUES[b.rank] - RANK_VALUES[a.rank]);
-                    return bestWithoutHiJoker(desc, winningCard, trump);
-                }
-                // Cheapest boss winner when we have one, else highest to fight
-                // for the trick (HI joker preserved when alternatives exist)
-                return pickWinner(winners, hand, memory, trump, winningCard, true);
+                // Opponents still to play — play highest winner to secure the trick
+                // (but preserve HI joker for leading)
+                const sorted = winners.sort((a, b) => RANK_VALUES[b.rank] - RANK_VALUES[a.rank]);
+                return bestWithoutHiJoker(sorted, winningCard);
             }
 
-            // No opponents remain — the lowest winner always holds the trick
-            return winners.sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank])[0];
+            // No opponents remain — play lowest winner (conserve cards)
+            const sortedWinners = winners.sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank]);
+            const lowestWinner = sortedWinners[0];
+
+            // King protection on large hands: if King is lowest winner and Ace not played
+            if (lowestWinner.rank === 'K' && handSize >= 8 && memory) {
+                const kingSuit = lowestWinner.suit;
+                if (kingSuit !== 'joker' && !memory.acesPlayed[kingSuit]) {
+                    if (sortedWinners.length > 1) {
+                        return sortedWinners[1]; // Play next lowest winner instead
+                    }
+                }
+            }
+
+            return lowestWinner;
         }
 
         // Can't win - play lowest
@@ -1107,20 +828,9 @@ function selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBro
     const nonTrumpCards = legalCards.filter(c => c.suit !== trump.suit && c.suit !== 'joker');
 
     if (partnerIsWinning && partnerHasPlayed) {
-        // When sweeping is mandatory, secure a vulnerable partner win with trump
-        if (effort === 'max' && opponentsRemain && trumpCards.length > 0 &&
-            isWinVulnerable(winningCard, leadCard, trump, memory, playedCards, position, hand)) {
-            const winningIsTrump = winningCard.suit === trump.suit || winningCard.suit === 'joker';
-            const candidates = winningIsTrump
-                ? trumpCards.filter(c => RANK_VALUES[c.rank] > RANK_VALUES[winningCard.rank])
-                : trumpCards;
-            if (candidates.length > 0) {
-                return pickWinner(candidates, hand, memory, trump, winningCard, true);
-            }
-        }
         // Partner winning - don't trump, just discard
         if (nonTrumpCards.length > 0) {
-            return selectDiscard(nonTrumpCards, trump, trumpCards.length > 0, memory, hand);
+            return selectDiscard(nonTrumpCards, trump, trumpCards.length > 0);
         }
         return trumpCards.sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank])[0];
     }
@@ -1128,30 +838,32 @@ function selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBro
     // Opponent winning - try to trump
     if (trumpCards.length > 0) {
         const winningIsTrump = winningCard.suit === trump.suit || winningCard.suit === 'joker';
-        const candidates = winningIsTrump
-            ? trumpCards.filter(c => RANK_VALUES[c.rank] > RANK_VALUES[winningCard.rank])
-            : trumpCards;
+        // Play high trump when opponents remain to secure the trick, low when last to act
+        const trumpSortOrder = opponentsRemain
+            ? (a, b) => RANK_VALUES[b.rank] - RANK_VALUES[a.rank]   // highest first
+            : (a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank];  // lowest first
 
-        if (candidates.length > 0) {
-            if (opponentsRemain) {
-                if (playStyle === 'flashy' && !effortIsMax) {
-                    const desc = [...candidates].sort((a, b) => RANK_VALUES[b.rank] - RANK_VALUES[a.rank]);
-                    return bestWithoutHiJoker(desc, winningCard, trump);
-                }
-                return pickWinner(candidates, hand, memory, trump, winningCard, true);
+        if (winningIsTrump) {
+            // Need to overtrump
+            const overtrumps = trumpCards.filter(c => RANK_VALUES[c.rank] > RANK_VALUES[winningCard.rank]);
+            if (overtrumps.length > 0) {
+                const sorted = overtrumps.sort(trumpSortOrder);
+                return opponentsRemain ? bestWithoutHiJoker(sorted, winningCard) : sorted[0];
             }
-            return candidates.sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank])[0];
+            // Can't overtrump - discard
+            if (nonTrumpCards.length > 0) {
+                return selectDiscard(nonTrumpCards, trump, true);
+            }
+            return trumpCards.sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank])[0];
         }
 
-        // Can't overtrump - discard
-        if (nonTrumpCards.length > 0) {
-            return selectDiscard(nonTrumpCards, trump, true, memory, hand);
-        }
-        return trumpCards.sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank])[0];
+        // Trump in (preserve HI joker for leading when possible)
+        const sorted = trumpCards.sort(trumpSortOrder);
+        return opponentsRemain ? bestWithoutHiJoker(sorted, winningCard) : sorted[0];
     }
 
     // No trump available - discard
-    return selectDiscard(legalCards, trump, false, memory, hand);
+    return selectDiscard(legalCards, trump, false);
 }
 
 /**
@@ -1159,28 +871,17 @@ function selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBro
  * @param {Array} cards - Available cards to discard from
  * @param {Object} trump - Trump card
  * @param {boolean} hasTrumpInHand - Whether bot holds any trump cards
- * @param {Object|null} [memory] - Card memory; enables boss-card protection
- * @param {Array} [fullHand] - Complete current hand (for boss detection)
  */
-function selectDiscard(cards, trump, hasTrumpInHand, memory = null, fullHand = null) {
+function selectDiscard(cards, trump, hasTrumpInHand) {
     const nonTrump = cards.filter(c => c.suit !== trump.suit && c.suit !== 'joker');
     const pool = nonTrump.length > 0 ? nonTrump : cards;
 
-    // A card is worth protecting if nothing left in unseen hands beats it
-    // (established winner), or — without memory — if it's an Ace or King
-    const isProtected = (c) => {
-        if (memory && fullHand) return countHigherUnseen(c, fullHand, memory, trump) === 0;
-        return c.rank === 'A' || c.rank === 'K';
-    };
-
     if (!hasTrumpInHand) {
-        // No trump = voiding is pointless. Keep suit coverage and winners,
-        // dump the lowest unprotected card.
-        const sorted = [...pool].sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank]);
-        return sorted.find(c => !isProtected(c)) || sorted[0];
+        // No trump = voiding is pointless. Keep suit coverage, dump lowest card overall.
+        return pool.sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank])[0];
     }
 
-    // Has trump - try to void shortest suit, but protect established winners
+    // Has trump - try to void shortest suit, but protect high cards
     const bySuit = {};
     for (const card of pool) {
         if (!bySuit[card.suit]) bySuit[card.suit] = [];
@@ -1200,13 +901,13 @@ function selectDiscard(cards, trump, hasTrumpInHand, memory = null, fullHand = n
         const candidate = bySuit[shortestSuit]
             .sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank])[0];
 
-        // Don't slough a winner to complete a void - find a lower card elsewhere
-        if (isProtected(candidate)) {
-            const allSorted = [...pool]
+        // Don't slough an Ace or King to complete a void - find a lower card elsewhere
+        if (candidate.rank === 'A' || candidate.rank === 'K') {
+            const allSorted = pool
                 .sort((a, b) => RANK_VALUES[a.rank] - RANK_VALUES[b.rank]);
-            const lowerCard = allSorted.find(c => !isProtected(c));
+            const lowerCard = allSorted.find(c => c.rank !== 'A' && c.rank !== 'K');
             if (lowerCard) return lowerCard;
-            // Everything is a winner - discard the lowest-ranked one
+            // All cards are high - discard the lowest-ranked one
             return allSorted[0];
         }
 
@@ -1218,19 +919,15 @@ function selectDiscard(cards, trump, hasTrumpInHand, memory = null, fullHand = n
 
 /**
  * Select optimal card to play
- * @param {Object|null} playContext - Contract state from BotController.buildPlayContext;
- *   null falls back to contract-blind tactics (used by older callers/tests)
- * @param {string} [personality] - Personality key; its playStyle flavors following
  */
-function selectOptimalCard(hand, playedCards, leadCard, leadPosition, trump, trumpBroken, position, memory, handSize, playContext = null, personality = 'mary') {
+function selectOptimalCard(hand, playedCards, leadCard, leadPosition, trump, trumpBroken, position, memory, handSize) {
     const isLeading = !leadCard || playedCards.every(c => c === undefined || c === null);
-    const contract = getContractState(playContext, position, handSize);
 
     if (isLeading) {
-        return selectLead(hand, trump, trumpBroken, { position }, memory, handSize, contract);
+        return selectLead(hand, trump, trumpBroken, { position }, memory, handSize);
     }
 
-    return selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBroken, position, memory, handSize, contract, getPlayStyle(personality));
+    return selectFollow(hand, playedCards, leadCard, leadPosition, trump, trumpBroken, position, memory, handSize);
 }
 
 module.exports = {
@@ -1254,8 +951,5 @@ module.exports = {
     applyBidModifier,
     hasOpponentsAfterMe,
     isWinVulnerable,
-    bestWithoutHiJoker,
-    countHigherUnseen,
-    getContractState,
-    pickWinner
+    bestWithoutHiJoker
 };

--- a/server/game/bot/sim/simulate.js
+++ b/server/game/bot/sim/simulate.js
@@ -1,0 +1,483 @@
+/**
+ * Bot-vs-bot simulation harness for tuning and regression-testing bot strategy.
+ *
+ * Requires the REAL modules — no game logic is reimplemented except the
+ * orchestration loop, which mirrors server/socket/gameHandlers.js exactly:
+ *  - first bidder = dealer + 1; dealer starts at 1 and rotates each hand
+ *  - team bid = BID_RANKS[bid_a] + BID_RANKS[bid_b], capped at hand size
+ *    (so any bore => team bid = hand size = must win ALL tricks)
+ *  - multiplier = rules.calculateMultiplier(bid_a, bid_b)
+ *  - both teams bid 0 => redeal, same hand size and dealer
+ *  - rainbows: 4-card hand only, checked after bidding, +10 per rainbow
+ *    player added to team score whether made or set
+ *  - score: made => bid*10*mult + (tricks-bid) + rainbows*10
+ *           set  => -bid*10*mult + rainbows*10
+ *  - trump broken when a trump-suit card or joker is played
+ *  - bots are notified of each card as it is played (notifyCardPlayed) and
+ *    advanceTrick on every bot after each trick (notifyTrickComplete)
+ *  - Zach partner history updated every hand, bore -> 0 (updatePartnerHistory)
+ *
+ * Every card a bot chooses is re-validated with rules.isLegalMove; illegal
+ * choices and thrown exceptions are counted and reported (and substituted so
+ * the run can continue). A healthy strategy reports zero of both.
+ *
+ * Usage:
+ *   node server/game/bot/sim/simulate.js                         # all experiments, 2000 games each
+ *   node server/game/bot/sim/simulate.js --games 8000            # more precision (~±1.1% CI at 8000)
+ *   node server/game/bot/sim/simulate.js --exp legacy            # current Mary vs frozen pre-tuning Mary
+ *   node server/game/bot/sim/simulate.js --exp personalities     # each personality+Mary vs Mary+Mary
+ *   node server/game/bot/sim/simulate.js --team mary,danny --vs legacy:mary,legacy:mary
+ *
+ * Personality specs: mary | sharon | danny | mike | zach, with optional
+ * `legacy:` prefix to use the frozen June-2026 strategy snapshot
+ * (./legacyStrategy.js) — the fixed benchmark all tuning is measured against.
+ *
+ * Matchups are seat-balanced: half the games are played with the pair swapped
+ * onto the other team, cancelling the first-bidder positional asymmetry, so
+ * an even matchup reads 50.0%.
+ */
+'use strict';
+
+const rules = require('../../rules');
+const BotPlayer = require('../BotPlayer');
+const legacyStrategy = require('./legacyStrategy');
+
+const { BID_RANKS } = rules;
+const HAND_SIZES = [12, 10, 8, 6, 4, 2, 1, 3, 5, 7, 9, 11, 13];
+const SUITS = ['spades', 'hearts', 'diamonds', 'clubs'];
+const RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A'];
+
+// ---------- Seeded RNG (mulberry32), installed over Math.random for reproducibility ----------
+function mulberry32(seed) {
+    let a = seed >>> 0;
+    return function () {
+        a |= 0; a = (a + 0x6D2B79F5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+let rng = mulberry32(12345);
+Math.random = () => rng(); // bot strategy randomness must go through the seeded RNG
+
+/** Bot that plays with the frozen legacy strategy but shares BotPlayer's memory machinery. */
+class LegacyBotPlayer extends BotPlayer {
+    decideBid(hand, trump, existingBids, handSize, gameContext) {
+        return legacyStrategy.calculateOptimalBid(
+            hand, trump, this.position, existingBids, handSize,
+            this.getMemorySnapshot(), gameContext, this.personality, this.partnerHistory
+        );
+    }
+
+    decideCard(hand, playedCards, leadCard, leadPosition, trump, trumpBroken, handSize) {
+        return legacyStrategy.selectOptimalCard(
+            hand, playedCards, leadCard, leadPosition, trump, trumpBroken,
+            this.position, this.getMemorySnapshot(), handSize
+        );
+    }
+}
+
+const NAMES = { mary: 'Mary', sharon: 'Sharon', danny: 'Danny', mike: 'Mike', zach: 'Zach' };
+
+/** spec: 'mary' or 'legacy:mary' */
+function makeBot(spec, position, gameId) {
+    const legacy = spec.startsWith('legacy:');
+    const personality = legacy ? spec.slice('legacy:'.length) : spec;
+    if (!NAMES[personality]) throw new Error(`Unknown personality spec: ${spec}`);
+    const Ctor = legacy ? LegacyBotPlayer : BotPlayer;
+    const bot = new Ctor(`🤖 ${NAMES[personality]}`, personality);
+    bot.assignToGame(gameId, position, position);
+    bot.statKey = spec; // legacy and current stats must not merge
+    return bot;
+}
+
+function freshDeck() {
+    const cards = [];
+    for (const suit of SUITS) for (const rank of RANKS) cards.push({ suit, rank });
+    cards.push({ suit: 'joker', rank: 'HI' });
+    cards.push({ suit: 'joker', rank: 'LO' });
+    for (let i = cards.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1));
+        [cards[i], cards[j]] = [cards[j], cards[i]];
+    }
+    return cards;
+}
+
+const cardStr = (c) => (c ? `${c.rank}${c.suit === 'joker' ? 'Jok' : c.suit[0].toUpperCase()}` : '-');
+const handStr = (h) => h.map(cardStr).join(' ');
+const isBore = (b) => ['B', '2B', '3B', '4B'].includes(b);
+const numericBid = (b) => (isBore(b) ? null : (parseInt(String(b), 10) || 0));
+
+// ---------- Global stat accumulators ----------
+const incidents = [];   // illegal card selections
+const exceptions = [];  // thrown errors
+let redealCount = 0;
+let totalHandsDealt = 0;
+const byHandSize = {};
+for (const hs of HAND_SIZES) byHandSize[hs] = { keptHands: 0, redeals: 0, sumTeamBids: 0, boreHands: 0 };
+
+function newPersStats() {
+    return {
+        handsBid: 0,
+        bidSumByHandSize: {}, bidCountByHandSize: {},
+        boreAttempts: 0, boreSuccesses: 0, boreOppsOneCard: 0, boreAttemptsOneCard: 0,
+        zeroBids: 0,
+        accuracy: {},
+        teamHands: 0, teamSets: 0,
+        teamMade: 0, overtricksOnMade: 0,
+        personalTricksSum: 0, personalBidSum: 0, nonBoreHands: 0
+    };
+}
+const persStats = {};
+function ps(key) { if (!persStats[key]) persStats[key] = newPersStats(); return persStats[key]; }
+
+/**
+ * Play one full 13-hand game.
+ * specs: array of 4 personality specs for positions 1..4. Team 1 = positions 1&3, team 2 = 2&4.
+ * Returns { score1, score2 }
+ */
+function playGame(specs, expName, gameIdx) {
+    const bots = {};
+    for (let p = 1; p <= 4; p++) bots[p] = makeBot(specs[p - 1], p, `sim:${expName}:${gameIdx}`);
+    const teamOf = (p) => (p === 1 || p === 3 ? 1 : 2);
+    const score = { 1: 0, 2: 0 };
+
+    let dealer = 1; // GameState starts dealer at 1; bidder = dealer + 1
+    for (let handIdx = 0; handIdx < HAND_SIZES.length; handIdx++) {
+        const handSize = HAND_SIZES[handIdx];
+        const firstBidder = (dealer % 4) + 1;
+
+        // ----- Deal (with zero-bid redeal loop, mirroring handlePostBid) -----
+        let hands, trump, playerBids, teamBid, mult;
+        let redeals = 0;
+        for (;;) {
+            totalHandsDealt++;
+            const deck = freshDeck();
+            hands = {};
+            for (let p = 1; p <= 4; p++) hands[p] = deck.slice((p - 1) * handSize, p * handSize);
+            trump = deck[4 * handSize]; // flipped card; suit 'joker' => no-trump
+            for (let p = 1; p <= 4; p++) bots[p].resetCardMemory(handSize, trump);
+
+            // ----- Bidding -----
+            playerBids = [undefined, undefined, undefined, undefined];
+            for (let i = 0; i < 4; i++) {
+                const pos = ((firstBidder - 1 + i) % 4) + 1;
+                const bot = bots[pos];
+                const gameContext = {
+                    teamScore: score[teamOf(pos)],
+                    oppScore: score[teamOf(pos) === 1 ? 2 : 1],
+                    currentHandSize: handSize
+                };
+                let bid;
+                try {
+                    bid = bot.decideBid(hands[pos].slice(), trump, playerBids, handSize, gameContext);
+                } catch (e) {
+                    exceptions.push({
+                        where: 'decideBid', exp: expName, game: gameIdx, handSize,
+                        position: pos, personality: bot.statKey,
+                        hand: handStr(hands[pos]), trump: cardStr(trump),
+                        existingBids: playerBids.slice(), error: e.message, stack: e.stack.split('\n')[1]
+                    });
+                    bid = '0';
+                }
+                playerBids[pos - 1] = bid;
+            }
+
+            teamBid = {
+                1: (BID_RANKS[playerBids[0]] || 0) + (BID_RANKS[playerBids[2]] || 0),
+                2: (BID_RANKS[playerBids[1]] || 0) + (BID_RANKS[playerBids[3]] || 0)
+            };
+            mult = {
+                1: rules.calculateMultiplier(playerBids[0], playerBids[2]),
+                2: rules.calculateMultiplier(playerBids[1], playerBids[3])
+            };
+            if (teamBid[1] > handSize) teamBid[1] = handSize;
+            if (teamBid[2] > handSize) teamBid[2] = handSize;
+
+            if (teamBid[1] === 0 && teamBid[2] === 0) {
+                redealCount++; redeals++;
+                byHandSize[handSize].redeals++;
+                if (redeals > 200) throw new Error('redeal livelock');
+                continue;
+            }
+            break;
+        }
+        byHandSize[handSize].keptHands++;
+        byHandSize[handSize].sumTeamBids += teamBid[1] + teamBid[2];
+        if (playerBids.some(isBore)) byHandSize[handSize].boreHands++;
+
+        // ----- Rainbows (4-card hand only, after bidding) -----
+        const rainbows = { 1: 0, 2: 0 };
+        if (handSize === 4) {
+            for (let p = 1; p <= 4; p++) {
+                if (rules.isRainbow(hands[p], trump)) rainbows[teamOf(p)]++;
+            }
+        }
+
+        // per-bid stats
+        for (let p = 1; p <= 4; p++) {
+            const s = ps(bots[p].statKey);
+            const bid = playerBids[p - 1];
+            s.handsBid++;
+            if (handSize === 1) s.boreOppsOneCard++;
+            if (isBore(bid)) {
+                s.boreAttempts++;
+                if (handSize === 1) s.boreAttemptsOneCard++;
+            } else {
+                const nb = numericBid(bid);
+                s.bidSumByHandSize[handSize] = (s.bidSumByHandSize[handSize] || 0) + nb;
+                s.bidCountByHandSize[handSize] = (s.bidCountByHandSize[handSize] || 0) + 1;
+                if (nb === 0) s.zeroBids++;
+            }
+        }
+
+        // ----- Play -----
+        let lead = rules.findHighestBidder(firstBidder, playerBids) + 1;
+        let trumpBroken = false;
+        const tricksByPos = { 1: 0, 2: 0, 3: 0, 4: 0 };
+        const teamTricks = { team1: 0, team2: 0 };
+
+        for (let t = 0; t < handSize; t++) {
+            const playedCards = [undefined, undefined, undefined, undefined];
+            let leadCard = null;
+            const leadPosition = lead;
+            for (let i = 0; i < 4; i++) {
+                const pos = ((lead - 1 + i) % 4) + 1;
+                const bot = bots[pos];
+                const hand = hands[pos];
+                const isLeading = i === 0;
+                // Contract state, shaped like what processBotPlay can read off `game`
+                const playContext = {
+                    playerBids,
+                    bids: { team1: teamBid[1], team2: teamBid[2] },
+                    tricks: { team1: teamTricks.team1, team2: teamTricks.team2 },
+                    team1Mult: mult[1], team2Mult: mult[2]
+                };
+                let card = null;
+                try {
+                    card = bot.decideCard(hand.slice(), playedCards,
+                        isLeading ? null : leadCard, isLeading ? null : leadPosition,
+                        trump, trumpBroken, handSize, playContext);
+                } catch (e) {
+                    exceptions.push({
+                        where: 'decideCard', exp: expName, game: gameIdx, handSize, trick: t,
+                        position: pos, personality: bot.statKey,
+                        hand: handStr(hand), trump: cardStr(trump), trumpBroken,
+                        playedCards: playedCards.map(cardStr).join(','),
+                        leadCard: cardStr(leadCard), error: e.message, stack: e.stack.split('\n')[1]
+                    });
+                }
+
+                // Validate the choice against the REAL rules before accepting it
+                const inHand = card && hand.find(c => c.suit === card.suit && c.rank === card.rank);
+                let legal = false;
+                if (inHand) {
+                    const remaining = hand.filter(c => c !== inHand);
+                    legal = rules.isLegalMove(inHand, remaining, leadCard || inHand, isLeading,
+                        trump, trumpBroken, pos, isLeading ? pos : leadPosition);
+                }
+                if (!inHand || !legal) {
+                    incidents.push({
+                        exp: expName, game: gameIdx, handSize, trick: t,
+                        position: pos, personality: bot.statKey,
+                        chosen: cardStr(card), inHand: !!inHand,
+                        hand: handStr(hand), trump: cardStr(trump), trumpBroken,
+                        leadCard: cardStr(leadCard),
+                        playedCards: playedCards.map(cardStr).join(',')
+                    });
+                    card = hand.find(c => {
+                        const remaining = hand.filter(x => x !== c);
+                        return rules.isLegalMove(c, remaining, leadCard || c, isLeading,
+                            trump, trumpBroken, pos, isLeading ? pos : leadPosition);
+                    }) || hand[0];
+                } else {
+                    card = inHand;
+                }
+
+                hands[pos] = hand.filter(c => c !== card);
+                playedCards[pos - 1] = card;
+                if (isLeading) leadCard = card;
+                if (card.suit === trump.suit || card.suit === 'joker') trumpBroken = true;
+
+                for (let q = 1; q <= 4; q++) bots[q].recordCardPlayed(card, pos, trump, leadPosition);
+            }
+            const winner = rules.determineWinner(playedCards, leadPosition, trump);
+            tricksByPos[winner]++;
+            teamTricks[winner === 1 || winner === 3 ? 'team1' : 'team2']++;
+            for (let q = 1; q <= 4; q++) bots[q].advanceTrick();
+            lead = winner;
+        }
+
+        const tricks = { 1: tricksByPos[1] + tricksByPos[3], 2: tricksByPos[2] + tricksByPos[4] };
+
+        // ----- Scoring (mirrors handleHandComplete exactly) -----
+        for (const T of [1, 2]) {
+            if (tricks[T] >= teamBid[T]) {
+                score[T] += teamBid[T] * 10 * mult[T] + (tricks[T] - teamBid[T]) + rainbows[T] * 10;
+            } else {
+                score[T] -= teamBid[T] * 10 * mult[T];
+                score[T] += rainbows[T] * 10;
+            }
+        }
+
+        // ----- Per-personality outcome stats -----
+        for (let p = 1; p <= 4; p++) {
+            const s = ps(bots[p].statKey);
+            const T = teamOf(p);
+            const bid = playerBids[p - 1];
+            s.teamHands++;
+            const made = tricks[T] >= teamBid[T];
+            if (!made) s.teamSets++;
+            else { s.teamMade++; s.overtricksOnMade += (tricks[T] - teamBid[T]); }
+            if (isBore(bid)) {
+                if (tricks[T] === handSize) s.boreSuccesses++;
+            } else {
+                const nb = numericBid(bid);
+                const diff = tricksByPos[p] - nb;
+                const key = diff <= -3 ? '<=-3' : diff >= 3 ? '>=3' : String(diff);
+                s.accuracy[key] = (s.accuracy[key] || 0) + 1;
+                s.personalTricksSum += tricksByPos[p];
+                s.personalBidSum += nb;
+                s.nonBoreHands++;
+            }
+        }
+
+        // ----- Zach partner history (mirrors updatePartnerHistory: bores skipped) -----
+        for (let p = 1; p <= 4; p++) {
+            const bot = bots[p];
+            if (bot.personality !== 'zach') continue;
+            const partnerPos = rules.getPartnerPosition(p);
+            const bidStr = String(playerBids[partnerPos - 1]);
+            if (bidStr.includes('B')) continue;
+            bot.recordPartnerHand(parseInt(bidStr, 10) || 0, tricksByPos[partnerPos]);
+        }
+
+        dealer = rules.rotatePosition(dealer);
+    }
+
+    return { score1: score[1], score2: score[2] };
+}
+
+/**
+ * Seat-balanced matchup: pairX vs pairY, with X on team 1 for even game
+ * indices and on team 2 for odd ones. Returns X's win rate (ties = 0.5).
+ */
+function runMatch(name, pairX, pairY, nGames, seed) {
+    rng = mulberry32(seed);
+    let winsX = 0, ties = 0, sumDeltaX = 0, sumX = 0, sumY = 0;
+    for (let g = 0; g < nGames; g++) {
+        const xOnTeam1 = g % 2 === 0;
+        const specs = xOnTeam1
+            ? [pairX[0], pairY[0], pairX[1], pairY[1]]
+            : [pairY[0], pairX[0], pairY[1], pairX[1]];
+        const r = playGame(specs, name, g);
+        const scoreX = xOnTeam1 ? r.score1 : r.score2;
+        const scoreY = xOnTeam1 ? r.score2 : r.score1;
+        if (scoreX > scoreY) winsX++;
+        else if (scoreX === scoreY) ties++;
+        sumDeltaX += scoreX - scoreY;
+        sumX += scoreX; sumY += scoreY;
+    }
+    const winRate = (winsX + ties * 0.5) / nGames;
+    const ci95 = 1.96 * Math.sqrt(winRate * (1 - winRate) / nGames);
+    return {
+        name, nGames,
+        teamX: pairX.join('+'), teamY: pairY.join('+'),
+        winRateX: +winRate.toFixed(4),
+        ci95: +ci95.toFixed(4),
+        avgScoreDeltaX: +(sumDeltaX / nGames).toFixed(1),
+        avgScoreX: +(sumX / nGames).toFixed(1),
+        avgScoreY: +(sumY / nGames).toFixed(1)
+    };
+}
+
+// ---------- CLI ----------
+function parseArgs(argv) {
+    const args = { games: 2000, seed: 1001, exp: 'all', team: null, vs: null };
+    for (let i = 2; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--games') args.games = parseInt(argv[++i], 10);
+        else if (a === '--seed') args.seed = parseInt(argv[++i], 10);
+        else if (a === '--exp') args.exp = argv[++i];
+        else if (a === '--team') args.team = argv[++i].split(',');
+        else if (a === '--vs') args.vs = argv[++i].split(',');
+        else if (/^\d+$/.test(a)) args.games = parseInt(a, 10); // bare number = games
+        else throw new Error(`Unknown argument: ${a}`);
+    }
+    return args;
+}
+
+function main() {
+    const args = parseArgs(process.argv);
+    const N = args.games;
+    const t0 = Date.now();
+    const results = [];
+
+    if (args.team && args.vs) {
+        results.push(runMatch('custom', args.team, args.vs, N, args.seed));
+    } else {
+        const exps = args.exp === 'all' ? ['baseline', 'legacy', 'personalities'] : [args.exp];
+        for (const exp of exps) {
+            if (exp === 'baseline') {
+                results.push(runMatch('baseline: mary vs mary', ['mary', 'mary'], ['mary', 'mary'], N, args.seed));
+            } else if (exp === 'legacy') {
+                results.push(runMatch('mary vs legacy mary', ['mary', 'mary'], ['legacy:mary', 'legacy:mary'], N, args.seed + 1));
+                results.push(runMatch('mary vs legacy danny+zach', ['mary', 'mary'], ['legacy:danny', 'legacy:zach'], N, args.seed + 2));
+            } else if (exp === 'personalities') {
+                for (const p of ['sharon', 'danny', 'mike', 'zach']) {
+                    results.push(runMatch(`${p}+mary vs mary+mary`, [p, 'mary'], ['mary', 'mary'], N, args.seed + 10 + p.charCodeAt(0)));
+                }
+            } else {
+                throw new Error(`Unknown experiment: ${exp}`);
+            }
+        }
+    }
+
+    const elapsed = (Date.now() - t0) / 1000;
+    const out = {
+        elapsedSec: +elapsed.toFixed(1),
+        gamesPerMatch: N,
+        results,
+        redealCount,
+        totalHandsDealt,
+        byHandSize: {},
+        personalities: {},
+        incidentCount: incidents.length,
+        incidents: incidents.slice(0, 25),
+        exceptionCount: exceptions.length,
+        exceptions: exceptions.slice(0, 25)
+    };
+    for (const hs of HAND_SIZES) {
+        const b = byHandSize[hs];
+        if (b.keptHands === 0) continue;
+        out.byHandSize[hs] = {
+            keptHands: b.keptHands,
+            redealRate: +(b.redeals / (b.keptHands + b.redeals)).toFixed(3),
+            avgCombinedTeamBid: +(b.sumTeamBids / b.keptHands).toFixed(2),
+            bidFractionOfTricks: +((b.sumTeamBids / b.keptHands) / hs).toFixed(3),
+            boreHandRate: +(b.boreHands / b.keptHands).toFixed(3)
+        };
+    }
+    for (const [key, s] of Object.entries(persStats)) {
+        const avgBidByHS = {};
+        for (const hs of HAND_SIZES) {
+            if (s.bidCountByHandSize[hs]) avgBidByHS[hs] = +(s.bidSumByHandSize[hs] / s.bidCountByHandSize[hs]).toFixed(2);
+        }
+        out.personalities[key] = {
+            handsBid: s.handsBid,
+            avgBidByHandSize: avgBidByHS,
+            zeroBidRate: +(s.zeroBids / Math.max(1, s.nonBoreHands)).toFixed(4),
+            boreAttemptRate: +(s.boreAttempts / s.handsBid).toFixed(4),
+            boreSuccessRate: s.boreAttempts ? +(s.boreSuccesses / s.boreAttempts).toFixed(3) : null,
+            oneCardBoreRate: s.boreOppsOneCard ? +(s.boreAttemptsOneCard / s.boreOppsOneCard).toFixed(3) : null,
+            teamSetRate: +(s.teamSets / s.teamHands).toFixed(4),
+            avgOvertricksPerMadeHand: +(s.overtricksOnMade / Math.max(1, s.teamMade)).toFixed(3),
+            avgPersonalBid: +(s.personalBidSum / Math.max(1, s.nonBoreHands)).toFixed(3),
+            avgPersonalTricks: +(s.personalTricksSum / Math.max(1, s.nonBoreHands)).toFixed(3),
+            accuracyHistogram: s.accuracy
+        };
+    }
+    console.log(JSON.stringify(out, null, 1));
+}
+
+main();

--- a/server/socket/chatHandlers.js
+++ b/server/socket/chatHandlers.js
@@ -206,8 +206,7 @@ function handleLeaveCommand(socket, io, game, position) {
             })
         );
         game.leaveAllFromRoom(io);
-        gameManager.abortGame(game.gameId);
-        botController.cleanupGame(game.gameId);
+        gameManager.abortGame(game.gameId); // also releases bots via cleanupGame
         io.to('mainRoom').emit('lobbiesUpdated', {
             lobbies: gameManager.getAllLobbies(),
             inProgressGames: gameManager.getInProgressGames(),

--- a/server/socket/gameHandlers.js
+++ b/server/socket/gameHandlers.js
@@ -83,7 +83,7 @@ function triggerBotIfNeeded(io, game, actionType) {
 
                 const hand = game.getHand(playerSocketId);
                 if (!hand || hand.length === 0) return;
-                const card = bot.decideCard(hand, game.playedCards, game.leadCard, game.leadPosition, game.trump, game.isTrumpBroken, game.currentHand);
+                const card = bot.decideCard(hand, game.playedCards, game.leadCard, game.leadPosition, game.trump, game.isTrumpBroken, game.currentHand, botController.buildPlayContext(game));
                 game.removeCardFromHand(playerSocketId, card);
                 const isLeading = game.playedCardsIndex === 0;
                 if (isLeading) {
@@ -97,7 +97,7 @@ function triggerBotIfNeeded(io, game, actionType) {
                     game.isTrumpBroken = true;
                 }
                 game.broadcast(io, 'cardPlayed', { playerId: playerSocketId, card, position: bot.position, trump: game.isTrumpBroken });
-                botController.notifyCardPlayed(game.gameId, card, bot.position, game.trump);
+                botController.notifyCardPlayed(game.gameId, card, bot.position, game.trump, game.leadPosition);
                 game.currentTurn = rotatePosition(game.currentTurn);
                 handlePostPlay(io, game);
             }
@@ -108,15 +108,15 @@ function triggerBotIfNeeded(io, game, actionType) {
     // Normal bot action
     if (actionType === 'bid') {
         botController.scheduleBotAction(io, game, 'bid', (io, game, bot) => {
-            botController.processBotBid(io, game, bot);
-            // After bot bids, advance turn and check for more bots or end bidding
+            // Only advance the turn if the bid actually happened — advancing
+            // after a stale-state bail wedges the game on a phantom turn
+            if (!botController.processBotBid(io, game, bot)) return;
             game.currentTurn = rotatePosition(game.currentTurn);
             handlePostBid(io, game);
         });
     } else if (actionType === 'play') {
         botController.scheduleBotAction(io, game, 'play', (io, game, bot) => {
-            botController.processBotPlay(io, game, bot);
-            // After bot plays, advance turn and check for trick complete
+            if (!botController.processBotPlay(io, game, bot)) return;
             game.currentTurn = rotatePosition(game.currentTurn);
             handlePostPlay(io, game);
         });
@@ -645,7 +645,7 @@ async function playCard(socket, io, data) {
     });
 
     // Notify bots about this card play
-    botController.notifyCardPlayed(game.gameId, card, position, game.trump);
+    botController.notifyCardPlayed(game.gameId, card, position, game.trump, game.leadPosition);
 
     // Advance turn
     game.currentTurn = rotatePosition(game.currentTurn);
@@ -1004,8 +1004,11 @@ async function forceResign(socket, io, data) {
     const oldPlayer = game.getPlayerByPosition(position);
     const oldUsername = oldPlayer?.username || `Player ${position}`;
 
-    // Pick a random personality
-    const personality = PERSONALITY_LIST[Math.floor(Math.random() * PERSONALITY_LIST.length)];
+    // Pick a random personality not already used by a bot in this game
+    const usedPersonalities = botController.getGameBots(game.gameId).map(b => b.personality);
+    const availablePersonalities = PERSONALITY_LIST.filter(p => !usedPersonalities.includes(p));
+    const pool = availablePersonalities.length > 0 ? availablePersonalities : PERSONALITY_LIST;
+    const personality = pool[Math.floor(Math.random() * pool.length)];
     const displayName = personalities.getDisplayName(personality);
     const botUsername = `🤖 ${displayName}`;
 


### PR DESCRIPTION
## Summary

A multi-agent evaluation found the old bot AI tactically sound but strategically blind: Mary systematically underbid (so much that two of her "flawed" personality variants — Danny and Zach — beat her head-to-head), card play had zero knowledge of the contract (bots bid bores and then busted them by leading their lowest trump), and a set of verified bugs (HI joker burned on side-suit Aces, first-bidder bores on zero information, bot registry/timer leaks on aborted games) compounded it.

This PR makes Mary genuinely win-rate-optimal, rebases the four personalities as slight measured variations that express themselves in both bidding **and** card play, fixes every verified bug, and adds the simulation infrastructure used to tune it all.

### Benchmark (16,000 games/matchup, seat-balanced, seeded)

| Matchup | Result |
|---|---|
| **New Mary vs frozen pre-rework Mary** | **58.5% ±0.8** (+18.5 pts/game) |
| New Mary vs legacy Danny+Zach (the old "best" pairing) | 58.9% |
| Sharon+Mary vs Mary+Mary | 49.0% |
| Danny+Mary vs Mary+Mary | 48.7% |
| Mike+Mary vs Mary+Mary | 48.3% |
| Zach+Mary vs Mary+Mary | 50.4% |

Zero illegal moves and zero exceptions across ~250k simulated games. All-zero-bid redeal churn cut from 70%→48% (1-card hands) and 50%→40% (2-card). Bore success 84%→91%.

## What changed

**Contract-aware card play** — `processBotPlay` now passes team bids/tricks/bores into the strategy, which derives an effort regime: bore execution (lead strength, secure partner's vulnerable wins with trump), bore defense (max effort for the single trick that sets an opposing bore), realistic set denial, and straight trick-maximizing once both contracts are decided.

**Card counting** — `countHigherUnseen` (flipped-card- and no-trump-aware) powers cheapest-boss winner selection, counting-based vulnerability (no more overtaking partner's boss trump "just in case"), and boss-aware discards.

**Bidding recalibration** — low/mid trump valued at every hand size (a trump Jack no longer rates below an off-suit King), first-bidder discount removed (sim-measured to triple-count uncertainty, −1.2% win rate), flipped-card honor promotion, no-trump small-hand logic, and looser 1/2-card thresholds.

**Personalities** — `personalities.js` is the single source of truth (`bidStyle` + `playStyle`): Sharon trims big bids and hoards honors; Danny rounds up near-misses and plays flashy; Mike randomly overbids and sometimes overtakes his own partner; Zach adapts to his partner's measured bid error. Styles never apply at max effort, so flavor can't bust a live bore.

**Bug fixes** (all adversarially verified before fixing): HI-joker side-suit-Ace burn, vacuous bore gating, seat-order bore escalation, personality bids exceeding the team cap, disconnect-abort bot registry/timer leak, silent-bail turn-advance wedge plus trick-full guards, mid-trick void-inference poisoning (leads now recorded explicitly), forceResign personality dedupe, Zach bore-history skew, timer-key overwrites.

**Infrastructure** — `npm run sim`: seeded, seat-balanced bot-vs-bot harness with a frozen legacy snapshot as the permanent benchmark; every decision validated against `rules.isLegalMove`. Tests 102→317 including a legality fuzz invariant (random hands, no-trump, forced bores) and per-personality behavior tests. `docs/bot-strategy-guide.md` rewritten from the simulation findings, including the counterintuitive ones (stacked conservatism loses; so does extra aggression; there is no card conservation once both contracts are decided).

## Test plan

- [x] `npm test` — 317/317 pass (9 suites)
- [x] `npm run sim` — 0 illegal moves / 0 exceptions; benchmark numbers above reproduce across three seeds (1001/909/31337)
- [x] Final diff adversarially reviewed by a 15-agent workflow; all 12 confirmed findings fixed and re-verified
- [ ] Human playtest against the new bots (feel check — Mike's table talk vs his subtler play)

🤖 Generated with [Claude Code](https://claude.com/claude-code)